### PR TITLE
clarify streams xread and xreadgroup compatibility

### DIFF
--- a/redis/features/restapi.mdx
+++ b/redis/features/restapi.mdx
@@ -577,5 +577,5 @@ summary about the performance of your APIs.
 | [Pub/Sub](https://redis.io/commands/?group=pubsub)            |      ⚠️       |              Only PUBLISH and PUBSUB are supported.               |
 | [Connection](https://redis.io/commands/?group=connection)     |      ⚠️       |                 Only PING and ECHO are supported.                 |
 | [JSON](https://redis.io/commands/?group=json)                 |      ✅       |                                                                   |
-| [Streams](https://redis.io/commands/?group=stream)            |      ✅       |                                                                   |
+| [Streams](https://redis.io/commands/?group=stream)            |      ✅       |    Supported, except blocking versions of XREAD and XREADGROUP.   |
 | [Cluster](https://redis.io/commands#cluster)                  |      ❌       |                                                                   |


### PR DESCRIPTION
we support only non-blocking versions of xread and xreadgroup