### PR TITLE
docs: Add QStash SDK examples to all pages

### DIFF
--- a/oss/sdks/py/qstash/examples/messages.mdx
+++ b/oss/sdks/py/qstash/examples/messages.mdx
@@ -7,8 +7,9 @@ title: Messages
   and awaiting the methods.
 </Info>
 
-Note: Messages are removed from the database shortly after they're delivered, so you
-may not be able to retrieve a message after.
+Messages are removed from the database shortly after they're delivered, so you
+will not be able to retrieve a message after. This endpoint is intended to be used
+for accessing messages that are in the process of being delivered/retried.
 
 #### Retrieve a message
 

--- a/oss/sdks/ts/qstash/examples/messages.mdx
+++ b/oss/sdks/ts/qstash/examples/messages.mdx
@@ -2,8 +2,9 @@
 title: Messages
 ---
 
-Note: Messages are removed from the database shortly after they're delivered, so you
-may not be able to retrieve a message after.
+Messages are removed from the database shortly after they're delivered, so you
+will not be able to retrieve a message after. This endpoint is intended to be used
+for accessing messages that are in the process of being delivered/retried.
 
 #### Retrieve a message
 

--- a/qstash/api/messages/get.mdx
+++ b/qstash/api/messages/get.mdx
@@ -11,6 +11,11 @@ authMethod: "bearer"
   The id of the message to retrieve.
 </ParamField>
 
+<Warning>
+Messages are removed from the database shortly after they're delivered, so you
+will not be able to retrieve a message after. This endpoint is intended to be used
+for accessing messages that are in the process of being delivered/retried.
+</Warning>
 ## Response
 
 <Snippet file="qstash-message-type.mdx" />

--- a/qstash/features/callbacks.mdx
+++ b/qstash/features/callbacks.mdx
@@ -31,14 +31,38 @@ created by callbacks are charged as any other message.
 You can add a callback url in the `Upstash-Callback` header when publishing a
 message. The value must be a valid URL.
 
-```bash
+<CodeGroup>
+```bash cURL
 curl -X POST \
-  https://qstash.upstash.com/v2/publish/<DESTINATION_URL> \
+  https://qstash.upstash.com/v2/publish/https://my-api... \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <QSTASH_TOKEN>' \
   -H 'Upstash-Callback: <CALLBACK_URL>' \
   -d '{ "hello": "world" }'
 ```
+
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  callback: "https://my-callback...",
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "callback": "https://my-callback...",
+})
+```
+</CodeGroup>
 
 The callback body sent to you will be a JSON object with the following fields:
 
@@ -107,7 +131,8 @@ This is designed to be an alternative to [List messages to DLQ](/qstash/api/dlq/
 You can add a failure callback URL in the `Upstash-Failure-Callback` header when publishing a
 message. The value must be a valid URL.
 
-```bash
+<CodeGroup>
+```bash cURL
 curl -X POST \
   https://qstash.upstash.com/v2/publish/<DESTINATION_URL> \
   -H 'Content-Type: application/json' \
@@ -115,6 +140,29 @@ curl -X POST \
   -H 'Upstash-Failure-Callback: <CALLBACK_URL>' \
   -d '{ "hello": "world" }'
 ```
+
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  failureCallback: "https://my-callback...",
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "failure_callback": "https://my-callback...",
+})
+```
+</CodeGroup>
 
 The callback body sent to you will be a JSON object with the following fields:
 
@@ -139,3 +187,5 @@ The callback body sent to you will be a JSON object with the following fields:
   "callerIP": "178.247.74.179"            // The IP address where the message that triggered the callback is published from
 }
 ```
+
+You can also use a callback and failureCallback together!

--- a/qstash/features/deduplication.mdx
+++ b/qstash/features/deduplication.mdx
@@ -17,21 +17,46 @@ status code. We'll send HTTP `202 Accepted` code in case of a duplicate message.
 To deduplicate a message, you can send the `Upstash-Deduplication-Id` header
 when publishing the message.
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
     -H "Upstash-Deduplication-Id: abcdef" \
     -d '{ "hello": "world" }' \
-    'https://qstash.upstash.io/v2/publish/...'
+    'https://qstash.upstash.io/v2/publish/https://my-api..."'
 ```
