### PR TITLE
Update Info Endpoint

### DIFF
--- a/vector/api/endpoints/info.mdx
+++ b/vector/api/endpoints/info.mdx
@@ -14,13 +14,12 @@ This request doesn't require any additional data.
 ## Response
 
 <ResponseField name="vectorCount" type="number" required>
-  The number of vectors in the index, that are ready to use.
-  This is the total number of vectors across all namespaces.
+  The number of vectors in the index, that are ready to use. This is the total
+  number of vectors across all namespaces.
 </ResponseField>
 <ResponseField name="pendingVectorCount" type="number" required>
-  The number of vectors in the index, that are still processing
-  and not ready to use.
-  This is the total number of pending vectors across all namespaces.
+  The number of vectors in the index, that are still processing and not ready to
+  use. This is the total number of pending vectors across all namespaces.
 </ResponseField>
 <ResponseField name="indexSize" type="number" required>
   The total size of the index, in **bytes**.
@@ -30,6 +29,30 @@ This request doesn't require any additional data.
 </ResponseField>
 <ResponseField name="similarityFunction" type="string" required>
   Name of the similarity function used in indexing and queries.
+</ResponseField>
+
+<ResponseField name="denseIndex" type="object">
+  Information about the dense vector index configuration.
+  <Expandable>
+    <ResponseField name="dimension" type="number" required>
+      Dimension of the dense vectors.
+    </ResponseField>
+    <ResponseField name="similarityFunction" type="string" required>
+      Similarity function used for dense vector comparisons.
+      Possible values: `"COSINE"`, `"EUCLIDEAN"`, `"DOT_PRODUCT"`
+    </ResponseField>
+    <ResponseField name="embeddingModel" type="string" required>
+      Name of the embedding model used for dense vectors.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+<ResponseField name="sparseIndex" type="object">
+  Information about the sparse vector index configuration.
+  <Expandable>
+    <ResponseField name="embeddingModel" type="string" required>
+      Name of the embedding model used for sparse vectors.
+    </ResponseField>
+  </Expandable>
 </ResponseField>
 <ResponseField name="namespaces" type="object" required>
   Map of namespace names to namespace .
@@ -59,23 +82,31 @@ curl $UPSTASH_VECTOR_REST_URL/info \
 
 ```json 200 OK
 {
-    "result": {
-        "vectorCount": 7,
-        "pendingVectorCount": 0,
-        "indexSize": 43501,
-        "dimension": 1536,
-        "similarityFunction": "COSINE",
-        "namespaces": {
-            "": {
-                "vectorCount": 6,
-                "pendingVectorCount": 0
-            },
-            "ns": {
-                "vectorCount": 1,
-                "pendingVectorCount": 0
-            }
-        }
+  "result": {
+    "vectorCount": 7,
+    "pendingVectorCount": 0,
+    "indexSize": 43501,
+    "dimension": 1024,
+    "similarityFunction": "COSINE",
+    "denseIndex": {
+      "dimension": 1024,
+      "similarityFunction": "COSINE",
+      "embeddingModel": "BGE_M3"
+    },
+    "sparseIndex": {
+      "embeddingModel": "BM25"
+    },
+    "namespaces": {
+      "": {
+        "vectorCount": 6,
+        "pendingVectorCount": 0
+      },
+      "ns": {
+        "vectorCount": 1,
+        "pendingVectorCount": 0
+      }
     }
+  }
 }
 ```
 


### PR DESCRIPTION
The new response of the info endpoint is as below, we updated the types accordingly:

```json
{
  "vectorCount": 793,
  "pendingVectorCount": 0,
  "indexSize": 10797470,
  "dimension": 1024,
  "similarityFunction": "COSINE",
  "namespaces": {
    "ns": {
      "vectorCount": 0,
      "pendingVectorCount": 0
    }
  },
  "indexType": "DENSE",
  "denseIndex": {
    "dimension": 1024,
    "similarityFunction": "COSINE",
    "embeddingModel": "BGE_M3"
  },
  "sparseIndex": {
    "embeddingModel": "BM25"
  }
}
```