### PR TITLE
Add SDK to Qstash API examples

### DIFF
--- a/qstash/overall/apiexamples.mdx
+++ b/qstash/overall/apiexamples.mdx
@@ -2,8 +2,19 @@
 title: "API Examples"
 ---
 
+### Use QStash via:
+
+- cURL
+- [Typescript SDK](https://github.com/upstash/sdk-qstash-ts)
+- [Python SDK](https://github.com/upstash/qstash-python)
+
+Below are some examples to get you started. You can also check the [how to](/qstash/howto/publishing) section for
+more technical details or the [API reference](/qstash/api/messages) to test the API.
+
 ### Publish a message to an endpoint
 
+<Tabs>
+<Tab title="cURL">
 ```shell
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
@@ -11,9 +22,38 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/https://example.com'
 ```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.publishJSON({
+  url: "https://example.com",
+  body: {
+    hello: "world",
+  },
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://example.com",
+  "body": {
+    "hello": "world",
+  },
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
 
 ### Publish a message to a topic
 
+<Tabs>
+<Tab title="cURL">
 ```shell
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
@@ -21,9 +61,38 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/myTopic'
 ```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.publishJSON({
+  topic: "myTopic",
+  body: {
+    hello: "world",
+  },
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "topic": "myTopic",
+  "body": {
+    "hello": "world",
+  },
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
 
 ### Publish a message with 5 minutes delay
 
+<Tabs>
+<Tab title="cURL">
 ```shell
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
@@ -32,9 +101,40 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/https://example.com'
 ```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.publishJSON({
+  url: "https://example.com",
+  body: {
+    hello: "world",
+  },
+  delay: 300,
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://example.com",
+  "body": {
+    "hello": "world",
+  },
+  "delay": 300,
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
 
 ### Send a custom header
 
+<Tabs>
+<Tab title="cURL">
 ```shell
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
@@ -43,20 +143,82 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/https://example.com'
 ```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.publishJSON({
+  url: "https://example.com",
+  body: {
+    hello: "world",
+  },
+  headers: {
+    "My-Header": "my-value",
+  },
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://example.com",
+  "body": {
+    "hello": "world",
+  },
+  "headers": {
+    "My-Header": "my-value",
+  },
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
 
 ### Schedule to run once a day
 
+<Tabs>
+<Tab title="cURL">
 ```shell
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
-	-H "Upstash-Cron: 0 0 * * *" \
+    -H "Upstash-Cron: 0 0 * * *" \
     -H "Content-type: application/json" \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/schedules/https://example.com'
 ```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const schedules = client.schedules();
+await schedules.create({
+  destination: "https://example.com",
+  cron: "0 0 * * *",
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+schedules = client.schedules()
+schedules.create({
+  "destination": "https://example.com",
+  "cron": "0 0 * * *",
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
 
 ### Set max retry count to 3
 
+<Tabs>
+<Tab title="cURL">
 ```shell
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
@@ -65,3 +227,128 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/https://example.com'
 ```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.publishJSON({
+  url: "https://example.com",
+  body: {
+    hello: "world",
+  },
+  retries: 3,
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://example.com",
+  "body": {
+    "hello": "world",
+  },
+  "retries": 3,
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
+
+### Set callback url
+
+<Tabs>
+<Tab title="cURL">
+```shell
+curl -XPOST \
+    -H 'Authorization: Bearer XXX' \
+    -H "Content-type: application/json" \
+    -H "Upstash-Callback: https://example.com/callback" \
+    -d '{ "hello": "world" }' \
+    'https://qstash.upstash.io/v2/publish/https://example.com'
+```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.publishJSON({
+  url: "https://example.com",
+  body: {
+    hello: "world",
+  },
+  callback: "https://example.com/callback",
+});
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://example.com",
+  "body": {
+    "hello": "world",
+  },
+  "callback": "https://example.com/callback",
+})
+# Async version is also available
+```
+</Tab>
+</Tabs>
+
+### List all events
+
+<Tabs>
+<Tab title="cURL">
+```shell
+curl https://qstash.upstash.io/v2/events \
+    -H "Authorization: Bearer <token>"
+```
+</Tab>
+
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const events = await client.events()
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+events = client.events()
+# Async version is also available
+```
+</Tab>
+</Tabs>
+
+### List all schedules
+
+<Tabs>
+<Tab title="cURL">
+```shell
+curl https://qstash.upstash.io/v2/schedules \
+    -H "Authorization: Bearer <token>"
+```
+
+</Tab>
+<Tab title="Typescript SDK">
+```typescript
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const schedules = client.schedules();
+const scheds = await schedules.list();
+```
+</Tab>
+
+<Tab title="Python SDK">
+```python
+client = Client("<QSTASH_TOKEN>")
+schedules = client.schedules()
+scheds = schedules.list()
+# Async version is also available
+```
+</Tab>
+</Tabs>

--- a/qstash/overall/getstarted.mdx
+++ b/qstash/overall/getstarted.mdx
@@ -58,6 +58,8 @@ curl -XPOST \
     'https://qstash.upstash.io/v2/publish/https://<your-api-url>'
 ```
 
+See more examples in the [example section](/qstash/overall/apiexamples).
+
 ## Check Response
 
 You should receive a response with a unique message ID.


### PR DESCRIPTION
We're missing documentation for the Qstash SDKs, this improves it a bit by adding tabs on the examples page
![Docs gif](https://github.com/upstash/docs/assets/24885081/c8dc461a-1665-463c-b7d1-ba966b497f1f)
