### PR TITLE
Fix parsing error on /qstash/api/dlq/

### DIFF
--- a/_snippets/qstash-dlq-message-type.mdx
+++ b/_snippets/qstash-dlq-message-type.mdx
@@ -52,7 +52,7 @@
 
 <ResponseField name="dlqId" type="string" required>
     The unique id within the DLQ. Use this to remove the message from the DLQ
-    [DELETE /v2/dlq/{dlqId}](/qstash/api/dlq/deleteMessage)
+    [DELETE /v2/dlq/\{dlqId}](/qstash/api/dlq/deleteMessage)
 </ResponseField>
 
 <ResponseField name="responseStatus" type="int">


### PR DESCRIPTION
This PR fixes the error addressed in the support ticket

<img width="1512" alt="CleanShot 2023-12-26 at 14 44 20@2x" src="https://github.com/upstash/docs/assets/44352119/62f4ed3d-2e6d-4dc4-ab30-5742637e832c">
