### PR TITLE
Refer to kv env vars in redis examples

### DIFF
--- a/redis/tutorials/nextjs_with_redis.mdx
+++ b/redis/tutorials/nextjs_with_redis.mdx
@@ -30,6 +30,15 @@ UPSTASH_REDIS_REST_URL=<YOUR_URL>
 UPSTASH_REDIS_REST_TOKEN=<YOUR_TOKEN>
 ```
 
+<Note>
+  If you are using the Vercel & Upstash integration, you may use the following environment variables:
+
+  ```shell .env
+  KV_REST_API_URL=<YOUR_URL>
+  KV_REST_API_TOKEN=<YOUR_TOKEN>
+  ```
+</Note>
+
 ### Home Page Setup
 
 Update `/app/page.tsx`:

--- a/redis/tutorials/nuxtjs_with_redis.mdx
+++ b/redis/tutorials/nuxtjs_with_redis.mdx
@@ -45,6 +45,15 @@ UPSTASH_REDIS_REST_TOKEN=""
 
 You can get the values of these env variables on the page of your Redis database.
 
+<Note>
+  If you are using the Vercel & Upstash integration, you may use the following environment variables:
+
+  ```shell .env
+  KV_REST_API_URL=<YOUR_URL>
+  KV_REST_API_TOKEN=<YOUR_TOKEN>
+  ```
+</Note>
+
 ### `4` Define the endpoint
 
 Next, we will define the endpoint which will call Redis:


### PR DESCRIPTION
Adding reference to KV_REST_API_URL and KV_REST_API_TOKEN env variables in the .env.example files of redis examples which are on Vercel templates website