### PR TITLE
Rest API Rate Limit Doc Update

### DIFF
--- a/qstash/api/api-ratelimiting.mdx
+++ b/qstash/api/api-ratelimiting.mdx
@@ -8,10 +8,7 @@ description: "This page documents the rate limiting behavior of our API and expl
 There is no request per second limit for operational API's as listed below:
 
 - trigger, publish, enqueue, notify, wait, batch
-- Other endpoints (like logs,listing flow-controls, queues, schedules etc) have rps limit.
-You can learn more about QStash plans and their limits on the [QStash pricing page](https://upstash.com/pricing/qstash).
-
-This is a short-term limit **per second** to prevent rapid bursts of requests. This limit applies to all API endpoints.
+- Other endpoints (like logs,listing flow-controls, queues, schedules etc) have rps limit. This is a short-term limit **per second** to prevent rapid bursts of requests.
 
 **Headers**:
 


### PR DESCRIPTION
After the pricing changes this doc was out-of-date. Updated accordingly.