### PR TITLE
Update bulk cancel docs

### DIFF
--- a/qstash/api/messages/bulk-cancel.mdx
+++ b/qstash/api/messages/bulk-cancel.mdx
@@ -18,7 +18,7 @@ If you provide a set of message IDs in the body of the request, only those messa
 If no body is sent, QStash will cancel all of your messages.
 
 This operation scans all your messages and attempts to cancel them. 
-If an individual message cannot be cancelled, it will be ignored, and the operation will continue to search for other messages. 
+If an individual message cannot be cancelled, it will not continue and will return an error message. 
 Therefore, some messages may not be cancelled at the end. 
 In such cases, you can run the bulk cancel operation multiple times.
 


### PR DESCRIPTION
Previously, the operation would continue even if there were errors for individual messages. In the updated version, the request will return an error message if a single message cannot be canceled.