### PR TITLE
Fix copy paste error in vector update rest api documentation

### DIFF
--- a/vector/api/endpoints/update.mdx
+++ b/vector/api/endpoints/update.mdx
@@ -27,7 +27,7 @@ To update both vector value and metadata, or data and metadata, use
   <Note>The vector should have the same dimensions as your index.</Note>
 </ParamField>
 <ParamField body="data" type="string">
-  The vector value to update to.
+  The raw text data to embed into a vector and update to.
   <Note>To update with data, the index must be created with an [embedding model](/vector/features/embeddingmodels).</Note>
 </ParamField>
 <ParamField body="metadata" type="Object">


### PR DESCRIPTION
The definition of the data field was wrong, copy pasted from the vector definition above.