### PR TITLE
Add SDK examples for metadata filtering

### DIFF
--- a/vector/features/filtering.mdx
+++ b/vector/features/filtering.mdx
@@ -52,9 +52,13 @@ Assuming you have a metadata like below:
 
 Then, you can query similar vectors with a filter like below:
 
+<Tabs>
+
+<Tab title="cURL">
+
 ```shell
-curl https://powerful-kodiak-60521-us1-vector.upstash.io/query \
-  -H "Authorization: Bearer UPSTASH_VECTOR_TOKEN" \
+curl UPSTASH_VECTOR_REST_URL/query \
+  -H "Authorization: Bearer UPSTASH_VECTOR_REST_TOKEN" \
   -d '{
    "vector":[0.9215,0.3897,...],
    "topK" : 5,
@@ -62,6 +66,75 @@ curl https://powerful-kodiak-60521-us1-vector.upstash.io/query \
    "includeMetadata": true
 }'
 ```
+
+</Tab>
+
+<Tab title="Python">
+
+```python
+from upstash_vector import Index
+
+index = Index(url="UPSTASH_VECTOR_REST_URL", token="UPSTASH_VECTOR_REST_TOKEN")
+
+index.query(
+  vector=[0.9215, 0.3897, ...],
+  filter="population >= 1000000 AND geography.continent = 'Asia'",
+  top_k=5,
+  include_metadata=True
+)
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+
+```js
+import { Index } from "@upstash/vector"
+
+const index = new Index({
+  url: "UPSTASH_VECTOR_REST_URL",
+  token: "UPSTASH_VECTOR_REST_TOKEN",
+})
+
+await index.query({
+  vector: [0.9215, 0.3897, ...],
+  filter: "population >= 1000000 AND geography.continent = 'Asia'",
+  topK: 5,
+  includeMetadata: true,
+});
+```
+
+</Tab>
+
+<Tab title="Go">
+
+```go
+import (
+  "net/http"
+  "github.com/upstash/vector-go"
+)
+
+func main() {
+  opts := vector.Options{
+    Url:    "UPSTASH_VECTOR_REST_URL",
+    Token:  "UPSTASH_VECTOR_REST_TOKEN",
+    Client: &http.Client{},
+  }
+
+  index := vector.NewIndexWith(opts)
+
+  scores, err := index.Query(vector.Query{
+    Vector:          []float32{0.9215, 0.3897, ...},
+    Filter:          `population >= 1000000 AND geography.continent = 'Asia'`
+    TopK:            5,
+    IncludeMetadata: true,
+  })
+}
+```
+
+</Tab>
+
+</Tabs>
 
 ### Operators
 


### PR DESCRIPTION
When we wrote the initial version of the metadata filtering documentation, SDKs were not released yet, so we only provided cURL commands. We now also provide SDK examples make it easier to use.