### PR TITLE
Fix: Remove Duplicate Line in Background Jobs

### DIFF
--- a/qstash/features/background-jobs.mdx
+++ b/qstash/features/background-jobs.mdx
@@ -22,7 +22,6 @@ QStash provides a simple and efficient way to run background jobs, you can under
 
 1. **Public API** Create a public API endpoint within your application. The endpoint should contain the logic for the background job.
 <Warning>
-Since QStash requires a public endpoint to invoke the background job, it won't be able to access any localhost APIs. 
 QStash requires a public endpoint to trigger background jobs, which means it cannot directly access localhost APIs. 
 To get around this, you have two options:
 - Run QStash [development server](/qstash/howto/local-development) locally


### PR DESCRIPTION
## What

- [x] removes 1 line about QStash needing a public endpoint

## Why

It was duplicated.