### PR TITLE
Failure function is now available w python as well

### DIFF
--- a/workflow/basics/serve.mdx
+++ b/workflow/basics/serve.mdx
@@ -81,13 +81,6 @@ The default value is `undefined`, meaning no failure URL is called.
 
 ### `failureFunction`
 
-<Note>
-  This feature is not yet available in
-  [workflow-py](https://github.com/upstash/workflow-py). See our
-  [Roadmap](/workflow/roadmap) for feature parity plans and
-  [Changelog](/workflow/changelog) for updates.
-</Note>
-
 Use the `failureFunction` to define a function that's executed when your workflow exhausts all its [retries](/qstash/features/retry) and fails.
 
 ```typescript


### PR DESCRIPTION
with this release: https://github.com/upstash/workflow-py/releases/tag/v0.1.2