### PR TITLE
Remove /docs -> /docs/introduction redirect

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -1333,10 +1333,6 @@
   },
   "redirects": [
     {
-      "source": "/docs",
-      "destination": "/docs/introduction"
-    },
-    {
       "source": "/docs/redis",
       "destination": "/redis/overall/getstarted"
     },


### PR DESCRIPTION
We believe this is the root of the 404 when clicking on the General tab. Removing this will fix it.