### PR TITLE
Workflow: add examples for nextjs pages router

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,14 +6,14 @@ title: Get Started
   <Card title="Serverless Redis" href="/redis/overall/getstarted">
     Create a Redis Database within seconds
   </Card>
-  <Card title="Serverless Kafka" href="/kafka/overall/getstarted">
-    Spin up a Kafka Cluster instantly
-  </Card>
   <Card title="Serverless Vector" href="/vector/overall/getstarted">
     Create a Vector Database for AI & LLMs
   </Card>
   <Card title="QStash" href="/qstash/overall/getstarted">
     Publish your first message
+  </Card>
+  <Card title="Upstash Workflow" href="/qstash/workflow/getstarted">
+    Write durable serverless functions
   </Card>
 </CardGroup>
 

--- a/mint.json
+++ b/mint.json
@@ -43,16 +43,16 @@
       "url": "redis"
     },
     {
-      "name": "Kafka",
-      "url": "kafka"
-    },
-    {
       "name": "Vector",
       "url": "vector"
     },
     {
       "name": "QStash",
       "url": "qstash"
+    },
+    {
+      "name": "Kafka",
+      "url": "kafka"
     },
     {
       "name": "Developer API",

--- a/qstash/workflow/quickstarts/vercel-nextjs.mdx
+++ b/qstash/workflow/quickstarts/vercel-nextjs.mdx
@@ -91,6 +91,44 @@ export const POST = async (request: NextRequest) => {
 };
 ```
 </Tab>
+<Tab title="Minimal example (Pages Router)">
+```typescript src/pages/api/workflow.ts
+import { servePagesRouter } from "@upstash/qstash/nextjs";
+
+export default servePagesRouter<string>(
+  async (context) => {
+    await context.run("initial-step", () => {
+      console.log("initial step ran")
+    })
+
+    await context.run("second-step", () => {
+      console.log("second step ran")
+    })
+  }
+)
+```
+</Tab>
+
+<Tab title="With request object (Pages Router)">
+```typescript src/pages/api/workflow.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+import { servePagesRouter } from "@upstash/qstash/nextjs";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  // do something with the native request object
+  const handler = servePagesRouter(
+    async (context) => {
+      // Your workflow steps
+    }
+  )
+
+  await handler(req, res)
+}
+```
+</Tab>
 </Tabs>
 
 ## Step 4: Run the Workflow Endpoint
@@ -111,6 +149,8 @@ UPSTASH_WORKFLOW_URL=https://<YOUR_NGROK_OR_TUNNEL_URL>/
 
 As an alternative to setting an environment variable, you can also use the `baseUrl` option in the `serve` method. This option is only needed for local development and can be omitted in production:
 
+<Tabs>
+<Tab title="App Router">
 ```typescript app/api/workflow/route.ts
 import { serve } from "@upstash/qstash/h3"
 
@@ -122,6 +162,21 @@ export const POST = serve(
   }
 )
 ```
+</Tab>
+<Tab title="Pages Router">
+```typescript src/pages/api/workflow.ts
+import { servePagesRouter } from "@upstash/qstash/nextjs";
+
+export default servePagesRouter<string>(
+  async (context) => { ... },
+  {
+    // no /api/workflow, just the base URL
+    baseUrl: "https://<YOUR_NGROK_OR_TUNNEL_URL>/",
+  }
+)
+```
+</Tab>
+</Tabs>
 
 ### Triggering the workflow
 
@@ -157,14 +212,17 @@ When deploying your Next.js application with Upstash Workflow to production, the
 
 2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, the `baseUrl` option in the `serve` function can be omitted in production:
 
+   <Tabs>
+   <Tab title="App Router">
    ```typescript app/api/workflow/route.ts
+   import { serve } from "@upstash/qstash/nextjs";
+
    export const POST = serve(
      async (context) => {
        // Your workflow steps
      },
      {
        // Conditionally set in development, but not in production
-       // as the baseUrl is automatically set in production
        baseUrl:
          process.env.NODE_ENV === "development"
            ? "https://<YOUR_NGROK_OR_TUNNEL_URL>/"
@@ -172,6 +230,26 @@ When deploying your Next.js application with Upstash Workflow to production, the
      }
    )
    ```
+   </Tab>
+   <Tab title="Pages Router">
+   ```typescript src/pages/api/workflow.ts
+   import { servePagesRouter } from "@upstash/qstash/nextjs";
+ 
+   export default servePagesRouter<string>(
+     async (context) => {
+       // Your workflow steps
+     },
+     {
+       // Conditionally set in development, but not in production
+       baseUrl:
+         process.env.NODE_ENV === "development"
+           ? "https://<YOUR_NGROK_OR_TUNNEL_URL>/"
+           : undefined,
+     }
+   )
+   ```
+   </Tab>
+   </Tabs>
 
 3. **Deployment**: Deploy your Next.js application to Vercel, AWS Amplify or other platforms as you normally would. These platforms will automatically detect and build your Next.js application.
 


### PR DESCRIPTION
adding nextjs pages router examples to the workflow nextjs quickstart

additionally, moved kafka tab to the right and replaced kafka card with Upstash Workflow:

from:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/b91b6bbe-90e1-4992-b5c7-a5e62ec42cfe">

to:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/5aa0594c-fe58-432a-b623-30880e756304">