### PR TITLE
docs: update workflow trigger example urls

### DIFF
--- a/workflow/basics/client.mdx
+++ b/workflow/basics/client.mdx
@@ -26,7 +26,7 @@ import { Client } from "@upstash/workflow";
 
 const client = new Client({ token: "<QSTASH_TOKEN>" })
 const { workflowRunId } = await client.trigger({
-  url: "https://workflow-endpoint.com",
+  url: "https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
   body: "hello there!",         // optional body
   headers: { ... },             // optional headers
   workflowRunId: "my-workflow", // optional workflow run id

--- a/workflow/getstarted.mdx
+++ b/workflow/getstarted.mdx
@@ -254,6 +254,41 @@ async def onboarding_workflow(context: AsyncWorkflowContext[InitialData]) -> Non
   platform-specific function timeouts.
 </Tip>
 
+Once your endpoint is ready, you can trigger the workflow via our SDKs or using plain REST.
+See [here](/workflow/howto/start) for details. 
+<CodeGroup>
+```ts ts SDK(recommended)
+import { Client } from "@upstash/workflow";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+
+const { workflowRunId } = await client.trigger({
+  url: "https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
+  body: "hello there!",         // Optional body
+  headers: { ... },             // Optional headers
+  workflowRunId: "my-workflow", // Optional workflow run ID
+  retries: 3                    // Optional retries for the initial request
+});
+```
+
+```py python SDK
+from qstash import AsyncQStash
+
+client = AsyncQStash("<QSTASH_TOKEN>")
+
+res = await client.message.publish_json(
+    url="https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
+    body={"hello": "there!"},
+    headers={...},
+    retries=3,
+)
+```
+
+```bash REST
+curl -X POST https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE> -b '{"hello": "there!"}'
+```
+</CodeGroup>
+
 The above example should give you a rough idea of how a workflow looks in code. For step-by-step instructions on setting up your first workflow with images along the way, see our [Next.js Quickstart](/workflow/quickstarts/vercel-nextjs) or [FastAPI Quickstart](/workflow/quickstarts/fastapi).
 
 ---

--- a/workflow/howto/start.mdx
+++ b/workflow/howto/start.mdx
@@ -24,7 +24,7 @@ import { Client } from "@upstash/workflow";
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 
 const { workflowRunId } = await client.trigger({
-  url: "https://workflow-endpoint.com",
+  url: "https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
   body: "hello there!",         // Optional body
   headers: { ... },             // Optional headers
   workflowRunId: "my-workflow", // Optional workflow run ID
@@ -43,7 +43,7 @@ import { Client } from "@upstash/qstash";
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 
 const { messageId } = await client.publishJSON({
-  url: "https://workflow-endpoint.com",
+  url: "https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
   body: { hello: "there!" },
   headers: { ... },    
   retries: 3           
@@ -57,7 +57,7 @@ from qstash import AsyncQStash
 client = AsyncQStash("<QSTASH_TOKEN>")
 
 res = await client.message.publish_json(
-    url="https://workflow-endpoint.com",
+    url="https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
     body={"hello": "there!"},
     headers={...},
     retries=3,
@@ -74,14 +74,14 @@ message_id = res.message_id
 <Tabs>
   <Tab title="curl">
   ```bash
-  curl -X POST https://workflow-endpoint.com \
+  curl -X POST https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE> \
        -H "my-header: foo" \
        -b '{"foo": "bar"}'
   ```
   </Tab>
   <Tab title="fetch (TypeScript)">
   ```js
-  await fetch("https://workflow-endpoint.com", {
+  await fetch("https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>", {
     method: "POST",
     body: JSON.stringify({ "foo": "bar" }),
     headers: {
@@ -95,7 +95,7 @@ message_id = res.message_id
   import requests
 
   requests.post(
-      "https://workflow-endpoint.com", json={"foo": "bar"}, headers={"my-header": "foo"}
+      "https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>", json={"foo": "bar"}, headers={"my-header": "foo"}
   )
 
   ```

--- a/workflow/integrations/ai-sdk.mdx
+++ b/workflow/integrations/ai-sdk.mdx
@@ -155,7 +155,7 @@ import { Client } from "@upstash/workflow";
 
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 const { workflowRunId } = await client.trigger({
-  url: "<WORKFLOW_ENDPOINT>",
+  url: "https://<YOUR_WORKFLOW_ENDPOINT>/<YOUR-WORKFLOW-ROUTE>",
   body: { "prompt": "How is the weather in San Francisco around this time?" },
 });
 ```


### PR DESCRIPTION
The change is to make it more obvious that
- Urls should be from users deployments
- And also they should contain the route(not just base url)