### PR TITLE
Fixed Announcement docs not showing in the contents list on the left

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -96,6 +96,7 @@
         "common/help/prosupport",
         "common/help/sla",
         "common/help/uptime",
+        "common/help/announcements",
         "common/help/legal",
         "common/help/compliance",
         "common/help/integration"


### PR DESCRIPTION
I fixed the issue with announcement docs not showing in the contents list on the left. #147