### PR TITLE
removed the section about direct port optimization for REST API

### DIFF
--- a/redis/features/restapi.mdx
+++ b/redis/features/restapi.mdx
@@ -510,47 +510,6 @@ redis-cli> ACL RESTTOKEN upstash fakepass
 (error) ERR Wrong password or user "upstash" does not exist
 ```
 
-## Optimizing Performance (for advanced users)
-
-In our internal tests, we have observed that the latency overhead of using the
-Upstash REST API compared to the native Redis API is less than 1 millisecond.
-However, if low latency is a critical requirement for your use case, you can
-further improve the latency by connecting directly to the database port.
-
-Connecting directly to the database port allows for a more direct and optimized
-communication path, which can potentially reduce latency even further. By
-bypassing the additional network layers involved in REST API communication, you
-can achieve lower response times.
-
-It's important to note that there is a trade-off when connecting directly to the
-database port, as some environments, like CloudFlare Workers, may restrict
-client access to ports other than the standard ones (e.g., 80 and 443). In such
-cases, using the Upstash REST API becomes the preferred method for accessing the
-database.
-
-Consider your specific requirements, network restrictions, and performance needs
-when deciding whether to connect to the database port directly or use the REST
-API.
-
-You can use the same url with two changes.
-
-- Append the database port to the url.
-- If TLS is disabled, use http instead of https.
-
-Optimized Redis URL (TLS enabled):
-
-```shell
-curl https://us1-merry-cat-32748.upstash.io:32748/set/foo/bar \
- -H "Authorization: Bearer 2553feg6a2d9842h2a0gcdb5f8efe9934"
-```
-
-Optimized Redis URL (TLS disabled):
-
-```shell
-curl http://us1-merry-cat-32748.upstash.io:32748/set/foo/bar \
- -H "Authorization: Bearer 2553feg6a2d9842h2a0gcdb5f8efe9934"
-```
-
 ## Redis Protocol vs REST API
 
 ### REST API Pros


### PR DESCRIPTION
it was possible for regional databases but not for global databases with single port. 