### PR TITLE
Add troubleshooting guide for unexpected command count increases

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -740,6 +740,7 @@
         {
           "group": "Troubleshooting",
           "pages": [
+            "redis/troubleshooting/command_count_increases_unexpectedly",
             "redis/troubleshooting/no_auth",
             "redis/troubleshooting/http_unauthorized",
             "redis/troubleshooting/econn_reset",

--- a/redis/troubleshooting/command_count_increases_unexpectedly.mdx
+++ b/redis/troubleshooting/command_count_increases_unexpectedly.mdx
@@ -1,0 +1,34 @@
+---
+title: Unexpected Increase in Command Count
+---
+
+### Symptom
+
+You notice an increasing command count for your Redis database in the Upstash Console, even when there are no connected clients.
+
+### Diagnosis
+
+The Upstash Console interacts with your Redis database to provide its functionality, which can result in an increased command count. This behavior is normal and expected. Here's a breakdown of why this occurs:
+
+1. **Data Explorer functionality:** 
+   The Data Explorer tab sends various commands to list and display your keys, including:
+   - SCAN: To iterate through the keyspace
+   - GET: To retrieve values for keys
+   - TTL: To check the time-to-live for keys
+
+2. **Rate Limiting check:** 
+   The Console checks if your database is being used for Rate Limiting. This involves sending EXISTS commands for rate limiting-related keys.
+
+3. **Other Console features:** 
+   Additional features in the Console may send commands to your database to retrieve or display information.
+
+### Verification
+
+You can use the Monitor tab in the Upstash Console to observe which commands are being sent by the Console itself. This can help you distinguish between Console-generated commands and those from your application or other clients.
+
+### Conclusion
+
+The increasing command count you're seeing is likely due to the Console's normal operations and should not be a cause for concern. These commands do not significantly impact your database's performance or your usage limits.
+
+If you have any further questions or concerns about command usage, please don't hesitate to contact Upstash support.
+


### PR DESCRIPTION
This PR adds a troubleshooting section explaining why users might see unexpected increases in command counts in the Upstash Console. It clarifies that this is normal behavior due to Console operations and provides steps for verification