### PR TITLE
docs: include = symbol

### DIFF
--- a/oss/sdks/py/qstash/examples/receiver.mdx
+++ b/oss/sdks/py/qstash/examples/receiver.mdx
@@ -17,7 +17,7 @@ receiver = Receiver({
 
 signature, body = req.headers["Upstash-Signature"], req.body
 
-is_valid receiver.verify({
+is_valid = receiver.verify({
   "body": body,
   "signature": signature,
   "url": "YOUR-SITE-URL"


### PR DESCRIPTION
Including the symbol `=` in the example to get consistency for the user.

#### Before
```python
is_valid receiver.verify({
  "body": body,
  "signature": signature,
  "url": "YOUR-SITE-URL"
})
```

#### After
```python
is_valid = receiver.verify({
  "body": body,
  "signature": signature,
  "url": "YOUR-SITE-URL"
})
```