### PR TITLE
Fix: Some typos on Vector Document

### DIFF
--- a/vector/features/algorithm.mdx
+++ b/vector/features/algorithm.mdx
@@ -20,7 +20,7 @@ And this helps Upstash Vector to be **cost-effective**, therefore cheaper compar
 Even though `DiskANN` has its advantages, it also requires more work to be practical.
 Main problem is that, you can't insert/update existing index without reindexing all the vectors.
 For this problem, there is another improved paper `FreshDiskANN`[4]. `FreshDiskANN` improves `DiskANN` via introducing
-a temporary index for up-to-date data in memory. Queries are served from both the temporary(up-to-date) index
+a temporary index for up-to-date data in memory. Queries are served from both the temporary (up-to-date) index
 and also from the disk. And these temporary indexes are merged to the disk from time-to-time behind the scene.
 
 Upstash Vector is based on `DiskANN` and `FreshDiskANN` with more improvements based on our

--- a/vector/overall/getstarted.mdx
+++ b/vector/overall/getstarted.mdx
@@ -28,11 +28,11 @@ Once you logged in, you can create a Vector Index by clicking on the `Create Ind
   <img src="/img/vector/getstarted/select_plan.png"  />
 </Frame>
 
-**Free:** The free plan is suitable for small projects. It has a limit of 10,000 queries and 10,000 updates limit daily.
+**Free:** The free plan is suitable for small projects. It has a limit of 10,000 queries and 10,000 updates daily.
 
 **Pay as You Go:** Pay as you go plan is a flexible plan with per-request-pricing. It is suitable for projects with unpredictable traffic. 
 
-**Fixed:** Fixed plan is suitable for projects with predictable traffic. It has a fixed monthly price with 1M query and 1M update limit daily. 
+**Fixed:** Fixed plan is suitable for projects with predictable traffic. It has a fixed monthly price with 1M query and 1M updates daily. 
 
 **Pro:** Pro plan is suitable for projects with high traffic and storage needs. It has a fixed monthly price with extra security and isolation features.
 

--- a/vector/overall/whatisvector.mdx
+++ b/vector/overall/whatisvector.mdx
@@ -5,7 +5,7 @@ title: What is Upstash Vector?
 Upstash Vector is a serverless vector database designed for working with vector embeddings. 
 
 In the domain of databases, a vector database is essential for managing numeric representations of 
-objects(images, sounds, text, etc.) in a multi-dimensional space. 
+objects (images, sounds, text, etc.) in a multi-dimensional space. 
 These databases are focused on efficiently handling vectors for storage, retrieval, and, most importantly, querying based on similarity.
 They are instrumental in integrating personalized data into AI applications
 enabling the AI system to provide tailored answers derived from your own dataset rather than generic responses, 

--- a/vector/sdks/ts/getting-started.mdx
+++ b/vector/sdks/ts/getting-started.mdx
@@ -6,12 +6,12 @@ title: Getting Started
 
 Using `@upstash/vector` you can:
 
-- Upsert a vector with metadata to an index
-- Fetching the vectors with specified IDs
-- Querying a vector over pre-defined embeddings
-- Remove vectors from an index
-- Access index stats
-- Reset everything related to an index
+- Upsert a vector with metadata to an index.
+- Fetching the vectors with specified IDs.
+- Querying a vector over pre-defined embeddings.
+- Remove vectors from an index.
+- Access index stats.
+- Reset everything related to an index.
 
 You can find the Github Repository [here](https://github.com/upstash/vector-js). 
 
@@ -32,7 +32,7 @@ pnpm add @upstash/vector
 
 ### Initializing the client
 
-There are two pieces of configuration required to use the Upstash vector client: an REST token and REST URL. These values can be passed using environment variables or in code through a configuration object. Find your configuration values in the console dashboard at [https://console.upstash.com/](https://console.upstash.com/).
+There are two pieces of configuration required to use the Upstash vector client: a REST token and REST URL. These values can be passed using environment variables or in code through a configuration object. Find your configuration values in the console dashboard at [https://console.upstash.com/](https://console.upstash.com/).
 
 #### Using environment variables
 


### PR DESCRIPTION
This includes fixing some typos for the PR vector document.
 
- [x] Put a space before the parenthesis (algorithm.mdx and whatisvector.mdx)
- [x] Some unncessary repetitions and plural expression errors have been corrected (getstarted.mdx)
- [x] Some punctuation and spelling errors have been corrected (getting-started.mdx)