### PR TITLE
Mention about the data size in vector FAQ

### DIFF
--- a/vector/help/faq.mdx
+++ b/vector/help/faq.mdx
@@ -14,11 +14,11 @@ title: FAQ
     
 - **How do you calculate the storage to be charged?**
     
-    Storage is a sum of vector storage and metadata storage. Vector storage depends on the number of dimensions and the number of vectors in that index. Each dimension is estimated to be 4 bytes, resulting in vector storage being calculated as vector count * dimension count * 4 bytes. For metadata storage, it is calculated based on the vector count in an index multiplied by the metadata size, which can be up to 48 Kbytes.
+    Storage is a sum of vector storage, metadata, and data storage. Vector storage depends on the number of dimensions and the number of vectors in that index. Each dimension is estimated to be 4 bytes, resulting in vector storage being calculated as vector count * dimension count * 4 bytes. For metadata and data storage, it is calculated based on the vector count in an index multiplied by the average metadata and data size, which can be up to 48 Kbytes and 1 Mbytes respectively.
     
-- **What happens when I exceed my Metadata Storage limit?**
+- **What happens when I exceed my Metadata / Data Storage limit?**
     
-    Metadata Storage has a soft limit, and you will receive an email reminder to optimize your index for optimal performance if you approach this limit. The storage cost remains at $0.25 per GB. For enhanced performance, we recommend upgrading to Pro tier that meets your requirements, which includes incremental metadata storage
+    Metadata / Data Storage has a soft limit, and you will receive an email reminder to optimize your index for optimal performance if you approach this limit. The storage cost remains at $0.25 per GB. For enhanced performance, we recommend upgrading to Pro tier that meets your requirements, which includes incremental metadata and data storage
     
 - **What happens when I exceed bandwidth limit of 200GB?**
     


### PR DESCRIPTION
A user recently thought we didn't include the data field size in the storage calculation since it was missing in the FAQ.

This PR adds that extra information here to clarify the situation.