### PR TITLE
Update kafka-ui

### DIFF
--- a/kafka/monitoring/kafka-ui.mdx
+++ b/kafka/monitoring/kafka-ui.mdx
@@ -3,7 +3,7 @@ title: "kafka-ui"
 description: "Connect and monitor your Upstash Kafka cluster using kafka-ui."
 ---
 
-[kafka-ui](https://github.com/provectus/kafka-ui) is a GUI for monitoring Apache
+[kafka-ui](https://github.com/kafbat/kafka-ui) is a GUI for monitoring Apache
 Kafka. From their description:
 
 > Kafka UI for Apache Kafka is a simple tool that makes your data flows
@@ -13,9 +13,9 @@ Kafka. From their description:
 > Consumption.
 
 You can connect and monitor your Upstash Kafka cluster using
-[kafka-ui](https://github.com/provectus/kafka-ui).
+[kafka-ui](https://github.com/kafbat/kafka-ui).
 
-To be able to use [kafka-ui](https://github.com/provectus/kafka-ui), first you
+To be able to use [kafka-ui](https://github.com/kafbat/kafka-ui), first you
 should create a yaml configuration file:
 
 ```yaml
@@ -43,9 +43,9 @@ kafka:
   - `UPSTASH_KAFKA_REST_PASSWORD`
 </Note>
 
-You can start [kafka-ui](https://github.com/provectus/kafka-ui) application
+You can start [kafka-ui](https://github.com/kafbat/kafka-ui) application
 directly using `jar` file. First download the latest release from
-[releases page](https://github.com/provectus/kafka-ui/releases). Then launch the
+[releases page](https://github.com/kafbat/kafka-ui/releases). Then launch the
 application using following command in the same directory with `application.yml`
 file:
 
@@ -56,11 +56,11 @@ java -jar kafka-ui-api-X.Y.Z.jar
 Alternatively you can start using Docker:
 
 ```shell
-docker run -p 8080:8080 -v ~/kafka-ui/application.yml:/application.yml provectuslabs/kafka-ui:latest
+docker run -p 8080:8080 -v ~/kafka-ui/application.yml:/application.yml ghcr.io/kafbat/kafka-ui:latest
 ```
 
-After launching the [kafka-ui](https://github.com/provectus/kafka-ui) app, just
+After launching the [kafka-ui](https://github.com/kafbat/kafka-ui) app, just
 go to [http://localhost:8080](http://localhost:8080) to access UI.
 
 For more information see
-[kafka-ui documentation](https://github.com/provectus/kafka-ui/blob/master/README.md).
+[kafka-ui documentation](https://github.com/kafbat/kafka-ui/blob/master/README.md).


### PR DESCRIPTION
While Provectus UI for Apache Kafka is no longer supported please find a possibility to add this PR with it succesor Kafbat UI. 