+
+```typescript TypeScript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  deduplicationId: "abcdef",
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "deduplication_id": "abcdef"
+})
+```
+</CodeGroup>
 
 ## Content Based Deduplication
 
 If you want to deduplicate messages automatically, you can set the
 `Upstash-Content-Based-Deduplication` header to `true`.
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
@@ -39,6 +64,29 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/...'
 ```
+
+```typescript TypeScript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  contentBasedDeduplication: true,
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "content_based_deduplication": True
+})
+```
+</CodeGroup>
 
 Content based deduplication creates a unique deduplication ID for the message
 based on the following fields:

--- a/qstash/features/delay.mdx
+++ b/qstash/features/delay.mdx
@@ -20,14 +20,39 @@ The format for the duration is `<number><unit>`. Here are some examples:
 
 You can send this duration inside the `Upstash-Delay` header.
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
     -H "Upstash-Delay: 1m" \
     -d '{ "hello": "world" }' \
-    'https://qstash.upstash.io/v2/publish/...'
+    'https://qstash.upstash.io/v2/publish/https://my-api...'
 ```
+
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  delay: 60,
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+res = client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "headers": { "test-header": "test-value" },
+  "delay": 60
+})
+```
+</CodeGroup>
 
 <Warning>
 
@@ -43,14 +68,39 @@ timestamp in seconds, based on the UTC timezone.
 
 You can send the timestamp inside the `Upstash-Not-Before` header.
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
     -H "Upstash-Not-Before: 1657104947" \
     -d '{ "hello": "world" }' \
-    'https://qstash.upstash.io/v2/publish/...'
+    'https://qstash.upstash.io/v2/publish/https://my-api...'
 ```
+
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  notBefore: 1657104947,
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+res = client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "headers": { "test-header": "test-value" },
+  "not_before": 1657104947
+})
+```
+</CodeGroup>
 
 <Info>
 

--- a/qstash/features/retry.mdx
+++ b/qstash/features/retry.mdx
@@ -10,14 +10,38 @@ The maximum number of retries depends on your current plan. By default, we retry
 the maximum amount of times, but you can set it lower by sending the
 `Upstash-Retries` header:
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
     -H "Upstash-Retries: 2" \
     -d '{ "hello": "world" }' \
-    'https://qstash.upstash.io/v2/publish/...'
+    'https://qstash.upstash.io/v2/publish/https://my-api...'
 ```
+
+```typescript TypeScript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  retries: 2,
+});
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "retries": 2
+})
+```
+</CodeGroup>
 
 The backoff algorithm calculates the retry delay based on the number of retries.
 Each delay is capped at 1 day.

--- a/qstash/features/schedules.mdx
+++ b/qstash/features/schedules.mdx
@@ -15,7 +15,8 @@ We use `UTC` as timezone when evaluating cron expressions.
 The following request would create a schedule that will automatically publish
 the message every minute:
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
@@ -23,6 +24,27 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/schedules/https://example.com'
 ```
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const schedules = client.schedules();
+await schedules.create({
+  destination: "example.com",
+  cron: "* * * * *",
+});
+```
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+schedules = client.schedules()
+res = schedules.create({
+  "destination": "example.com",
+  "cron": "* * * * *",
+})
+```
+</CodeGroup>
 
 All of the [other config options](/qstash/howto/publishing#optional-parameters-and-configuration)
 can still be used.
@@ -42,7 +64,8 @@ You can see and manage your schedules in the
 Instead of scheduling a message to a specific URL, you can also create a
 schedule, that publishes to a topic. Simply use either the topic name or its id:
 
-```bash
+<CodeGroup>
+```bash cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
@@ -50,3 +73,24 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/schedules/<TOPIC_ID_OR_NAME>'
 ```
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const schedules = client.schedules();
+await schedules.create({
+  destination: "topicName",
+  cron: "* * * * *",
+});
+```
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+schedules = client.schedules()
+res = schedules.create({
+  "destination": "topic_name",
+  "cron": "* * * * *",
+})
+```
+</CodeGroup>

--- a/qstash/howto/delete-schedule.mdx
+++ b/qstash/howto/delete-schedule.mdx
@@ -5,11 +5,30 @@ title: "Delete Schedules"
 
 Deleting schedules can be done using the [schedules api](/qstash/api/schedules/remove).
 
