### PR TITLE
Add Drizzle integration docs

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -708,6 +708,7 @@
             "redis/howto/vercelintegration",
             "redis/integrations/replit-templates",
             "redis/howto/emqxintegration",
+            "redis/integrations/drizzle",
             "redis/integrations/celery",
             "redis/integrations/mcp"
           ]

--- a/mint.json
+++ b/mint.json
@@ -701,6 +701,7 @@
         {
           "group": "Integrations",
           "pages": [
+            "redis/integrations/drizzle",
             "redis/howto/datadog",
             "redis/integrations/prometheus",
             "redis/integrations/bullmq",
@@ -708,7 +709,6 @@
             "redis/howto/vercelintegration",
             "redis/integrations/replit-templates",
             "redis/howto/emqxintegration",
-            "redis/integrations/drizzle",
             "redis/integrations/celery",
             "redis/integrations/mcp"
           ]

--- a/redis/integrations/drizzle.mdx
+++ b/redis/integrations/drizzle.mdx
@@ -1,0 +1,86 @@
+---
+title: "Drizle ORM with Upstash Redis"
+sidebarTitle: "Drizzle"
+---
+
+We now support native caching integration with Drizzle ORM via Upstash Redis!
+
+Drizzle ORM has an explicit caching model — by default, queries go directly to your database with no automatic caching or invalidation. You can easily opt in to use Upstash cache either per query or globally.
+
+### Installation
+
+```bash
+npm install drizzle-orm@cache
+```
+
+### Quickstart
+
+Drizzle provides an `upstashCache()` helper to easily connect with Upstash Redis.
+
+```ts
+import { upstashCache } from "drizzle-orm/cache/upstash";
+import { drizzle } from "drizzle-orm/...";
+ 
+const db = drizzle(process.env.DB_URL!, {
+  cache: upstashCache(),
+});
+```
+
+You can also customize the Upstash credentials and caching behavior:
+
+```ts
+const db = drizzle(process.env.DB_URL!, {
+  cache: upstashCache({
+    url: "<UPSTASH_URL>",
+    token: "<UPSTASH_TOKEN>",
+    global: true, // Enable caching for all queries by default (optional)
+    config: { ex: 60 }, // Default cache expiration time (optional)
+  }),
+});
+```
+
+### Cache Behavior
+
+- **Per-query caching (default):**  
+  No queries are cached unless you explicitly call `.$withCache()`.
+
+  ```ts
+  const res = await db.select().from(users).$withCache();
+  ```
+
+- **Global caching:**  
+  If `global: true` is enabled, all `select` queries will read from cache by default.
+
+  ```ts
+  const db = drizzle(process.env.DB_URL!, {
+    cache: upstashCache({ global: true }),
+  });
+  ```
+
+  You can disable caching for a specific query:
+
+  ```ts
+  const res = await db.select().from(users).$withCache(false);
+  ```
+
+### Cache Invalidation
+
+You can manually invalidate cached queries by table name or custom tags:
+
+```ts
+// Invalidate by table
+await db.$cache?.invalidate({ tables: "usersTable" });
+
+// Invalidate by custom tag
+await db.$cache?.invalidate({ tags: "custom_key" });
+```
+
+If you enabled global caching, invalidation will be applied automatically.
+
+### Additional Options
+
+- Set custom cache expiration (`ex`).
+- Control field-level expiration with `hexOptions`.
+- Manage consistency by turning off `autoInvalidate` if needed (use carefully for eventual consistency scenarios).
+
+For more details on this integration, refer to the [Drizzle ORM caching documentation](https://cache.drizzle-orm-fe.pages.dev/docs/cache).


### PR DESCRIPTION
Added the docs under redis/integrations.

This is TS specific but I still put it under `integrations/redis`, because we have done something similar for PY too with [Celery](https://upstash.com/docs/redis/integrations/celery).

I kept it simple and quick and referenced Drizzle docs for further details.