### PR TITLE
Add missing headers create schedule & add upstash-callback-forward

### DIFF
--- a/_snippets/qstash-common-request.mdx
+++ b/_snippets/qstash-common-request.mdx
@@ -57,16 +57,10 @@ See the content of what will be delivered to a callback [here](/qstash/features/
 For the `api/llm` destination, specifying a callback is required.
 </ParamField>
 
-<ParamField header="Upstash-Callback-Timeout" type="string" >
-Defines the timeout applied when calling the `Upstash-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
-</ParamField>
+<ParamField header="Upstash-Callback-*" type="string" >
+Using the `Upstash-Callback-` prefix; you can set the timeout duration, number of retries, delay to apply or more for the callback request.
 
-<ParamField header="Upstash-Callback-Retries" type="string" >
-Defines the number of retries when calling the `Upstash-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
-</ParamField>
-
-<ParamField header="Upstash-Callback-Delay" type="string" >
-Defines the delay to apply when calling the `Upstash-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
+See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
 </ParamField>
 
 <ParamField header="Upstash-Callback-Forward-*" type="string" >
@@ -78,8 +72,6 @@ To include a header in the callback request, prefix the header name with
 `Upstash-Callback-Forward-`. We will strip this prefix and forward the header to the callback destination..
 
 example: "Upstash-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
-
-To learn more about how callbacks can be configured, see the [Configuring Callbacks section](/qstash/features/callbacks#configuring-callbacks).
 </ParamField>
 
 <ParamField header="Upstash-Failure-Callback" type="string" >
@@ -92,16 +84,10 @@ See the content of what will be delivered to a failure callback [here](/qstash/f
 - Callbacks will use the retry setting from the original request.
 </ParamField>
 
-<ParamField header="Upstash-Failure-Callback-Timeout" type="string" >
-Defines the timeout applied when calling the `Upstash-Failure-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
-</ParamField>
+<ParamField header="Upstash-Failure-Callback-*" type="string" >
+Using the `Upstash-Failure-Callback-` prefix; you can set the timeout duration, number of retries, delay to apply or more for the failure callback request.
 
-<ParamField header="Upstash-Failure-Callback-Retries" type="string" >
-Defines the number of retries when calling the `Upstash-Failure-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
-</ParamField>
-
-<ParamField header="Upstash-Failure-Callback-Delay" type="string" >
-Defines the delay to apply when calling the `Upstash-Failure-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
+See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
 </ParamField>
 
 <ParamField header="Upstash-Failure-Callback-Forward-*" type="string" >
@@ -113,6 +99,4 @@ To include a header in the callback request, add `Upstash-Failure-Callback-Forwa
 We will strip this prefix and forward the header to the callback destination.
 
 example: "Upstash-Failure-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
-
-To learn more about how callbacks can be configured, see the [Configuring Callbacks section](/qstash/features/callbacks#configuring-callbacks).
 </ParamField>

--- a/_snippets/qstash-common-request.mdx
+++ b/_snippets/qstash-common-request.mdx
@@ -68,23 +68,23 @@ example: "Upstash-Forward-My-Header: my-value" -> "My-Header: my-value"
 </ParamField>
 
 <ParamField header="Upstash-Callback-Forward-*" type="string" >
- If you using the `Upstash-Callback` header to define a callback url,
- you can specify the haeders sent along with the callback request using
+ If you are using the `Upstash-Callback` header to define a callback url,
+ you can specify the headers sent along with the callback request using
  the `Upstash-Callback-Forward-*` header.
 
 To include a header in the callback request, prefix the header name with
-`Upstash-Callback-Forward-`. We will strip efix and them to the destination API.
+`Upstash-Callback-Forward-`. We will strip this prefix and forward the header to the callback destination..
 
 example: "Upstash-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
 </ParamField>
 
 <ParamField header="Upstash-Failure-Callback-Forward-*" type="string" >
- If you using the `Upstash-Failure-Callback` header to define a callback url
- when the delivery fails, you can specify the haeders sent along with the failure
+ If are you using the `Upstash-Failure-Callback` header to define a callback url
+ when the delivery fails, you can specify the headers sent along with the failure
  callback request using the `Upstash-Failure-Callback-Forward-*` header.
 
-To include a header in the callback request, prefix the header name with
-`Upstash-Failure-Callback-Forward-`. We will strip efix and them to the destination API.
+To include a header in the callback request, add `Upstash-Failure-Callback-Forward-` prefix to the header name.
+We will strip this prefix and forward the header to the callback destination.
 
 example: "Upstash-Failure-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
 </ParamField>

--- a/_snippets/qstash-common-request.mdx
+++ b/_snippets/qstash-common-request.mdx
@@ -38,26 +38,6 @@ times the task has been retried.
 `min(86400, e ** (2 * n))`
 </ParamField>
 
-<ParamField header="Upstash-Callback" type="string" >
-You can define a callback url that will be called after each attempt. 
-See the content of what will be delivered to a callback [here](https://docs.upstash.com/qstash/features/callbacks#how-do-i-use-callbacks) 
-- The callback url must be prefixed with a valid protocol (`http://` or `https://`)
-- Callbacks are charged as a regular message.
-- Callbacks will use the retry setting from the original request.
-
-For the `api/llm` destination, specifying a callback is required.
-</ParamField>
-
-<ParamField header="Upstash-Failure-Callback" type="string" >
-You can define a failure callback url that will be called when a delivery is failed. 
-That is when all the defined retries are exhausted.
-See the content of what will be delivered to a failure callback [here](https://docs.upstash.com/qstash/features/callbacks#what-is-a-failure-callback) 
-
-- The failure callback url must be prefixed with a valid protocol (`http://` or `https://`)
-- Callbacks are charged as a regular message.
-- Callbacks will use the retry setting from the original request.
-</ParamField>
-
 <ParamField header="Upstash-Forward-*" type="string" >
  You can send custom headers along with your message.
 
@@ -65,6 +45,28 @@ To send a custom header, prefix the header name with `Upstash-Forward-`. We will
 strip efix and them to the destination API.
 
 example: "Upstash-Forward-My-Header: my-value" -> "My-Header: my-value"
+</ParamField>
+
+<ParamField header="Upstash-Callback" type="string" >
+You can define a callback url that will be called after each attempt. 
+See the content of what will be delivered to a callback [here](/qstash/features/callbacks#how-do-i-use-callbacks) 
+- The callback url must be prefixed with a valid protocol (`http://` or `https://`)
+- Callbacks are charged as a regular message.
+- Callbacks will use the retry setting from the original request.
+
+For the `api/llm` destination, specifying a callback is required.
+</ParamField>
+
+<ParamField header="Upstash-Callback-Timeout" type="string" >
+Defines the timeout applied when calling the `Upstash-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
+</ParamField>
+
+<ParamField header="Upstash-Callback-Retries" type="string" >
+Defines the number of retries when calling the `Upstash-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
+</ParamField>
+
+<ParamField header="Upstash-Callback-Delay" type="string" >
+Defines the delay to apply when calling the `Upstash-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
 </ParamField>
 
 <ParamField header="Upstash-Callback-Forward-*" type="string" >
@@ -78,6 +80,28 @@ To include a header in the callback request, prefix the header name with
 example: "Upstash-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
 
 To learn more about how callbacks can be configured, see the [Configuring Callbacks section](/qstash/features/callbacks#configuring-callbacks).
+</ParamField>
+
+<ParamField header="Upstash-Failure-Callback" type="string" >
+You can define a failure callback url that will be called when a delivery is failed. 
+That is when all the defined retries are exhausted.
+See the content of what will be delivered to a failure callback [here](/qstash/features/callbacks#what-is-a-failure-callback) 
+
+- The failure callback url must be prefixed with a valid protocol (`http://` or `https://`)
+- Callbacks are charged as a regular message.
+- Callbacks will use the retry setting from the original request.
+</ParamField>
+
+<ParamField header="Upstash-Failure-Callback-Timeout" type="string" >
+Defines the timeout applied when calling the `Upstash-Failure-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
+</ParamField>
+
+<ParamField header="Upstash-Failure-Callback-Retries" type="string" >
+Defines the number of retries when calling the `Upstash-Failure-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
+</ParamField>
+
+<ParamField header="Upstash-Failure-Callback-Delay" type="string" >
+Defines the delay to apply when calling the `Upstash-Failure-Callback`. See [the Configuring Callbacks](/qstash/features/callbacks#configuring-callbacks) section to learn more.
 </ParamField>
 
 <ParamField header="Upstash-Failure-Callback-Forward-*" type="string" >

--- a/_snippets/qstash-common-request.mdx
+++ b/_snippets/qstash-common-request.mdx
@@ -66,3 +66,14 @@ strip efix and them to the destination API.
 
 example: "Upstash-Forward-My-Header: my-value" -> "My-Header: my-value"
 </ParamField>
+
+<ParamField header="Upstash-Callback-Forward-*" type="string" >
+ If you using the `Upstash-Callback` header to define a callback url,
+ you can specify the haeders sent along with the callback request using
+ the `Upstash-Callback-Forward-*` header.
+
+To include a header in the callback request, prefix the header name with
+`Upstash-Callback-Forward-`. We will strip efix and them to the destination API.
+
+example: "Upstash-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
+</ParamField>

--- a/_snippets/qstash-common-request.mdx
+++ b/_snippets/qstash-common-request.mdx
@@ -77,3 +77,14 @@ To include a header in the callback request, prefix the header name with
 
 example: "Upstash-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
 </ParamField>
+
+<ParamField header="Upstash-Failure-Callback-Forward-*" type="string" >
+ If you using the `Upstash-Failure-Callback` header to define a callback url
+ when the delivery fails, you can specify the haeders sent along with the failure
+ callback request using the `Upstash-Failure-Callback-Forward-*` header.
+
+To include a header in the callback request, prefix the header name with
+`Upstash-Failure-Callback-Forward-`. We will strip efix and them to the destination API.
+
+example: "Upstash-Failure-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
+</ParamField>

--- a/_snippets/qstash-common-request.mdx
+++ b/_snippets/qstash-common-request.mdx
@@ -76,6 +76,8 @@ To include a header in the callback request, prefix the header name with
 `Upstash-Callback-Forward-`. We will strip this prefix and forward the header to the callback destination..
 
 example: "Upstash-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
+
+To learn more about how callbacks can be configured, see the [Configuring Callbacks section](/qstash/features/callbacks#configuring-callbacks).
 </ParamField>
 
 <ParamField header="Upstash-Failure-Callback-Forward-*" type="string" >
@@ -87,4 +89,6 @@ To include a header in the callback request, add `Upstash-Failure-Callback-Forwa
 We will strip this prefix and forward the header to the callback destination.
 
 example: "Upstash-Failure-Callback-Forward-My-Header: my-value" -> "My-Header: my-value"
+
+To learn more about how callbacks can be configured, see the [Configuring Callbacks section](/qstash/features/callbacks#configuring-callbacks).
 </ParamField>

--- a/qstash/api/schedules/create.mdx
+++ b/qstash/api/schedules/create.mdx
@@ -65,14 +65,16 @@ will be updated with the new settings.
 
 ```sh curl
 curl -XPOST https://qstash.upstash.io/v2/schedules/https://www.example.com/endpoint \
-  -H "Authorization: Bearer <token>"
+  -H "Authorization: Bearer <token>" \
+  -H "Upstash-Cron: */5 * * * *"
 ```
 
 ```js Node
 const response = await fetch('https://qstash.upstash.io/v2/schedules/https://www.example.com/endpoint', {
   method: 'POST',
   headers: {
-    'Authorization': 'Bearer <token>'
+    'Authorization': 'Bearer <token>',
+    'Upstash-Cron': '*/5 * * * *'
   }
 });
 ```
@@ -82,6 +84,7 @@ import requests
 
 headers = {
     'Authorization': 'Bearer <token>',
+    'Upstash-Cron': '*/5 * * * *'
 }
 
 response = requests.post(
@@ -96,6 +99,7 @@ if err != nil {
   log.Fatal(err)
 }
 req.Header.Set("Authorization", "Bearer <token>")
+req.Header.Set("Upstash-Cron", "*/5 * * * *")
 resp, err := http.DefaultClient.Do(req)
 if err != nil {
   log.Fatal(err)

--- a/qstash/api/schedules/create.mdx
+++ b/qstash/api/schedules/create.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Create Schedule"
 description: "Create a schedule to send messages periodically"
-api: "POST https://qstash.upstash.io/v2/schedules"
+api: "POST https://qstash.upstash.io/v2/schedules/{destination}"
 authMethod: "bearer"
 ---
 

--- a/qstash/api/schedules/create.mdx
+++ b/qstash/api/schedules/create.mdx
@@ -45,6 +45,16 @@ Format for this header is a number followed by duration abbreviation, like
 example: "50s" | "3m" | "10h" | "1d"
 </ParamField>
 
+<ParamField header="Upstash-Schedule-Id" type="string" >
+Assign a schedule id to the created schedule.
+
+This header allows you to set the schedule id yourself instead of QStash assigning
+a random id.
+
+If a schedule with the provided id exists, the settings of the existing schedule
+will be updated with the new settings.
+</ParamField>
+
 ## Response
 
 <ResponseField name="scheduleId" type="string" required>

--- a/qstash/api/schedules/create.mdx
+++ b/qstash/api/schedules/create.mdx
@@ -54,12 +54,12 @@ example: "50s" | "3m" | "10h" | "1d"
 <RequestExample>
 
 ```sh curl
-curl -XPOST https://qstash.upstash.io/v2/schedules \
+curl -XPOST https://qstash.upstash.io/v2/schedules/https://www.example.com/endpoint \
   -H "Authorization: Bearer <token>"
 ```
 
 ```js Node
-const response = await fetch('https://qstash.upstash.io/v2/schedules', {
+const response = await fetch('https://qstash.upstash.io/v2/schedules/https://www.example.com/endpoint', {
   method: 'POST',
   headers: {
     'Authorization': 'Bearer <token>'
@@ -75,13 +75,13 @@ headers = {
 }
 
 response = requests.post(
-  'https://qstash.upstash.io/v2/schedules',
+  'https://qstash.upstash.io/v2/schedules/https://www.example.com/endpoint',
    headers=headers
 )
 ```
 
 ```go Go 
-req, err := http.NewRequest("POST", "https://qstash.upstash.io/v2/schedules", nil)
+req, err := http.NewRequest("POST", "https://qstash.upstash.io/v2/schedules/https://www.example.com/endpoint", nil)
 if err != nil {
   log.Fatal(err)
 }

--- a/qstash/features/callbacks.mdx
+++ b/qstash/features/callbacks.mdx
@@ -205,9 +205,11 @@ Instead of the `Upstash` prefix for headers, the `Upstash-Callback`/`Upstash-Fai
 Upstash-Callback-Timeout 
 Upstash-Callback-Retries
 Upstash-Callback-Delay 
+Upstash-Callback-Method 
 Upstash-Failure-Callback-Timeout 
 Upstash-Failure-Callback-Retries
 Upstash-Failure-Callback-Delay
+Upstash-Failure-Callback-Method
 ```
 
 You can also forward headers to your callback endpoints as follows:

--- a/qstash/features/callbacks.mdx
+++ b/qstash/features/callbacks.mdx
@@ -170,7 +170,7 @@ The callback body sent to you will be a JSON object with the following fields:
 
 ```json
 {
-  "status": 200,
+  "status": 400,
   "header": { "key": ["value"] },         // Response header
   "body": "YmFzZTY0IGVuY29kZWQgcm9keQ==", // base64 encoded response body
   "retried": 3,                           // How many times we retried to deliver the original message


### PR DESCRIPTION
This pr does several things:
- ef2268166fb3d2099b6a783a1def7b8db102a499: request examples in create schedule didn't have destinations. Added example destination.
- 57f9564b4b48b984dc998cb03104301831511fab: documented upstash-callback-forward header
- 4ba54e8bf9d2dbfa5bf7854c8c24c28752fb3f57: destination field was missing in the path of create schedule. This interactive playground didn't work. It still doesn't work. More info below.
- 3cd2e35b9cb1c997e7654c6ba703bb2ee54b5c58: added upstash-schedule-id docs

### Issue in Create Schedule Playground

task for tracking https://linear.app/upstash/issue/DX-1270/docs-create-schedule-doesnt-work

Previously, the destination was missing in the path altogether:

![image](https://github.com/user-attachments/assets/7d34a192-575d-43df-8497-b26012d1b209)

this results in an error as seen above. The request doesn't even have the provided destination.

After the update, the destination exists in the request but it is escaped, which still doesn't work on QStash:

![image](https://github.com/user-attachments/assets/2d68bfcf-b093-4b38-ac3d-d7b768f9e90a)
![image](https://github.com/user-attachments/assets/ea7bdf46-bb54-4df4-9785-b371c565e69f)

It doesn't look like the ParamField has fields which can help us in this case.
https://mintlify.com/docs/api-playground/overview
https://mintlify.com/docs/content/components/params