-```
+<CodeGroup>
+```shell cURL
 curl -XDELETE \
     -H 'Authorization: Bearer XXX' \
     'https://qstash.upstash.io/v2/schedules/<schedule_id>'
 ```
+
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const schedules = client.schedules();
+await schedules.delete("<scheduleId>");
+```
+
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+schedules = client.schedules()
+schedules.delete("<scheduleId>")
+```
+
+</CodeGroup>
 
 Deleting a schedule does not stop existing messages from being delivered. It
 only stops the schedule from creating new messages.
@@ -19,8 +38,24 @@ only stops the schedule from creating new messages.
 If you don't know the schedule ID, you can get a list of all of your schedules
 from [here](/qstash/api/schedules/list).
 
-```
+<CodeGroup>
+```shell cURL
 curl \
     -H 'Authorization: Bearer XXX' \
     'https://qstash.upstash.io/v2/schedules'
 ```
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const schedules = client.schedules();
+const allSchedules = await schedules.list();
+```
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+schedules = client.schedules()
+all_scheds = schedules.list()
+```
+</CodeGroup>

--- a/qstash/howto/publishing.mdx
+++ b/qstash/howto/publishing.mdx
@@ -6,14 +6,12 @@ title: "Publish Messages"
 Publishing a message is as easy as sending a HTTP request to the `/publish`
 endpoint. All you need is a valid url of your destination.
 
-<Frame>
+<Frame caption="Send a message via the Upstash Console">
   <img src="/img/qstash/publish.png" width="688" />
 </Frame>
 
 <Info>
-
 Destination URLs must always include the protocol (`http://` or `https://`)
-
 </Info>
 
 ## The message
@@ -31,7 +29,8 @@ message.
 
 #### Here's an example
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H 'Upstash-Forward-My-Header: my-value' \
@@ -39,6 +38,27 @@ curl -XPOST \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/https://example.com'
 ```
+``` typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  url: "https://example.com",
+  body: { "hello": "world" },
+  headers: { "my-header": "my-value" },
+});
+```
+``` python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+res = client.publish_json({
+  "url": "https://my-api...",
+  "body": { "hello": "world" },
+  "headers": { "my-header": "my-value" },
+})
+```
+</CodeGroup>
 
 In this case, we would deliver a `POST` request to `https://example.com` with
 the following body and headers:
@@ -61,6 +81,8 @@ with a success status code (200-299), the message will be retried and delivered
 when it comes back online. You do not need to worry about retrying messages or
 ensuring that they are delivered.
 
+By default, the multiple messages publshed to QStash are sent to your API in parallel.
+
 ## Publish to topic
 
 Topics allow you to publish a single message to more than one API endpoints. To
@@ -75,13 +97,33 @@ https://qstash.upstash.io/v2/publish/https://example.com
 https://qstash.upstash.io/v2/publish/my-topic
 ```
 
-```
+<CodeGroup>
+```shell cURL
 curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/my-topic'
 ```
+``` typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const res = await client.publishJSON({
+  topic: "my-topic",
+  body: { "hello": "world" },
+});
+```
+``` python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+res = client.publish_json({
+  "topic": "my-topic",
+  "body": { "hello": "world" },
+})
+```
+</CodeGroup>
 
 ## Optional parameters and configuration
 

--- a/qstash/howto/signature.mdx
+++ b/qstash/howto/signature.mdx
@@ -31,7 +31,49 @@ Instead here are the steps you need to follow:
      `body` claim.
 
 You can also reference the implementation in our
