### PR TITLE
docs(typescript): refactored Qstash's typescript SDK's docs

### DIFF
--- a/qstash/features/schedules.mdx
+++ b/qstash/features/schedules.mdx
@@ -28,8 +28,7 @@ curl -XPOST \
 import { Client } from "@upstash/qstash";
 
 const client = new Client({ token: "<QSTASH_TOKEN>" });
-const schedules = client.schedules();
-await schedules.create({
+await client.schedules.create({
   destination: "example.com",
   cron: "* * * * *",
 });
@@ -77,8 +76,7 @@ curl -XPOST \
 import { Client } from "@upstash/qstash";
 
 const client = new Client({ token: "<QSTASH_TOKEN>" });
-const schedules = client.schedules();
-await schedules.create({
+await client.schedules.create({
   destination: "topicName",
   cron: "* * * * *",
 });


### PR DESCRIPTION
`const schedules = client.schedules();`
 schedules is not a method in the typescript sdk SDK.
