### PR TITLE
Fix vector delete rest endpoint docs

### DIFF
--- a/vector/api/endpoints/delete.mdx
+++ b/vector/api/endpoints/delete.mdx
@@ -10,7 +10,12 @@ authMethod: "bearer"
 You can either delete a single vector, or multiple vectors in an array.
 
 <ParamField body="ids" type="string[]" required>
-  The IDs of the vectors to be deleted.
+  An array of vector ids or a singular vector id to be deleted.
+
+  <Note>
+    This is not a field, you should use the array or the string as the
+    request body itself.
+  </Note>
 </ParamField>
 
 ## Response
@@ -30,9 +35,7 @@ curl https://better-dodo-20522-us1-vector.upstash.io/delete \
 ```js Node
 const url = "https://better-dodo-20522-us1-vector.upstash.io/delete"; // Replace with your index endpoint.
 const token = "YOUR_TOKEN"; // Replace with your actual token
-const data = {
-  ids: ["1", "2", "abcde"],
-};
+const data = ["1", "2", "abcde"];
 
 fetch(url, {
   method: "DELETE",
@@ -57,9 +60,7 @@ headers = {
     'Authorization': f'Bearer {token}',
     'Content-Type': 'application/json'
 }
-data = {
-    'ids': ["1", "2", "abcde"],
-}
+data = ["1", "2", "abcde"]
 
 response = requests.delete(url, headers=headers, data=json.dumps(data))
 print(response.json())


### PR DESCRIPTION
It was using the vector ids to be deleted in Node.js and Python examples as a field of a body, but we expect a string or the array itself as the body.

Note that, mintlify does not allow me to represent that in the request section, so I added a note for it.