### PR TITLE
cloud-3657 Qstash and Search Devops

### DIFF
--- a/devops/developer-api/openapi.yml
+++ b/devops/developer-api/openapi.yml
@@ -31,7 +31,16 @@ tags:
     externalDocs:
       description: Find out more
       url: https://upstash.com/docs/devops/developer-api/introduction
-
+  - name: search
+    description: Manage search indices.
+    externalDocs:
+      description: Find out more
+      url: https://upstash.com/docs/devops/developer-api/introduction
+  - name: qstash
+    description: Manage QStash.
+    externalDocs:
+      description: Find out more
+      url: https://upstash.com/docs/devops/developer-api/introduction
 paths:
   /redis/databases:
     get:
@@ -1044,7 +1053,9 @@ paths:
       tags:
         - vector
       summary: Transfer Index
-      description: This endpoint is used to transfer an index to another team.
+      description: |
+        This endpoint is used to transfer an index to another team. 
+        Transferring to a personal account is not supported. However, transferring an index from a personal account to a team is allowed.
       x-mint:
         href: /devops/developer-api/vector/transfer_index
       operationId: transferIndex
@@ -1064,8 +1075,8 @@ paths:
               properties:
                 target_account:
                   type: string
-                  description: The ID of the target account. If the target is a team, then use the format `team:<TEAM_ID>`, else if the target is your personal account use the format `<YOUR_EMAIL>`.
-                  example: "team:team-id-1"
+                  description: The team ID of the target team.
+                  example: "99a4c327-31f0-490f-a594-043ade84085a"
               required:
                 - target_account
       responses:
@@ -1076,6 +1087,450 @@ paths:
               schema:
                 type: string
                 example: "OK"
