### PR TITLE
Bulk delete DLQ

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -635,7 +635,8 @@
               "pages": [
                 "qstash/api/dlq/listMessages",
                 "qstash/api/dlq/getMessage",
-                "qstash/api/dlq/deleteMessage"
+                "qstash/api/dlq/deleteMessage",
+                "qstash/api/dlq/deleteMessages"
               ]
             },
             {

--- a/qstash/api/dlq/deleteMessages.mdx
+++ b/qstash/api/dlq/deleteMessages.mdx
@@ -1,0 +1,52 @@
+---
+title: "Delete multiple messages from the DLQ"
+description: "Manually remove messages"
+api: "DELETE https://qstash.upstash.io/v2/dlq"
+authMethod: "bearer"
+---
+
+Delete multiple messages from the DLQ. 
+
+<Info>
+You can get the `dlqId` from the [list DLQs endpoint](/qstash/api/dlq/listmessages).
+</Info>
+## Request
+
+<ParamField body="dlqIds" type="Array" required>
+  The list of DLQ message IDs to remove. This must be an array of strings, 
+  not an array of objects.
+
+  <ParamField body="dlqId" type="String">
+    The ID of the DLQ message to remove.
+  </ParamField>
+</ParamField>
+
+## Response
+
+A deleted object with the number of deleted messages.
+
+```JSON
+{
+  "deleted": number
+}
+```
+
+<ResponseExample>
+```json 200 OK
+{
+  "deleted": 3
+}
+```
+</ResponseExample>
+
+<RequestExample>
+
+```sh
+curl -XDELETE https://qstash.upstash.io/v2/dlq \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+     "dlqIds": ["dlqId1-0", "dlqId2-0", "dlqId3-0"]
+    }'
+```
+</RequestExample>


### PR DESCRIPTION
Add docs page for bulk delete for dlq messages. There is a bug where the API playground shows an array of objects instead of strings, but I'm not sure how to fix it.