### PR TITLE
Document SINTERSTORE properly, currently a copy of SINTER

### DIFF
--- a/oss/sdks/ts/redis/commands/set/sinterstore.mdx
+++ b/oss/sdks/ts/redis/commands/set/sinterstore.mdx
@@ -1,5 +1,5 @@
 ---
-title: SINTER
+title: SINTERSTORE
 description: Return the intersection between sets and store the resulting set in a key
 ---
 
@@ -27,7 +27,7 @@ description: Return the intersection between sets and store the resulting set in
 ```ts Example 
 await redis.sadd("set1", "a", "b", "c"); 
 await redis.sadd("set2", "c", "d", "e"); 
-await redis.sinter("destination", "set1", "set2");
+await redis.sinterstore("destination", "set1", "set2");
 ```
 
 </RequestExample>


### PR DESCRIPTION
sinterstore.mdx has the correct description of the API, but is referring to it as `sinter` and not `sinterstore`

<img width="271" alt="image" src="https://github.com/upstash/docs/assets/510740/0ab8356a-51e7-4ec7-a3c5-21525c1fc0b4">