+      security:
+        - basicAuth: []
+  /vector/index/stats:
+    get:
+      summary: Get Vector Stats
+      description: Get vector statistics for all the vector indices associated with the authenticated user
+      operationId: getGlobalVectorStats
+      tags:
+        - vector
+      responses:
+        '200':
+          description: Statistics for the vector indices retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalStats'
+      security:
+        - basicAuth: []
+  /vector/index/{id}/stats:
+    get:
+      summary: Get Index Stats
+      description: Retrieves statistics and metrics for a specific vector index
+      operationId: getVectorIndexStats
+      tags:
+        - vector
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the vector index
+          required: true
+          schema:
+            type: string
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1h
+              - 3h
+              - 12h
+              - 1d
+              - 3d
+              - 7d
+              - 30d
+            default: 1h
+          description: |
+            Time period for statistics aggregation. Each period returns 60 datapoints 
+            with intervals adjusted to the period length. 
+            
+            Exceptionally for 30 days, it returns 240 datapoints with 3-hour intervals for increased granularity.
+          example: 3h
+      responses:
+        '200':
+          description: Statistics for the specified vector index retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStats'
+      security:
+        - basicAuth: []
+  /search:
+    get:
+      summary: List Search Indexes
+      description: Returns a list of all search indices belonging to the authenticated user.
+      operationId: listSearchIndexes
+      tags:
+        - search
+      responses:
+        '200':
+          description: Successfully retrieved list of search indices.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SearchIndex'
+      security:
+        - basicAuth: []
+    post:
+      summary: Create Search Index
+      description: Creates a new search index with the specified configuration
+      operationId: createSearchIndex
+      tags:
+        - search
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - region
+                - type
+              properties:
+                name:
+                  type: string
+                  description: Name of the search index
+                  example: mySearchIndex
+                region:
+                  type: string
+                  enum: [eu-west-1, us-central1]
+                  description: Region of the index
+                  example: eu-west-1
+                type:
+                  type: string
+                  enum: [free, payg, fixed]
+                  description: Index payment type. Currently 'free' and 'payg' are available.
+                  example: payg
+      responses:
+        '200':
+          description: Index created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchIndex'
+      security:
+        - basicAuth: []
+  /search/{id}:
+    get:
+      summary: Get Search Index
+      description: Retrieves detailed information about a specific search index
+      operationId: getSearchIndex
+      tags:
+        - search
+      parameters:
+        - name: id
+          in: path
+          description: The unique ID of the search index to be retrieved
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully retrieved specified search index
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchIndex'
+      security:
+        - basicAuth: []
+    delete:
+      summary: Delete Search Index
+      description: Permanently deletes a search index and all its data
+      operationId: deleteSearchIndex
+      tags:
+        - search
+      parameters:
+        - name: id
+          in: path
+          description: The unique ID of the search index to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Search Index Deleted Successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "OK"
+      security:
+        - basicAuth: []
+  /search/stats:
+    get:
+      summary: Get Search Stats
+      description: Get search statistics for all the search indices associated with the authenticated user
+      operationId: getGlobalSearchStats
+      tags:
+        - search
+      responses:
+        '200':
+          description: Statistics for the search indices retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalStats'
+      security:
+        - basicAuth: []
+  /search/{id}/stats:
+    get:
+      summary: Get Index Stats
+      description: Retrieves statistics and metrics for a specific search index
+      operationId: getSearchIndexStats
+      tags:
+        - search
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the search index
+          required: true
+          schema:
+            type: string
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1h
+              - 3h
+              - 12h
+              - 1d
+              - 3d
+              - 7d
+              - 30d
+            default: 1h
+          description: |
+            Time period for statistics aggregation. Each period returns 60 datapoints 
+            with intervals adjusted to the period length. 
+            
+            Exceptionally for 30 days, it returns 240 datapoints with 3-hour intervals for increased granularity.
+          example: 3h
+      responses:
+        '200':
+          description: Statistics for the specified search index retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorStats'
+      security:
+        - basicAuth: []
+  /search/{id}/reset-password:
+    post:
+      summary: Reset Password
+      description: This endpoint resets the regular and readonly tokens of a search index.
+      operationId: resetSearchPassword
+      tags:
+        - search
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the search index
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Search index passwords reset successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "OK"
+      security:
+        - basicAuth: []
+  /search/{id}/transfer:
+    post:
+      summary: Transfer Search Index
+      description: | 
+        Transfers ownership of a search index to another team.
+        Transferring to a personal account is not supported.
+        However, transferring from a personal account to a team is allowed.
+      operationId: transferSearchIndex
+      tags:
+        - search
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the search index
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                target_account:
+                  type: string
+                  description: The ID of the target team account.
+                  example: "99a4c327-31f0-490f-a594-043ade84085a"
+              required:
+                - target_account
+      responses:
+        "200":
+          description: Search index transferred successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "OK"
+      security:
+        - basicAuth: []
+  /search/{id}/rename:
+    post:
+      summary: Rename Search Index
+      description: Renames a search index.
+      operationId: renameSearchIndex
+      tags:
+        - search
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the search index
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: New name for the index
+                  example: new-index-name
+      responses:
+        "200":
+          description: Search index renamed successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "OK"
+      security:
+        - basicAuth: []
+  /qstash/user:
+    servers:
+    - url: https://api.upstash.com
+    get:
+      summary: Get QStash
+      description: Retrieves detailed information about the authenticated user's QStash, including plan details, limits, and configuration
+      operationId: getQStashUser
+      tags:
+        - qstash
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QStashUser'
+      security:
+        - basicAuth: []
+  /qstash/user/rotatetoken:
+    servers:
+    - url: https://api.upstash.com
+    post:
+      summary: Reset QStash Token
+      description: |
+        Resets the authentication credentials for the QStash user account. 
+        This invalidates the old password and token, and generates new ones.
+        Returns the updated user information with new credentials.
+      operationId: resetQStashToken
+      tags:
+        - qstash
+      responses:
+        '200':
+          description: Token reset successfully, returns updated user information with new credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QStashUser'
+      security:
+        - basicAuth: []
+  /qstash-upgrade:
+    servers:
+      - url: https://api.upstash.com
+    post:
+      summary: Set QStash Plan
+      description: |
+        Changes the QStash account to a different plan type.
+        This operation changes the plan and associated limits for the QStash account.
+      operationId: setQStashPlan
+      tags:
+        - qstash
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - customer_id
+                - plan_name
+              properties:
+                customer_id:
+                  type: string
+                  description: Customer identifier or team ID
+                  example: example@upstash.com
+                plan_name:
+                  type: string
+                  description: Target plan to upgrade to
+                  enum:
+                    - paid
+                    - qstash_enterprise_1m
+                    - qstash_enterprise_10m
+                  example: paid
+      responses:
+        "200":
+          description: QStash plan changed successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "OK"
+      security:
+        - basicAuth: []
+  /qstash/stats:
+    get:
+      summary: Get QStash Stats
+      description: |
+        Retrieves detailed usage statistics for the QStash account including 
+        daily requests, billing, bandwidth, and workflow metrics over time.
+      operationId: getQStashStats
+      tags:
+        - qstash
+      parameters:
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1h
+              - 3h
+              - 12h
+              - 1d
+              - 3d
+              - 7d
+              - 30d
+            default: 1h
+          description: |
+            Time period for statistics aggregation. Each period returns 60 datapoints 
+            with intervals adjusted to the period length. 
+            
+            Exceptionally for 30 days, it returns 240 datapoints with 3-hour intervals for increased granularity.
+          example: 3h
+      responses:
+        '200':
+          description: Successful response with usage statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QStashStats'
       security:
         - basicAuth: []
 components:
