### PR TITLE
fix: correct qstash pip installation command

### DIFF
--- a/oss/sdks/py/qstash/gettingstarted.mdx
+++ b/oss/sdks/py/qstash/gettingstarted.mdx
@@ -7,7 +7,7 @@ title: Getting Started
 ### PyPI
 
 ```bash
-pip install upstash-qstash
+pip install qstash-python
 ```
 
 ## Get QStash token


### PR DESCRIPTION
**Description:**
It seems like the installation command given in the QStash Python SDK's Getting Started page is obsolete. I have corrected it.

**References:**
qstash-python GitHub repo: https://github.com/upstash/qstash-python
qstash-python PyPI: https://pypi.org/project/qstash-python/