-[typescript sdk](https://github.com/upstash/sdk-qstash-ts/blob/main/src/receiver.ts#L82).
+[typescript sdk](https://github.com/upstash/sdk-qstash-ts/blob/main/src/receiver.ts#L82) or use 
+the methods provided in the SDKs:
+
+<CodeGroup>
+```typescript Typescript
+import { Receiver } from "@upstash/qstash";
+
+const receiver = new Receiver({
+  currentSigningKey: "YOUR_CURRENT_SIGNING_KEY",
+  nextSigningKey: "YOUR_NEXT_SIGNING_KEY",
+});
+
+// ... in your request handler
+
+const signature = req.headers["Upstash-Signature"];
+const body = req.body;
+
+const isValid = receiver.verify({
+  body,
+  signature,
+  url: "YOUR-SITE-URL",
+});
+```
+
+```python Python
+from upstash_qstash import Receiver
+
+receiver = Receiver({
+  "current_signing_key": "YOUR_CURRENT_SIGNING_KEY",
+  "next_signing_key": "YOUR_NEXT_SIGNING_KEY",
+})
+
+# ... in your request handler
+
+signature, body = req.headers["Upstash-Signature"], req.body
+
+is_valid receiver.verify({
+  "body": body,
+  "signature": signature,
+  "url": "YOUR-SITE-URL"
+})
+```
+</CodeGroup>
 
 After you have verified the signature and the claims, you can be sure the
 request came from Upstash and process it accordingly.

--- a/qstash/howto/topic-endpoint.mdx
+++ b/qstash/howto/topic-endpoint.mdx
@@ -24,7 +24,8 @@ After creating the topic, you can add endpoints to it:
 
 You can create a topic and endpoint using the [console](https://console.upstash.com/qstash) or [REST API](/qstash/api/topics/add-endpoint).
 
-```bash
+<CodeGroup>
+```bash cURL
 curl -XPOST https://qstash.upstash.io/v2/topics/:topicName/endpoints \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
@@ -41,3 +42,32 @@ curl -XPOST https://qstash.upstash.io/v2/topics/:topicName/endpoints \
     ]
   }'
 ```
+```typescript Typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+const topics = client.topics();
+await topics.addEndpoints({
+  name: "topicName",
+  endpoints: [
+    { name: "endpoint1", url: "https://example.com" },
+    { name: "endpoint2", url: "https://somewhere-else.com" },
+  ],
+});
+```
+```python Python
+from upstash_qstash import Client
+
+client = Client("<QSTASH_TOKEN>")
+topics = client.topics()
+topics.upsert_or_add_endpoints(
+  {
+    "name": "topic_name",
+    "endpoints": [
+      { "name": "endpoint1", "url": "https://example.com" },
+      { "name": "endpoint2", "url": "https://somewhere-else.com" },
+    ],
+  }
+)
+```
+</CodeGroup>

--- a/qstash/overall/apiexamples.mdx
+++ b/qstash/overall/apiexamples.mdx
@@ -13,6 +13,8 @@ more technical details or the [API reference](/qstash/api/messages) to test the 
 
 ### Publish a message to an endpoint
 
+Simple example to [publish](/qstash/howto/publishing) a message to an endpoint.
+
 <Tabs>
 <Tab title="cURL">
 ```shell
@@ -52,6 +54,9 @@ client.publish_json({
 
 ### Publish a message to a topic
 
+The [topic](/qstash/features/topics) is a way to publish a message to multiple endpoints in a
+fan out pattern.
+
 <Tabs>
 <Tab title="cURL">
 ```shell
@@ -90,6 +95,9 @@ client.publish_json({
 </Tabs>
 
 ### Publish a message with 5 minutes delay
+
+Add a delay to the message to be published. After QStash receives the message, 
+it will wait for the specified time (5 minutes in this example) before sending the message to the endpoint.
 
 <Tabs>
 <Tab title="cURL">
@@ -132,6 +140,8 @@ client.publish_json({
 </Tabs>
 
 ### Send a custom header
+
+Add a custom header to the message to be published.
 
 <Tabs>
 <Tab title="cURL">
@@ -217,6 +227,9 @@ schedules.create({
 
 ### Set max retry count to 3
 
+Configure how many times QStash should retry to send the message to the endpoint before
+sending it to the [dead letter queue](/qstash/features/dlq).
+
 <Tabs>
 <Tab title="cURL">
 ```shell
@@ -259,6 +272,9 @@ client.publish_json({
 
 ### Set callback url
 
+Receive a response from the endpoint and send it to the specified callback URL.
+If the endpoint returns a response, QStash will send it to the failure callback URL.
+
 <Tabs>
 <Tab title="cURL">
 ```shell
@@ -266,6 +282,7 @@ curl -XPOST \
     -H 'Authorization: Bearer XXX' \
     -H "Content-type: application/json" \
     -H "Upstash-Callback: https://example.com/callback" \
+    -H "Upstash-Failure-Callback: https://example.com/failure" \
     -d '{ "hello": "world" }' \
     'https://qstash.upstash.io/v2/publish/https://example.com'
 ```
@@ -280,6 +297,7 @@ await client.publishJSON({
     hello: "world",
   },
   callback: "https://example.com/callback",
+  failureCallback: "https://example.com/failure",
 });
 ```
 </Tab>
@@ -293,6 +311,7 @@ client.publish_json({
     "hello": "world",
   },
   "callback": "https://example.com/callback",
+  "failure_callback": "https://example.com/failure",
 })
 # Async version is also available
 ```
@@ -300,6 +319,9 @@ client.publish_json({
 </Tabs>
 
 ### List all events
+
+Retrieve a list of all [events](https://upstash.com/docs/qstash/api/events/list) that have 
+been published.
 
 <Tabs>
 <Tab title="cURL">


### PR DESCRIPTION
- Includes some warnings/message to clarify the behavior of QStash messages.
- Add descriptions to API examples
- Add examples to all howto/feature section that only contain `cURL`