### PR TITLE
docs(qstash): update FlowControl docs for SDK rate and period changes

### DIFF
--- a/qstash/features/flowcontrol.mdx
+++ b/qstash/features/flowcontrol.mdx
@@ -19,6 +19,12 @@ The rate limit is the number of calls that can be made to your endpoint per seco
 QStash will delay the delivery of the messages if the rate limit is exceeded. 
 In case of burst calls to QStash, a delivery can be delayed as long as necessary to guarantee the rate limit.
 
+<Warning>This parameter is deprecated. Use `rate` and `period` instead.</Warning>
+
+## Rate and Period
+
+-   The `rate` parameter defines the number of requests that can be activated within the specified period for the same flow control key.
+-   The `period` parameter specifies the time interval for the rate limit, which can be set as a number (in seconds) or a duration string (e.g., '10s' for 10 seconds, '5m' for 5 minutes, '1h' for 1 hour, or '2d' for 2 days). It defaults to '1s' if not specified.
 
 You can set the rate limit 10 calls per second as follows:
 
@@ -29,7 +35,7 @@ const client = new Client({ token: "<QSTASH_TOKEN>" });
 await client.publishJSON({
     url: "https://example.com",
     body: { hello: "world" },
-    flowControl: { key: "USER_GIVEN_KEY", ratePerSecond: 10 },
+    flowControl: { key: "USER_GIVEN_KEY", rate: 10, period: 1 }, // period in seconds
 });
 ```
 
@@ -37,7 +43,7 @@ await client.publishJSON({
 curl -XPOST -H 'Authorization: Bearer XXX' \
             -H "Content-type: application/json" \
             -H "Upstash-Flow-Control-Key:USER_GIVEN_KEY"  \
-            -H "Upstash-Flow-Control-Value:Rate=10" \
+            -H "Upstash-Flow-Control-Value:Rate=10,Period=1s" \
            'https://qstash.upstash.io/v2/publish/https://example.com' \ 
             -d '{"message":"Hello, World!"}'
 ```
@@ -74,7 +80,7 @@ curl -XPOST -H 'Authorization: Bearer XXX' \
 You can also use the Rest API to get information how many messages waiting for parallelism limit.
 See the [API documentation](/qstash/api/flow-control/get) for more details.
 
-### RatePerSecond and Parallelism Together
+### Rate and Parallelism Together
 
 Both parameters can be combined. For example, with a rate of 10 per second and parallelism of 20, if each request takes a minute to complete, QStash will trigger 10 calls in the first second and another 10 in the next. Since none of them will have finished, the system will wait until one completes before triggering another.
 
@@ -85,7 +91,7 @@ const client = new Client({ token: "<QSTASH_TOKEN>" });
 await client.publishJSON({
     url: "https://example.com",
     body: { hello: "world" },
-    flowControl: { key: "USER_GIVEN_KEY", ratePerSecond: 20, parallelism: 10 },
+    flowControl: { key: "USER_GIVEN_KEY", rate: 20, period: 1, parallelism: 10 },
 });
 ```
 
@@ -93,7 +99,7 @@ await client.publishJSON({
 curl -XPOST -H 'Authorization: Bearer XXX' \
             -H "Content-type: application/json" \
             -H "Upstash-Flow-Control-Key:USER_GIVEN_KEY"  \
-            -H "Upstash-Flow-Control-Value:Rate=20,Parallelism=10" \
+            -H "Upstash-Flow-Control-Value:Rate=20,Period=1s,Parallelism=10" \
            'https://qstash.upstash.io/v2/publish/https://example.com' \ 
             -d '{"message":"Hello, World!"}'
 ```


### PR DESCRIPTION
Update the FlowControl documentation by incorporating SDK updates, including the deprecation of the `ratePerSecond` parameter in favor of `rate` and the addition of the `period` parameter for more flexible rate limiting.