### PR TITLE
fix twitter logo on introduction page

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -39,7 +39,7 @@ title: Get Started
 ## Get In touch
 
 <CardGroup cols={3}>
-  <Card title="X" icon="X" href="https://x.com/upstash">
+  <Card title="X" icon="x-twitter" href="https://x.com/upstash">
     Follow us on X for the latest news and updates.
   </Card>
   <Card title="Discord" icon="discord" href="https://upstash.com/discord">


### PR DESCRIPTION
Small change to fix the twitter logo because it was annoying

**Before**
<img width="254" alt="Screenshot 2025-01-14 at 9 28 01 AM" src="https://github.com/user-attachments/assets/57d950fe-2136-4ea9-868c-42cff1d23c00" />

**After**
![Screenshot 2025-01-14 at 9 28 13 AM](https://github.com/user-attachments/assets/5b7891a0-f4af-4d23-a3bb-67b6d9adb2f0)