@@ -1946,6 +2401,550 @@ components:
             ]
       xml:
         name: vectorIndex
+    VectorStats:
+      type: object
+      properties:
+        pending_index_count:
+          type: integer
+          description: Number of pending index operations
+          example: 1
+        current_vector_count:
+          type: integer
+          description: Current number of vectors in the index
+          example: 1000
+        daily_query_count:
+          type: integer
+          description: Total number of query operations executed today
+          example: 100
+        daily_update_count:
+          type: integer
+          description: Total number of update operations executed today
+          example: 10
+        monthly_query_count:
+          type: integer
+          description: Total query operations in current month
+          example: 1000
+        monthly_update_count:
+          type: integer
+          description: Total update operations in current month
+          example: 1000
+        monthly_bandwidth_usage:
+          type: integer
+          description: Total bandwidth used in current month (bytes)
+          example: 7000
+        storage_usage:
+          type: integer
+          description: Current storage used (bytes)
+          example: 7000
+        monthly_cost:
+          type: number
+          format: float
+          description: Total cost in current month
+          example: 0.5
+        daily_update_requests:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Daily update requests over time
+          example: [{ "x": "2025-10-19 18:33:05.244068975 +0000 UTC", "y": 1 }]
+        daily_query_requests:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Daily query requests over time
+          example: [{ "x": "2025-10-19 18:33:05.244068975 +0000 UTC", "y": 7 }]
+        daily_bandwidths:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Daily bandwidth usage over time
+          example: [{ "x": "2025-10-19 18:33:05.244068975 +0000 UTC", "y": 7 }]
+        days:
+          type: array
+          items:
+            type: string
+          description: Days of the week for measurement
+          example: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday"]
+        query_throughput:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Query throughput over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 7 }]
+        update_throughput:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Update throughput over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 7 }]
+        query_latency_mean:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Average query latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        query_latency_99:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: 99th percentile query latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        update_latency_mean:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Average update latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        update_latency_99:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: 99th percentile update latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        embeds_latency_mean:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Average embedding latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        embeds_latency_99:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: 99th percentile embedding latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        vector_count:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Vector count over time
+          example: [{ "x": "2025-10-23 17:35:00.000 +0000 UTC", "y": 2 }]
+        data_size:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Data size over time
+          example: [{ "x": "2025-10-23 17:35:00.000 +0000 UTC", "y": 76 }]
+        daily_rerank_count:
+          type: integer
+          description: Total number of rerank operations executed today
+          example: 0
+        monthly_rerank_count:
+          type: integer
+          description: Total rerank operations in current month
+          example: 10
+        daily_rerank_requests:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Daily rerank requests over time
+          example: [{ "x": "2025-10-19 18:33:05.244068975 +0000 UTC", "y": 1 }]
+        rerank_latency_mean:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Average rerank latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+        rerank_latency_99:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: 99th percentile rerank latency over time
+          example: [{ "x": "2025-10-23 17:34:00.000 +0000 UTC", "y": 0 }]
+    SearchIndex:
+      type: object
+      properties:
+        customer_id:
+          type: string
+          description: The associated ID of the owner of the index
+          example: "example@upstash.com"
+        id:
+          type: string
+          format: uuid
+          description: Unique ID of the index
+          example: 99a4c327-31f0-490f-a594-043ade84085a
+        name:
+          type: string
+          description: Name of the search index
+          example: mySearchIndex
+        endpoint:
+          type: string
+          description: The REST endpoint of the index
+          example: glowing-baboon-15797-us1
+        type:
+          type: string
+          description: The payment plan of the index
+          enum: [free, payg, fixed]
+          example: "payg"
+        region:
+          type: string
+          description: The region where the index is currently deployed
+          enum: [eu-west-1, us-central1]
+          example: us-central1
+        vercel_email:
+          type: string
+          description: The email associated with Vercel integration, if any. Empty string otherwise.
+          example: example@vercel.com
+        token:
+          type: string
+          description: The REST authentication token for the index
+          example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
+        read_only_token:
+          type: string
+          description: The REST authentication read only token for the search index
+          example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
+        max_vector_count:
+          type: integer
+          description: Maximum number of vectors allowed in the index
+          example: 2000000
+        max_monthly_reranks:
+          type: integer
+          description: Maximum monthly rerank operations (-1 for unlimited)
+          example: -1
+        max_daily_updates:
+          type: integer
+          description: Maximum daily update operations (-1 for unlimited)
+          example: -1
+        max_daily_queries:
+          type: integer
+          description: Maximum daily query operations (-1 for unlimited)
+          example: -1
+        max_monthly_bandwidth:
+          type: integer
+          description: Maximum monthly bandwidth in bytes (-1 for unlimited)
+          example: -1
+        max_writes_per_second:
+          type: integer
+          description: Maximum write operations per second (rate limit)
+          example: 1000
+        max_query_per_second:
+          type: integer
+          description: Maximum query operations per second (rate limit)
+          example: 1000
+        max_reads_per_request:
+          type: integer
+          description: Maximum number of reads allowed per request
+          example: 100
+        max_writes_per_request:
+          type: integer
+          description: Maximum number of writes allowed per request
+          example: 100
+        creation_time:
+          type: integer
+          format: int64
+          description: Unix timestamp of creation
+          example: 1761200000
+        input_enrichment_enabled:
+          type: boolean
+          description: Whether input enrichment is enabled for this index
+          example: true
+        throughput_vector:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Throughput metrics over time
+          example: [{ "x": "2025-10-23 20:54:00.000 +0000 UTC", "y": 0 }]
+    GlobalStats:
+      type: object
+      properties:
+        record_count:
+          type: integer
+          description: Total number of indexed records across all indexes
+          example: 10
+        request:
+          type: integer
+          description: Total API requests count across all indexes
+          example: 10
+        bandwidth:
+          type: integer
+          description: Total bandwidth usage in bytes across all indexes
+          example: 750
+        storage:
+          type: integer
+          description: Total storage usage in bytes across all indexes
+          example: 950
+        billing:
+          type: number
+          format: float
+          description: Current billing amount across all indexes
+          example: 0.001
+        rerank_count:
+          type: integer
+          description: Total reranking operations count across all indexes
+          example: 0
+    QStashUser:
+      type: object
+      properties:
+        customer_id:
+          type: string
+          description: Customer identifier (email or team ID)
+          example: example@upstash.com
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the QStash user account
+          example: 99a4c327-31f0-490f-a594-043ade84085a
+        password:
+          type: string
+          description: QStash authentication password
+          example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
+        token:
+          type: string
+          description: Authentication token for QStash operations
+          example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
+        active:
+          type: boolean
+          description: Whether the QStash account is active
+          example: true
+        state:
+          type: string
+          description: Current state of the QStash account
+          enum: [active, passive]
+          example: active
+        last_plan_upgrade_time:
+          type: integer
+          format: int64
+          description: Unix timestamp of the last plan upgrade
+          example: 1761267303
+        max_message_size:
+          type: integer
+          description: Maximum message size in bytes
+          example: 52428800
+        max_requests_per_day:
+          type: integer
+          description: Soft limit for maximum requests per day
+          example: 1000000
+        max_requests_per_day_hard:
+          type: integer
+          description: Hard limit for maximum requests per day
+          example: 10000000
+        max_endpoints_per_topic:
+          type: integer
+          description: Maximum number of endpoints allowed per topic
+          example: 1000
+        max_requests_per_second:
+          type: integer
+          description: Maximum requests per second (rate limit)
+          example: 500
+        max_dlq_size:
+          type: integer
+          description: Maximum dead letter queue size
+          example: 2147483647
+        max_retries:
+          type: integer
+          description: Maximum number of retry attempts for failed messages
+          example: 20
+        max_topics:
+          type: integer
+          description: Maximum number of topics allowed
+          example: 1000
+        max_schedules:
+          type: integer
+          description: Maximum number of schedules allowed
+          example: 1000000
+        max_events_size:
+          type: integer
+          description: Maximum size for events
+          example: 100000
+        max_dlq_retention_time_milis:
+          type: integer
+          format: int64
+          description: Maximum retention time for dead letter queue in milliseconds
+          example: 2592000000
+        max_delay:
+          type: integer
+          description: Maximum delay for scheduled messages in seconds
+          example: 2147483647
+        max_parallelism:
+          type: integer
+          description: Maximum parallel processing per endpoint
+          example: 10
+        max_global_parallelism:
+          type: integer
+          description: Maximum global parallel processing across all endpoints
+          example: 200
+        max_queues:
+          type: integer
+          description: Maximum number of queues allowed
+          example: 1000
+        prod_pack_enabled:
+          type: boolean
+          description: Whether production pack features are enabled
+          example: false
+        timeout:
+          type: integer
+          description: Request timeout in seconds
+          example: 21600
+        type:
+          type: string
+          description: Account plan type
+          enum: [free, paid]
+          example: paid
+        reserved_type:
+          type: string
+          description: |
+            Indicates the reserved plan type for QStash.
+            If a credit card is attached, this field reflects the associated reserved plan.
+            If no credit card is added and the account is not on a pay-as-you-go plan, this field will be an empty string.
+          enum: [paid, qstash_enterprise_1m, qstash_enterprise_10m]
+          example: qstash_enterprise_1m
+        reserved_price:
+          type: number
+          format: float
+          description: Reserved plan price
+          example: 180
+        created_by:
+          type: string
+          description: Email of the user who created this account
+          example: example@upstash.com
+        creation_time:
+          type: integer
+          format: int64
+          description: Unix timestamp of account creation
+          example: 1760423113
+    QStashStats:
+      type: object
+      properties:
+        days:
+          type: array
+          items:
+            type: string
+          description: | 
+            Array of day names for the measurement period, typically representing all days in the current month.
+            This includes both past and future dates within the current month, so the array covers the entire month regardless of the current day.
+            Future days are included to align with other daily metrics arrays, allowing for consistent indexing.
+          example: ["Wednesday", "Thursday", "Friday", "Saturday", "Sunday", "Monday", "Tuesday"]
+        daily_requests:
+          type: array
+          items:
+            type: object
+            properties:
+              x:
+                type: string
+                description: Timestamp in UTC format
+                example: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y:
+                type: number
+                description: Total request count for this day
+                example: 0
+              workflow_message:
+                type: integer
+                description: Number of workflow messages for this day
+                example: 0
+              workflow_run:
+                type: integer
+                description: Number of workflow runs for this day
+                example: 0
+          description: Daily request metrics including workflow breakdowns
+          example: 
+            - x: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y: 0
+              workflow_message: 0
+              workflow_run: 0
+        daily_billings:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesData'
+          description: Daily billing amounts over time
+          example:
+            - x: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y: 0
+        daily_bandwidths:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesData'
+          description: Daily bandwidth usage over time
+          example:
+            - x: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y: 0
+        daily_used:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesData'
+          description: |
+            Request counts for the requested time period
+            If 1h is specified, it shows 60 data points for every 1 minute within the last 1 hour.
+          example:
+            - x: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y: 0
+        daily_used_workflow:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesData'
+          description: |
+            Workflow usage metrics for the requested time period
+            If 1h is specified, it shows 60 data points for every 1 minute within the last 1 hour.
+          example:
+            - x: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y: 0
+        daily_qstash_messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesWithId'
+          description: | 
+            QStash message counts broken down by metric identifier for the requested time period.
+            If 1h is specified, it shows 60 data points for every 1 minute within the last 1 hour.
+          example: [
+            {
+              id: "delivered",
+              data_points: [
+                { x: "2023-05-22 10:59:23.426 +0000 UTC", y: 320 },
+                { x: "2023-05-22 11:00:23.426 +0000 UTC", y: 450 },
+              ],
+            },
+          ]
+        daily_workflow_messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesWithId'
+          description: |
+            Workflow metrics broken down by metric identifier for the requested time period.
+            If 1h is specified, it shows 60 data points for every 1 minute within the last 1 hour.
+          example: [
+            {
+              id: "canceled",
+              data_points: [
+                { x: "2023-05-22 10:59:23.426 +0000 UTC", y: 320 },
+                { x: "2023-05-22 11:00:23.426 +0000 UTC", y: 450 },
+              ],
+            },
+          ]
+        dlq_message_count:
+          type: integer
+          description: Current number of messages in the dead letter queue
+          example: 0
+        daily_bandwidth_used:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeriesData'
+          description: | 
+            Bandwidth usage for the requested time period
+            If 1h is specified, it shows 60 data points for every 1 minute within the last 1 hour.
+          example:
+            - x: "2025-10-01 11:33:05.585757103 +0000 UTC"
+              y: 0
+        total_monthly_billing:
+          type: number
+          format: float
+          description: Total billing amount for the current month
+          example: 5.806
+    TimeSeriesWithId:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier for the time series data
+          example: "example_id"
+        data_points:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeriesData"
+          description: Data points for the time series
+          example:
+            [
+              { "x": "2023-05-22 10:59:23.426 +0000 UTC", "y": 320 },
+              { "x": "2023-05-22 11:00:23.426 +0000 UTC", "y": 450 },
+            ]
     CreateIndexRequest:
       type: object
       properties:

