### PR TITLE
Add DLQ filtering fields docs

### DIFF
--- a/qstash/api/dlq/listMessages.mdx
+++ b/qstash/api/dlq/listMessages.mdx
@@ -13,6 +13,50 @@ List all messages currently inside the DLQ
   By providing a cursor you can paginate through all of the messages in the DLQ
 </ParamField>
 
+<ParamField query="messageId" type="string">
+  Filter DLQ messages by message id.
+</ParamField>
+
+<ParamField query="url" type="string">
+  Filter DLQ messages by url.
+</ParamField>
+
+<ParamField query="topicName" type="string">
+  Filter DLQ messages by url group.
+</ParamField>
+
+<ParamField query="scheduleId" type="string">
+  Filter DLQ messages by schedule id.
+</ParamField>
+
+<ParamField query="queueName" type="string">
+  Filter DLQ messages by queue name.
+</ParamField>
+
+<ParamField query="api" type="number">
+  Filter DLQ messages by API name.
+</ParamField>
+
+<ParamField query="fromDate" type="number">
+  Filter DLQ messages by starting date, in milliseconds (Unix timestamp). This is inclusive.
+</ParamField>
+
+<ParamField query="toDate" type="number">
+  Filter DLQ messages by ending date, in milliseconds (Unix timestamp). This is inclusive.
+</ParamField>
+
+<ParamField query="responseStatus" type="number">
+  Filter DLQ messages by HTTP response status code.
+</ParamField>
+
+<ParamField query="callerIp" type="number">
+  Filter DLQ messages by IP address of the publisher.
+</ParamField>
+
+<ParamField query="count" type="number">
+  The number of messages to return. Default and maximum is 100.
+</ParamField>
+
 ## Response
 
 <ResponseField name="cursor" type="string">

--- a/qstash/api/dlq/listMessages.mdx
+++ b/qstash/api/dlq/listMessages.mdx
@@ -57,6 +57,10 @@ List all messages currently inside the DLQ
   The number of messages to return. Default and maximum is 100.
 </ParamField>
 
+<ParamField query="order" type="string">
+  The sorting order of DLQ messages by timestamp. Valid values are "earliestFirst" and "latestFirst". The default is "earliestFirst".
+</ParamField>
+
 ## Response
 
 <ResponseField name="cursor" type="string">

--- a/qstash/api/dlq/listMessages.mdx
+++ b/qstash/api/dlq/listMessages.mdx
@@ -33,7 +33,7 @@ List all messages currently inside the DLQ
   Filter DLQ messages by queue name.
 </ParamField>
 
-<ParamField query="api" type="number">
+<ParamField query="api" type="string">
   Filter DLQ messages by API name.
 </ParamField>
 
@@ -49,7 +49,7 @@ List all messages currently inside the DLQ
   Filter DLQ messages by HTTP response status code.
 </ParamField>
 
-<ParamField query="callerIp" type="number">
+<ParamField query="callerIp" type="string">
   Filter DLQ messages by IP address of the publisher.
 </ParamField>
 

--- a/qstash/api/events/list.mdx
+++ b/qstash/api/events/list.mdx
@@ -47,6 +47,10 @@ authMethod: "bearer"
   The number of events to return. Default and max is 1000.
 </ParamField>
 
+<ParamField query="order" type="string">
+  The sorting order of events by timestamp. Valid values are "earliestFirst" and "latestFirst". The default is "latestFirst".
+</ParamField>
+
 ## Response
 
 <ResponseField>


### PR DESCRIPTION
This PR adds docs on filtering DLQ messages by the following fields:

- MessageId
- Url
- TopicName
- ScheduleId
- QueueName
- Api
- FromDate
- ToDate
- ResponseStatus
- CallerIP
- Count