### PR TITLE
Workflow: context.call can parse the json results

### DIFF
--- a/qstash/workflow/basics/context.mdx
+++ b/qstash/workflow/basics/context.mdx
@@ -178,6 +178,19 @@ export const POST = serve<{ topic: string }>(async (context) => {
 })
 ```
 
+context.call attempts to parse the response body as JSON. If this is not possible, the body is returned as it is.
+
+In TypeScript, you can declare the expected result type as follows:
+
+```typescript
+type ResultType = {
+  field1: string,
+  field2: number
+};
+
+const result = await context.call<ResultType>( ... ); 
+```
+
 ## Error handling and retries
 
 - context.run and context.call automatically retry on failures.

--- a/qstash/workflow/examples/allInOne.mdx
+++ b/qstash/workflow/examples/allInOne.mdx
@@ -29,6 +29,15 @@ import {
   splitIntoChunks,
 } from "./utils"
 
+type OpenAiResponse = {
+  choices: {
+    message: {
+      role: string,
+      content: string
+    }
+  }[]
+}
+
 export const POST = serve<{ datasetId: string; userId: string }>(
   async (context) => {
     const request = context.requestPayload
@@ -47,7 +56,7 @@ export const POST = serve<{ datasetId: string; userId: string }>(
     const processedChunks: string[] = []
 
     for (let i = 0; i < chunks.length; i++) {
-      const processedChunk = await context.call(
+      const processedChunk = await context.call<OpenAiResponse>(
         `process-chunk-${i}`,
         "https://api.openai.com/v1/chat/completions",
         "POST",


### PR DESCRIPTION
The allInOne example wasn't correct: context.call didn't return an object, it returned a string (fixed in https://github.com/upstash/qstash-js/pull/177). Also, we should pass the return type to context.call so that processedChunk has the correct type