### PR TITLE
fix: fill pricing pages

### DIFF
--- a/qstash/overall/pricing.mdx
+++ b/qstash/overall/pricing.mdx
@@ -2,3 +2,5 @@
 title: Pricing & Limits
 url: https://upstash.com/pricing/qstash
 ---
+
+Please check our [pricing page](https://upstash.com/pricing/qstash) for the most up-to-date information on pricing and limits. 

--- a/redis/overall/pricing.mdx
+++ b/redis/overall/pricing.mdx
@@ -2,3 +2,5 @@
 title: Pricing & Limits
 url: https://upstash.com/pricing
 ---
+
+Please check our [pricing page](https://upstash.com/pricing/redis) for the most up-to-date information on pricing and limits. 

--- a/vector/overall/pricing.mdx
+++ b/vector/overall/pricing.mdx
@@ -2,3 +2,5 @@
 title: Pricing & Limits
 url: https://upstash.com/pricing/vector
 ---
+
+Please check our [pricing page](https://upstash.com/pricing/vector) for the most up-to-date information on pricing and limits. 


### PR DESCRIPTION
Pricing pages are just external links to the main pricing page. But the pages can be reached from [google search results](https://www.google.com/search?q=upstash+docs+redis+pricing) and they don't redirect when opened. [Example](https://upstash.com/docs/redis/overall/pricing)

Fixes #297 