### PR TITLE
Extract healthcare data management to standalone page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -682,7 +682,8 @@
                 "group": "Security & Compliance",
                 "pages": [
                   "redis/help/production-checklist",
-                  "redis/help/shared-responsibility-model"
+                  "redis/help/shared-responsibility-model",
+                  "redis/help/managing-healthcare-data"
                 ]
               },
               {

--- a/redis/help/managing-healthcare-data.mdx
+++ b/redis/help/managing-healthcare-data.mdx
@@ -1,0 +1,23 @@
+---
+title: Managing Healthcare Data
+---
+
+You can use Upstash Redis to store and process Protected Health Information (PHI). You are responsible for the following:
+
+- **Signing a Business Associate Agreement (BAA)** with Upstash. Email [support@upstash.com](mailto:support@upstash.com) to get started.
+- **Marking specific databases as HIPAA databases** and addressing security issues raised by the advisor.
+- **Ensuring MFA is enabled** on all Upstash accounts.
+  - Enforce MFA as a requirement to access the organization
+- **Enabling Prod Pack** which provides encryption at rest and advanced security features.
+- **Enabling Credential Protection** to prevent storing credentials in Upstash infrastructure and limit console access requiring database credentials.
+- **Configuring IP allowlist** to restrict database access to authorized networks.
+- **Enabling daily backups** to validate recoverability and meet retention requirements.
+- **Complying with encryption requirements** in the HIPAA Security Rule. Data is encrypted at rest and in transit by Upstash. You can consider encrypting the data at your application layer.
+- **Ensuring that PHI is stored only within your database**. Storing PHI in resource names or other locations is strictly prohibited.
+- **Ensuring that PHI is stored only in values of data structures, not in identifiers or keys**. Avoid logging keys anywhere.
+- **Not using public endpoints** to process PHI.
+- **Not transferring databases** to a non-HIPAA organization.
+
+<Note>
+  For a comprehensive guide on implementing these responsibilities in production, see our [Production Checklist](/redis/help/production-checklist). For questions about managing healthcare data, contact our support team at [support@upstash.com](mailto:support@upstash.com).
+</Note>

--- a/redis/help/shared-responsibility-model.mdx
+++ b/redis/help/shared-responsibility-model.mdx
@@ -61,25 +61,4 @@ Upstash Redis is a serverless database service that provides Redis® API compati
   </Accordion>
 </AccordionGroup>
 
-## Managing healthcare data
-
-You can use Upstash Redis to store and process Protected Health Information (PHI). You are responsible for the following:
-
-- **Signing a Business Associate Agreement (BAA)** with Upstash. Email [support@upstash.com](mailto:support@upstash.com) to get started.
-- **Marking specific databases as HIPAA databases** and addressing security issues raised by the advisor.
-- **Ensuring MFA is enabled** on all Upstash accounts.
-  - Enforce MFA as a requirement to access the organization
-- **Enabling Prod Pack** which provides encryption at rest and advanced security features.
-- **Enabling Credential Protection** to prevent storing credentials in Upstash infrastructure and limit console access requiring database credentials.
-- **Configuring IP allowlist** to restrict database access to authorized networks.
-- **Enabling daily backups** to validate recoverability and meet retention requirements.
-- **Complying with encryption requirements** in the HIPAA Security Rule. Data is encrypted at rest and in transit by Upstash. You can consider encrypting the data at your application layer.
-- **Ensuring that PHI is stored only within your database**. Storing PHI in resource names or other locations is strictly prohibited.
-- **Ensuring that PHI is stored only in values of data structures, not in identifiers or keys**. Avoid logging keys anywhere.
-- **Not using public endpoints** to process PHI.
-- **Not transferring databases** to a non-HIPAA organization.
-<Note>
-  For a comprehensive guide on implementing these responsibilities in production, see our [Production Checklist](/redis/help/production-checklist). For questions about the shared responsibility model, contact our support team at [support@upstash.com](mailto:support@upstash.com).
-</Note>
-
 


### PR DESCRIPTION
- Create new standalone page for managing healthcare data
- Move content from shared responsibility model to dedicated page
- Update docs.json to include new page in Security & Compliance section
- Remove healthcare section from original shared responsibility model page