--- a/docs.json
+++ b/docs.json
@@ -1586,12 +1586,37 @@
                 "pages": [
                   "GET /vector/index",
                   "GET /vector/index/{id}",
+                  "GET /vector/index/{id}/stats",
+                  "GET /vector/index/stats",
                   "POST /vector/index",
                   "POST /vector/index/{id}/rename",
                   "POST /vector/index/{id}/reset-password",
                   "POST /vector/index/{id}/setplan",
                   "POST /vector/index/{id}/transfer",
                   "DELETE /vector/index/{id}"
+                ]
+              },
+              {
+                "group": "Search",
+                "pages": [
+                  "GET /search",
+                  "GET /search/{id}",
+                  "GET /search/stats",
+                  "GET /search/{id}/stats",
+                  "POST /search",
+                  "POST /search/{id}/reset-password",
+                  "POST /search/{id}/transfer",
+                  "POST /search/{id}/rename",
+                  "DELETE /search/{id}"
+                ]
+              },
+              {
+                "group": "QStash",
+                "pages": [
+                  "GET /qstash/user",
+                  "GET /qstash/stats",
+                  "POST /qstash/user/rotatetoken",
+                  "POST /qstash-upgrade"
                 ]
               },
               {


### PR DESCRIPTION
- Added QStash and Search Endpoints openapi documentation to developerAPI docs.
- Added stats endpoint for vector
- Changed vector transfer endpoint so that it does not say one can transfer to a personal account.

---
added endpoints
"GET /vector/index/{id}/stats"
"GET /vector/index/stats"
"GET /search",
"GET /search/{id}",
"GET /search/stats",
"GET /search/{id}/stats",
"POST /search",
"POST /search/{id}/reset-password",
"POST /search/{id}/transfer",
"POST /search/{id}/rename",
"DELETE /search/{id}"
"GET /qstash/user",
"GET /qstash/stats",
"POST /qstash/user/rotatetoken",
"POST /qstash-upgrade"
