### PR TITLE
docs: add warning for queue API's for pause and delete

### DIFF
--- a/qstash/api/queues/pause.mdx
+++ b/qstash/api/queues/pause.mdx
@@ -9,6 +9,11 @@ Pausing a queue stops the delivery of enqueued messages.
 The queue will still accept new messages, but they will wait until the queue becomes active for delivery. 
 If the queue is already paused, this action has no effect.
 
+<Warning>
+Resuming or creating a queue may take up to a minute. 
+Therefore, it is not recommended to pause or delete a queue during critical operations.
+</Warning>
+
 ## Request
 
 <ParamField path="queueName" type="string" required>

--- a/qstash/api/queues/remove.mdx
+++ b/qstash/api/queues/remove.mdx
@@ -5,6 +5,11 @@ api: "DELETE https://qstash.upstash.io/v2/queues/{queueName}"
 authMethod: "bearer"
 ---
 
+<Warning>
+Resuming or creating a queue may take up to a minute. 
+Therefore, it is not recommended to pause or delete a queue during critical operations.
+</Warning>
+
 ## Request
 
 <ParamField path="queueName" type="string" required>

--- a/qstash/sdks/py/examples/queues.mdx
+++ b/qstash/sdks/py/examples/queues.mdx
@@ -26,6 +26,11 @@ queue_name = "upstash-queue"
 client.queue.delete(queue_name)
 ```
 
+<Warning>
+Resuming or creating a queue may take up to a minute. 
+Therefore, it is not recommended to pause or delete a queue during critical operations.
+</Warning>
+
 #### Pause/Resume a queue
 
 ```python
@@ -43,3 +48,8 @@ print(queue.paused) # prints True
 
 client.queue.resume(queue_name)
 ```
+
+<Warning>
+Resuming or creating a queue may take up to a minute. 
+Therefore, it is not recommended to pause or delete a queue during critical operations.
+</Warning>

--- a/qstash/sdks/ts/examples/queues.mdx
+++ b/qstash/sdks/ts/examples/queues.mdx
@@ -24,6 +24,11 @@ const queueName = "upstash-queue";
 await client.queue({ queueName: queueName }).delete();
 ```
 
+<Warning>
+Resuming or creating a queue may take up to a minute. 
+Therefore, it is not recommended to pause or delete a queue during critical operations.
+</Warning>
+
 #### Pause/Resume a queue
 
 ```typescript
@@ -43,3 +48,8 @@ console.log(queueInfo.paused); // prints true
 // resume queue
 await queue.resume();
 ```
+
+<Warning>
+Resuming or creating a queue may take up to a minute. 
+Therefore, it is not recommended to pause or delete a queue during critical operations.
+</Warning>


### PR DESCRIPTION
```
<Warning>
Resuming or creating a queue may take up to a minute. 
Therefore, it is not recommended to pause or delete a queue during critical operations. 
</Warning>
```