### PR TITLE
docs: correct markdown syntax error in documentation

### DIFF
--- a/redis/howto/connectwithtls.mdx
+++ b/redis/howto/connectwithtls.mdx
@@ -33,7 +33,6 @@ const redis = new Redis({ url: 'UPSTASH_REDIS_REST_URL', token: 'UPSTASH_REDIS_R
     console.error(error);
   }
 })();
-```;
 ````
 
 ## Node.js


### PR DESCRIPTION
- Fixed a markdown syntax error in the documentation
- Improved the readability and consistency of the documentation