### PR TITLE
Fix incorrect installation and import instructions for upstash-redis-…

### DIFF
--- a/redis/howto/migratefromregionaltoglobal.mdx
+++ b/redis/howto/migratefromregionaltoglobal.mdx
@@ -77,7 +77,7 @@ Another reliable method is using the official [upstash-redis-dump](https://githu
 
 1. Install upstash-redis-dump:
    ```bash
-   npm install -g upstash-redis-dump
+   go install github.com/upstash/upstash-redis-dump@latest
    ```
 
 2. Export data from regional database:
@@ -87,7 +87,7 @@ Another reliable method is using the official [upstash-redis-dump](https://githu
 
 3. Import data to global database:
    ```bash
-   cat redis.dump | upstash-redis-dump -db 0 -host YOUR_GLOBAL_HOST -port 6379 -pass YOUR_PASSWORD -tls -import
+   redis-cli --tls -u redis://YOUR_PASSWORD@YOUR_REGIONAL_HOST:6379 --pipe < redis.dump
    ```
 
 ## Verification


### PR DESCRIPTION
…dump

This PR corrects two issues in the documentation regarding the use of upstash-redis-dump:
	•	Installation: The tool is not available via npm install -g, but should instead be installed using go install github.com/upstash/upstash-redis-dump@latest or downloaded from the GitHub releases.
	•	Import process: The -import flag does not exist in upstash-redis-dump. Data import should be done using redis-cli with the --pipe option, as shown:

redis-cli --tls -u redis://YOUR_PASSWORD@YOUR_GLOBAL_HOST:6379 --pipe < redis.dump