### PR TITLE
Add Terraform syntax highlighting to examples

### DIFF
--- a/redis/howto/terraformprovider.mdx
+++ b/redis/howto/terraformprovider.mdx
@@ -10,7 +10,7 @@ required in order to create resources.
 Provider requires your email address and api key which can be created in
 console.
 
-```
+```tf
 provider "upstash" {
   email = ""
   api_key = ""
@@ -21,7 +21,7 @@ provider "upstash" {
 
 As input you need to give database name, region and type.
 
-```
+```tf
 resource "upstash_database" "mydb" {
   database_name = "testdblstr"
   region = "eu-west-1"
@@ -31,7 +31,7 @@ resource "upstash_database" "mydb" {
 
 You can output database credentials as following
 
-```
+```tf
 output "endpoint" {
   value = "${upstash_database.mydb.endpoint}"
 }


### PR DESCRIPTION
Updated code blocks to use Terraform syntax highlighting.