### PR TITLE
chore: improved readability in the oss and qstash section

### DIFF
--- a/oss/sdks/py/redis/commands/bitmap/bitpos.mdx
+++ b/oss/sdks/py/redis/commands/bitmap/bitpos.mdx
@@ -24,7 +24,7 @@ description: Find the position of the first set or clear bit (bit with a value o
 ## Response
 
 <ResponseField type="int" required>
-  The index of the first occurence of the bit in the string.
+  The index of the first occurrence of the bit in the string.
 </ResponseField>
 
 <RequestExample>

--- a/oss/sdks/py/redis/commands/generic/pexpireat.mdx
+++ b/oss/sdks/py/redis/commands/generic/pexpireat.mdx
@@ -11,7 +11,7 @@ description: Sets a timeout on key. After the timeout has expired, the key will 
 </ParamField>
 
 <ParamField body="unix_time_milliseconds" type="int | datetime.datetime" required>
-  The timeout in unix miliseconds timestamp as int or a datetime.datetime object.
+  The timeout in unix milliseconds timestamp as int or a datetime.datetime object.
 </ParamField>
 
 <ParamField body="nx" type="bool">

--- a/oss/sdks/py/redis/commands/list/lrem.mdx
+++ b/oss/sdks/py/redis/commands/list/lrem.mdx
@@ -1,6 +1,6 @@
 ---
 title: LREM
-description: Remove the first `count` occurences of an element from a list.
+description: Remove the first `count` occurrences of an element from a list.
 ---
 
 ## Arguments

--- a/oss/sdks/ts/ratelimit/features.mdx
+++ b/oss/sdks/ts/ratelimit/features.mdx
@@ -119,7 +119,7 @@ databases as well as offering lower latencies to more of your users.
 
 `MultiRegionRatelimit` does this by checking the current limit in the closest db
 and returning immediately. Only afterwards will the state be asynchronously
-replicated to the other datbases leveraging
+replicated to the other databases leveraging
 [CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type). Due
 to the nature of distributed systems, there is no way to guarantee the set
 ratelimit is not exceeded by a small margin. This is the tradeoff for reduced

--- a/oss/sdks/ts/ratelimit/gettingstarted.mdx
+++ b/oss/sdks/ts/ratelimit/gettingstarted.mdx
@@ -81,7 +81,7 @@ export type RatelimitResponse = {
    * For the MultiRegion setup we do some synchronizing in the background, after returning the current limit.
    * In most case you can simply ignore this.
    *
-   * On Vercel Edge or Cloudflare workers, you need to explicitely handle the pending Promise like this:
+   * On Vercel Edge or Cloudflare workers, you need to explicitly handle the pending Promise like this:
    *
    * **Vercel Edge:**
    * https://nextjs.org/docs/api-reference/next/server#nextfetchevent

--- a/oss/sdks/ts/redis/commands/bitmap/bitpos.mdx
+++ b/oss/sdks/ts/redis/commands/bitmap/bitpos.mdx
@@ -24,7 +24,7 @@ description: Find the position of the first set or clear bit (bit with a value o
 ## Response
 
 <ResponseField type="integer" required>
-  The index of the first occurence of the bit in the string.
+  The index of the first occurrence of the bit in the string.
 </ResponseField>
 
 <RequestExample>

--- a/oss/sdks/ts/redis/commands/list/lrem.mdx
+++ b/oss/sdks/ts/redis/commands/list/lrem.mdx
@@ -1,6 +1,6 @@
 ---
 title: LREM
-description: Remove the first `count` occurences of an element from a list.
+description: Remove the first `count` occurrences of an element from a list.
 ---
 
 ## Arguments

--- a/oss/sdks/ts/redis/commands/zset/zlexcount.mdx
+++ b/oss/sdks/ts/redis/commands/zset/zlexcount.mdx
@@ -1,10 +1,10 @@
 ---
 title: ZLEXCOUNT
-description: Returns the number of elements in the sorted set stored at key filterd by lex.
+description: Returns the number of elements in the sorted set stored at key filtered by lex.
 ---
 
 
-## Arguments 
+## Arguments
 
 <ParamField body="key" type="string" required>
   The key to get.

--- a/oss/sdks/ts/redis/developing.mdx
+++ b/oss/sdks/ts/redis/developing.mdx
@@ -78,7 +78,7 @@ ready, because SRH doesn't create a Redis connection until the first command
 comes in.
 
 ```yml
-name: Test @upstash/redis compatability
+name: Test @upstash/redis compatibility
 on:
   push:
   workflow_dispatch:

--- a/oss/sdks/ts/vector/commands/query.mdx
+++ b/oss/sdks/ts/vector/commands/query.mdx
@@ -16,7 +16,7 @@ The query method is designed to retrieve the most similar vectors from the index
       The query vector
     </ResponseField>
     <ResponseField name="topK" type="number" required>
-      The total number of the vectors that you want to recieve as a query
+      The total number of the vectors that you want to receive as a query
       result. The response will be sorted based on the distance metric score,
       and `topK` vectors will be returned.
     </ResponseField>

--- a/oss/sdks/ts/vector/overview-backup.mdx
+++ b/oss/sdks/ts/vector/overview-backup.mdx
@@ -62,7 +62,7 @@ To perform data operations on an index, access it using the `index` method.
 await index.fetch([....], { includeMetadata: true, includeVectors: true });
 ```
 
-### Accesing an index, with metadata typing
+### Accessing an index, with metadata typing
 
 If you are storing metadata alongside your vector values, you can pass a type parameter to `index()` in order to get proper TypeScript typechecking.
 

--- a/qstash/api/messages/create.mdx
+++ b/qstash/api/messages/create.mdx
@@ -46,7 +46,7 @@ example: "50s" | "3m" | "10h" | "1d"
 </ParamField>
 
 <ParamField header="Upstash-Retries" type="int" default={3} >
- How often should this messasge be retried in case the destination API is not available.
+ How often should this message be retried in case the destination API is not available.
 
 The total number of deliveries is therefore capped at `1 + retries`
 

--- a/qstash/api/schedules/create.mdx
+++ b/qstash/api/schedules/create.mdx
@@ -49,7 +49,7 @@ example: "50s" | "3m" | "10h" | "1d"
 </ParamField>
 
 <ParamField header="Upstash-Retries" type="int" default={3} >
- How often should this messasge be retried in case the destination API is not available.
+ How often should this message be retried in case the destination API is not available.
 
 The total number of deliveries is therefore capped at `1 + retries`
 


### PR DESCRIPTION
This PR fixes typos in the `oss` and `qstash` section