### PR TITLE
Add missing step issue to caveats

### DIFF
--- a/workflow/basics/caveats.mdx
+++ b/workflow/basics/caveats.mdx
@@ -340,3 +340,58 @@ async def example(context: AsyncWorkflowContext[str]) -> None:
 ```
 
 </CodeGroup>
+
+### Include At Least One Step in Workflow
+
+Every workflow must include at least one step execution with `context.run`. If no steps are defined, the workflow will throw a `Failed to authenticate Workflow request.` error.
+
+<CodeGroup>
+
+```typescript ❌ Missing steps - TypeScript
+export const { POST } = serve<string>(async (context) => {
+  const input = context.requestPayload
+  
+  // 👇 Problem: No context.run call
+  console.log("Processing input:", input)
+  
+  // This workflow will fail with "Failed to authenticate Workflow request."
+})
+```
+
+```typescript ✅ Correct - TypeScript
+export const { POST } = serve<string>(async (context) => {
+  const input = context.requestPayload
+  
+  // 👇 At least one step is required
+  await context.run("dummy-step", async () => {
+    return
+  })
+})
+```
+
+```python ❌ Missing steps - Python
+@serve.post("/api/example")
+async def example(context: AsyncWorkflowContext[str]) -> None:
+    input = context.request_payload
+    
+    # 👇 Problem: No context.run call
+    print("Processing input:", input)
+    
+    # This workflow will fail with "Failed to authenticate Workflow request."
+```
+
+```python ✅ Correct - Python
+@serve.post("/api/example")
+async def example(context: AsyncWorkflowContext[str]) -> None:
+    input = context.request_payload
+    
+    # 👇 At least one step is required
+    async def _dummy_step():
+        return
+        
+    await context.run("dummy-step", _dummy_step)
+```
+
+</CodeGroup>
+
+Even for the placeholder implementations, you must include one dummy step for the Workflow authentication mechanism to function properly.


### PR DESCRIPTION
Every workflow must include at least one step, otherwise the authentication fails and we throw `Failed to authenticate Workflow request.` error. 