### PR TITLE
QSTH-211 Add missing content for new features

### DIFF
--- a/_snippets/qstash-dlq-message-type.mdx
+++ b/_snippets/qstash-dlq-message-type.mdx
@@ -56,7 +56,7 @@
 </ResponseField>
 
 <ResponseField name="responseHeader" type="string">
-  The respponse header of the last failed deliver attempt.
+  The response header of the last failed deliver attempt.
 </ResponseField>
 
 <ResponseField name="responseBody" type="string">

--- a/_snippets/qstash-dlq-message-type.mdx
+++ b/_snippets/qstash-dlq-message-type.mdx
@@ -45,3 +45,20 @@
 <ResponseField name="failureCallback" type="string">
   The url where we send a callback to after the message is failed
 </ResponseField>
+
+<ResponseField name="dlqId" type="string" required>
+    The unique id within the DLQ. Use this to remove the message from the DLQ
+    [DELETE /v2/dlq/{dlqId}](/qstash/api/dlq/deleteMessage)
+</ResponseField>
+
+<ResponseField name="responseStatus" type="int">
+  The http status code of the last failed deliver attempt.
+</ResponseField>
+
+<ResponseField name="responseHeader" type="string">
+  The respponse header of the last failed deliver attempt.
+</ResponseField>
+
+<ResponseField name="responseBody" type="string">
+  The response body of the last failed deliver attempt.
+</ResponseField>

--- a/_snippets/qstash-message-type.mdx
+++ b/_snippets/qstash-message-type.mdx
@@ -7,7 +7,7 @@
 </ResponseField>
 
 <ResponseField name="endpointName" type="string">
-  The endpointName of the message if the endpoint is given a name withing the topic.
+  The endpoint name of the message if the endpoint is given a name within the topic.
 </ResponseField>
 
 <ResponseField name="url" type="string" required>

--- a/mint.json
+++ b/mint.json
@@ -453,6 +453,7 @@
           "group": "Dead Letter Queues",
           "pages": [
             "qstash/api/dlq/listMessages",
+            "qstash/api/dlq/getMessage",
             "qstash/api/dlq/deleteMessage"
           ]
         },

