### PR TITLE
update ratelimit js docs

### DIFF
--- a/oss/sdks/ts/ratelimit/costs.mdx
+++ b/oss/sdks/ts/ratelimit/costs.mdx
@@ -4,7 +4,7 @@ title: Costs
 
 This page details the cost of the Ratelimit algorithms in terms of the number of Redis commands. Note that these are calculated for Regional Ratelimits. For [Multi Region Ratelimit](https://upstash.com/docs/oss/sdks/ts/ratelimit/features#multi-region), costs will be higher. Additionally, if a Global Upstash Redis is used as the database, number of commands should be calculated as `(1+readRegionCount) * writeCommandCount + readCommandCount` and plus 1 if analytics is enabled.
 
-The Rate Limit SDK minimizes Redis calls to reduce latency overhead and cost. The count of commands executed by the Rate Limit algorithm depends on the chosen algorithm, as well as the state of the algorithm and the caching.
+The Rate Limit SDK minimizes Redis calls to reduce latency overhead and cost. Number of commands executed by the Rate Limit algorithm depends on the chosen algorithm, as well as the state of the algorithm and the caching.
 
 #### Algorithm State
 
@@ -89,4 +89,4 @@ Works the same as `limit()`.
 
 # Analytics
 
-If analytics is enabled, all calls of `limit` will result in 1 more command since `HINCRBY` will be called to update the analytics.
+If analytics is enabled, all calls of `limit` will result in 1 more command since `ZINCRBY` will be called to update the analytics.

--- a/oss/sdks/ts/ratelimit/features.mdx
+++ b/oss/sdks/ts/ratelimit/features.mdx
@@ -155,8 +155,13 @@ This way, the algorithm will subtract `batchSize` instead of 1.
 ## Multi Region
 
 Let's assume you have customers in the US and Europe. In this case you can
-create 2 regional redis databases on [Upstash](https://console.upstash.com) and
-your users will enjoy the latency of whichever db is closest to them.
+create 2 seperate global redis databases on [Upstash](https://console.upstash.com)
+(one with its primary in US and the other in Europe) and your users will enjoy
+the latency of whichever db is closest to them.
+
+Using a single Redis instance with replicas in different regions can not offer
+the same performance as `MultiRegionRatelimit` because all write commands have
+to go through the primary, increasing latency in other regions.
 
 Using a single redis instance has the downside of providing low latencies only
 to the part of your userbase closest to the deployed db. That's why we also
@@ -214,4 +219,7 @@ const { pending } = await ratelimit.limit("id")
 context.waitUntil(pending)
 ```
 
-See `waitUntil` documentation in [Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#contextwaituntil) and [Vercel](https://vercel.com/docs/functions/edge-middleware/middleware-api#waituntil) for more details.
+See more information on `context.waitUntil` at
+[Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/context/#waituntil)
+and [Vercel](https://vercel.com/docs/functions/edge-middleware/middleware-api#waituntil).
+You can also utilize [`waitUntil` from Vercel Functions API](https://vercel.com/docs/functions/functions-api-reference#waituntil).

--- a/oss/sdks/ts/ratelimit/gettingstarted.mdx
+++ b/oss/sdks/ts/ratelimit/gettingstarted.mdx
@@ -129,7 +129,10 @@ const { pending } = await ratelimit.limit("id");
 context.waitUntil(pending);
 ```
 
-See `waitUntil` documentation in [Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#contextwaituntil) and [Vercel](https://vercel.com/docs/functions/edge-middleware/middleware-api#waituntil) for more details.
+See more information on `context.waitUntil` at
+[Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/context/#waituntil)
+and [Vercel](https://vercel.com/docs/functions/edge-middleware/middleware-api#waituntil).
+You can also utilize [`waitUntil` from Vercel Functions API](https://vercel.com/docs/functions/functions-api-reference#waituntil).
 
 ## Customizing the Ratelimit Algorithm
 


### PR DESCRIPTION
- replaced references to regional redis with global redis
- added reference to the new waitUntil in vercel funcions API
- fix analytics command as ZINCRBY