### PR TITLE
Extend warning alert

### DIFF
--- a/qstash/api/messages/bulk-cancel.mdx
+++ b/qstash/api/messages/bulk-cancel.mdx
@@ -18,7 +18,9 @@ If you provide a set of message IDs in the body of the request, only those messa
 
 If you include filter parameters in the request body, only the messages that match the filters will be canceled.
 
-If no body is sent, QStash will cancel all of your messages.
+If the `messageIds` array is empty, QStash will cancel all of your messages.
+
+If no body is sent, QStash will also cancel all of your messages.
 </Warning>
 
 This operation scans all your messages and attempts to cancel them. 


### PR DESCRIPTION
I noticed that when the `messageIds` array is empty, it cancels all of my messages. I believe this behavior should be addressed, as it’s inconsistent with expectations where an empty `messageIds` array should not trigger the cancellation of all messages.