--- a/qstash/api/dlq/getMessage.mdx
+++ b/qstash/api/dlq/getMessage.mdx
@@ -1,0 +1,31 @@
+---
+title: "Get a message from the DLQ"
+description: "Get a message from the DLQ"
+api: "GET https://qstash.upstash.io/v2/dlq/{dlqId}"
+authMethod: "bearer"
+---
+
+Get a message from DLQ.
+
+## Request
+
+<ParamField path="dlqId" type="string">
+  The dlq id of the message you want to retrieve. You will see this id when
+  listing all messages in the dlq with the [/v2/dlq](/qstash/api/dlq/listMessages) endpoint, 
+  as well as in the content of [the failure callback](https://docs.upstash.com/qstash/features/callbacks#what-is-a-failure-callback)
+</ParamField>
+
+## Response
+
+If the message is not found in the DLQ, (either is has been removed by you, or automatically), the endpoint returns a 404 status code.
+
+<Snippet file="qstash-dlq-message-type.mdx" />
+
+<RequestExample>
+
+```sh
+curl -X GET https://qstash.upstash.io/v2/dlq/my-dlq-id \
+  -H "Authorization: Bearer <token>"
+```
+
+</RequestExample>

--- a/qstash/api/dlq/listMessages.mdx
+++ b/qstash/api/dlq/listMessages.mdx
@@ -22,49 +22,7 @@ List all messages currently inside the DLQ
 
 <ResponseField name="messages" type="Array">
   <Expandable defaultOpen>
-    <ResponseField name="messageId" type="string" required>
-      The unique identifier of the message.
-    </ResponseField>
-
-     <ResponseField name="url" type="string" required>
-      The URL of your API.
-    </ResponseField>
-     <ResponseField name="topicName" type="string">
-     The topic name if the message was published to a topic.
-    </ResponseField>
-      <ResponseField name="endpointName" type="string">
-     The endpoint name if the message was published to a topic and the endpoint has a name.
-    </ResponseField>
-
-
-     <ResponseField name="callback" type="string">
-     The callback URL if configured
-    </ResponseField>
-
-     <ResponseField name="method" type="string" required>
-     The HTTP method to use when calling your API.
-    </ResponseField>
-     <ResponseField name="header" type="Record<string,string[]>" >
-      The HTTP headers to send to your API.
-    </ResponseField>
-     <ResponseField name="body" type="string" >
-      The HTTP body to send to your API.
-    </ResponseField>
-    <ResponseField name="maxRetries" type="number">
-      How many times the message will be retried before it is discarded.
-    </ResponseField>
-    <ResponseField name="notBefore" type="number" required>
-      The unix timestamp in milliseconds after which processing of this message may
-      start.
-    </ResponseField>
-    <ResponseField name="createdAt" type="number" required>
-      The unix timestamp in milliseconds when the message was created.
-    </ResponseField>
-    <ResponseField name="dlqId" type="string" required>
-      The unique id within the DLQ. Use this to remove the message from the DLQ
-      [DELETE /v2/dlq/{dlqId}](/qstash/api/dlq/deleteMessage)
-    </ResponseField>
-
+    <Snippet file="qstash-dlq-message-type.mdx" />
   </Expandable>
 </ResponseField>
 

--- a/qstash/api/messages/create.mdx
+++ b/qstash/api/messages/create.mdx
@@ -59,9 +59,19 @@ times the task has been retried.
 
 </ParamField>
 <ParamField header="Upstash-Callback" type="string" >
-You can define a callback url that will be called with the response from the destination API.
-Callbacks are experimental, and the API might change in the future!
+You can define a callback url that will be called after each attempt. 
+See the content of what will be delivered to a callback [here](https://docs.upstash.com/qstash/features/callbacks#how-do-i-use-callbacks) 
 - The callback url must be prefixed with a valid protocol (`http://` or `https://`)
+- Callbacks are charged as a regular message.
+- Callbacks will use the retry setting from the original request.
+</ParamField>
+
+<ParamField header="Upstash-Failure-Callback" type="string" >
+You can define a failure callback url that will be called when a delivery is failed. 
+That is when all the defined retries are exhausted.
+See the content of what will be delivered to a failure callback [here](https://docs.upstash.com/qstash/features/callbacks#what-is-a-failure-callback) 
+
+- The failure callback url must be prefixed with a valid protocol (`http://` or `https://`)
 - Callbacks are charged as a regular message.
 - Callbacks will use the retry setting from the original request.
 </ParamField>

--- a/qstash/features/callbacks.mdx
+++ b/qstash/features/callbacks.mdx
@@ -45,13 +45,20 @@ The callback body sent to you will be a JSON object with the following fields:
 ```json
 {
   "status": 200,
-  "sourceMessasgeId": "msg_xxx", // The ID of the message that triggered the callback
-  "headers": {
-    "key": "value"
-  },
-  "body": "base64 encoded response body",
-  "retried": 1 // How many times we retried to deliver the original message
-  "maxRetries" : 3, //number of retries before the message assumed to be failed to delivered.
+  "header": { "key": "value"},            // Response header 
+  "body": "YmFzZTY0IGVuY29kZWQgcm9keQ==", // base64 encoded response body
+  "retried": 2,                           // How many times we retried to deliver the original message
+  "maxRetries" : 3,                       // Number of retries before the message assumed to be failed to delivered.
+  "sourceMessasgeId": "msg_xxx",          // The ID of the message that triggered the callback
+  "topicName" : "myTopic",                // The name of the topic if the request was part of a topic 
+  "endpointName" : "myEndpoint",          // The endpoint name if the endpoint is given a name within a topic
+  "url" : "http://myurl.com" ,            // The destination url of the message that triggered the callback
+  "method" : "GET",                       // The http method of the message that triggered the callback
+  "sourceHeader" : { "key": "value"},     // The http header of the message that triggered the callback
+  "sourceBody" : "BODY",                  // The body of the message that triggered the callback
+  "notBefore" : "1701198458025",          // The unix timestamp of the message that triggered the callback is/will be delivered in milliseconds
+  "createdAt" : "1701198447054",          // The unix timestamp of the message that triggered the callback is created in milliseconds
+  "scheduleId" : "scd_xxx"                // The scheduleId of the message if the message is triggered by a schedule
 }
 ```
 
@@ -113,14 +120,21 @@ The callback body sent to you will be a JSON object with the following fields:
 ```json
 {
   "status": 200,
-  "sourceMessasgeId": "msg_xxx", // The ID of the message that triggered the callback
-  "header": {
-    "key": "value"
-  },
-  "body": "base64 encoded response body",
-  "retried": 3,  // How many times we retried to deliver the original message
-  "maxRetries" : 3, //number of retries before the message assumed to be failed to delivered.
-  "dlqId" : dlqId // Dead Letter Queue id. This can be used to remove the related message from DLQ.
+  "header": { "key": "value"},            // Response header 
+  "body": "YmFzZTY0IGVuY29kZWQgcm9keQ==", // base64 encoded response body
+  "retried": 3,                           // How many times we retried to deliver the original message
+  "maxRetries" : 3,                       // Number of retries before the message assumed to be failed to delivered.
+  "dlqId" : dlqId                         // Dead Letter Queue id. This can be used to retrieve/remove the related message from DLQ.
+  "sourceMessasgeId": "msg_xxx",          // The ID of the message that triggered the callback
+  "topicName" : "myTopic",                // The name of the topic if the request was part of a topic 
+  "endpointName" : "myEndpoint",          // The endpoint name if the endpoint is given a name within a topic
+  "url" : "http://myurl.com" ,            // The destination url of the message that triggered the callback
+  "method" : "GET",                       // The http method of the message that triggered the callback
+  "sourceHeader" : { "key": "value"},     // The http header of the message that triggered the callback
+  "sourceBody" : "BODY",                  // The body of the message that triggered the callback
+  "notBefore" : "1701198458025",          // The unix timestamp of the message that triggered the callback is/will be delivered in milliseconds
+  "createdAt" : "1701198447054",          // The unix timestamp of the message that triggered the callback is created in milliseconds
+  "scheduleId" : "scd_xxx"                // The scheduleId of the message if the message is triggered by a schedule
 }
 ```
 

--- a/qstash/howto/debug-logs.mdx
+++ b/qstash/howto/debug-logs.mdx
@@ -12,7 +12,7 @@ Only the last 10.000 logs are kept and older logs are removed automatically.
 To understand the lifecycle of each message, we'll look at the following chart:
 
 <Frame>
-[![](https://mermaid.ink/img/pako:eNplkEFrg0AQhf9KmGOJsWprEg8FiVsI5GSlUGoPG3fVBXVlnQ0E8b931RgC2dPs994bZqaHTDIOAXRIkUeCForW1sVNm5V5vy9_K8v6WB1iEiYkmuHtMwnhITl-k5nP9YRjksQ_TzQiJ1PGS58H5TM8nhY8ZZ-a37OTYuaa8RxcGKyh5qqmgpmF-tGRApa85ikEpmQ8p7rCFNJmMFbdMrMyYQKlgiCnVcfXQDXKr2uTQYBK88V0u8vdVUnKuAn1gNd2vF4hOjQtM9nkohi5VpXBJWLbBbY9yptCYKnPm0zWdidYSRWWl71v-66_o67H_a1H3z2PZWdnv8vdNydn21fHpTAMwz9coHw1?type=png)](https://mermaid.live/edit#pako:eNplkEFrg0AQhf9KmGOJsWprEg8FiVsI5GSlUGoPG3fVBXVlnQ0E8b931RgC2dPs994bZqaHTDIOAXRIkUeCForW1sVNm5V5vy9_K8v6WB1iEiYkmuHtMwnhITl-k5nP9YRjksQ_TzQiJ1PGS58H5TM8nhY8ZZ-a37OTYuaa8RxcGKyh5qqmgpmF-tGRApa85ikEpmQ8p7rCFNJmMFbdMrMyYQKlgiCnVcfXQDXKr2uTQYBK88V0u8vdVUnKuAn1gNd2vF4hOjQtM9nkohi5VpXBJWLbBbY9yptCYKnPm0zWdidYSRWWl71v-66_o67H_a1H3z2PZWdnv8vdNydn21fHpTAMwz9coHw1)
+[![](https://mermaid.ink/img/pako:eNptkWFvgjAQhv-KuY-LyoQNlQ9LiHaJCdmyiku2sSyVFmgClEAxMYb_vkJFna6f7p577_L27gChoAwcqCSRbMlJXJJstDODfKDe1933YDR6Giwwcn201PCYdAV34a_e0ZG7Lwvk_WD0tkHrXqChpzIt0g1dCWH8ijXtwg5i5OOPG-kSeSrEvYOLyrO78nrc9d7aurB7bfG67-YL1_b-H3Cy12nU0jTW3v6y8z6OGIaQsTIjnKojHFpRADJhGQvAUSFlEalTGUCQN0pKainW-zwER5Y1G0Jd0PPZwIlIWp0oolyK8gRTQShT6QHkvmgvHvNKqpGhyCMet7wuU4UTKYvKMYy2PI65TOrtOBSZUXGakFImu7lt2KY9I6bF7KlFHi2LhtvJfBaZD5OITu8nJoGmGUJB8k8helfNL76fr7o?type=png)](https://mermaid.live/edit#pako:eNptkWFvgjAQhv-KuY-LyoQNlQ9LiHaJCdmyiku2sSyVFmgClEAxMYb_vkJFna6f7p577_L27gChoAwcqCSRbMlJXJJstDODfKDe1933YDR6Giwwcn201PCYdAV34a_e0ZG7Lwvk_WD0tkHrXqChpzIt0g1dCWH8ijXtwg5i5OOPG-kSeSrEvYOLyrO78nrc9d7aurB7bfG67-YL1_b-H3Cy12nU0jTW3v6y8z6OGIaQsTIjnKojHFpRADJhGQvAUSFlEalTGUCQN0pKainW-zwER5Y1G0Jd0PPZwIlIWp0oolyK8gRTQShT6QHkvmgvHvNKqpGhyCMet7wuU4UTKYvKMYy2PI65TOrtOBSZUXGakFImu7lt2KY9I6bF7KlFHi2LhtvJfBaZD5OITu8nJoGmGUJB8k8helfNL76fr7o)
 </Frame>
 
 Either you or a previously setup schedule will create a message.
@@ -25,6 +25,8 @@ considered successful and will be marked as `DELIVERED`.
 
 Otherwise the message is being retried if there are any retries left and moves to `RETRY`. If all retries are exhausted, the task has `FAILED` and the message will be moved to the DLQ.
 
+During all this a message can be cancelled via [DELETE /v2/messages/:messageId](http://docs.upstash.com/qstash/api/messages/cancel). When the request is recevied, `CANCEL_REQUESTED` will be logged first.
+If retries are not exhausted yet, in the next deliver time, the message will be marked as `CANCELLED` and will be completely removed from the system.
 
 ## Console
 

--- a/qstash/howto/receiving.mdx
+++ b/qstash/howto/receiving.mdx
@@ -11,14 +11,15 @@ We are forwarding all headers that have been prefixed with `Upstash-Forward-` to
 
 In addition to your custom headers, we're sending these headers as well:
 
-| Header               | Description                                                          |
-| -------------------- | -------------------------------------------------------------------- |
-| `User-Agent`         | Will be set to `Upstash-QStash`                                      |
-| `Content-Type`       | The original `Content-Type` header                                   |
-| `Upstash-Topic-Name` | The topic name if sent to a topic                                    |
-| `Upstash-Signature`  | The signature you need to verify [See here](/qstash/howto/signature) |
-| `Upstash-Retried`    | How often the message has been retried so far. Starts with 0.        |
-| `Upstash-Message-Id` | The message id of the message.                                       |
+| Header                | Description                                                          |
+| ----------------------| -------------------------------------------------------------------- |
+| `User-Agent`          | Will be set to `Upstash-QStash`                                      |
+| `Content-Type`        | The original `Content-Type` header                                   |
+| `Upstash-Topic-Name`  | The topic name if sent to a topic                                    |
+| `Upstash-Signature`   | The signature you need to verify [See here](/qstash/howto/signature) |
+| `Upstash-Retried`     | How often the message has been retried so far. Starts with 0.        |
+| `Upstash-Message-Id`  | The message id of the message.                                       |
+| `Upstash-Schedule-Id` | The schedule id of the message if it is related to a schedule.       |
 
 ## Body
 


### PR DESCRIPTION
- New fields on the callbacks: - Message content. - Schedule Id - Dlq id's

- Schedule id on the header of a request
- DLQ message // following Response fields are only set for DLQ Messages ResponseStatus int `json:"responseStatus,omitempty"` ResponseHeader map[string][]string `json:"responseHeader,omitempty"` ResponseBody string `json:"responseBody,omitempty"

- Get message from DLQ API