### PR TITLE
Make behavior of bulk cancel more clear

### DIFF
--- a/qstash/api/messages/bulk-cancel.mdx
+++ b/qstash/api/messages/bulk-cancel.mdx
@@ -13,9 +13,10 @@ in the future. If a message is in flight to your API, it might be too late to
 cancel.
 </Note>
 
-
+<Warning>
 If you provide a set of message IDs in the body of the request, only those messages will be cancelled. 
 If no body is sent, QStash will cancel all of your messages.
+</Warning>
 
 This operation scans all your messages and attempts to cancel them. 
 If an individual message cannot be cancelled, it will not continue and will return an error message. 


### PR DESCRIPTION
Since the bulk cancel of all messages can have critical impact on some users, it would be better to make this part more visible.