### PR TITLE
Add QStash Prod Pack & Enterprise documentation

### DIFF
--- a/common/help/sla.mdx
+++ b/common/help/sla.mdx
@@ -4,7 +4,7 @@ title: Uptime SLA
 
 This Service Level Agreement ("SLA") applies to Upstash resources with the Prod Pack add-on or Enterprise plans. It is clarified that this SLA is subject to the [terms of the Agreement](https://upstash.com/trust/terms.pdf), and does not derogate therefrom (capitalized terms, unless otherwise indicated herein, have the meaning specified in the Agreement).
 
-To receive uptime SLA guarantees, you need to enable the Prod Pack add-on or be on an Enterprise plan for your resource. Learn more about [Prod Pack and Enterprise features](/redis/overall/enterprise).
+To receive uptime SLA guarantees, you need to enable the Prod Pack add-on or be on an Enterprise plan for your resource. Learn more about [Prod Pack and Enterprise features for Redis](/redis/overall/enterprise) or [QStash](/qstash/overall/enterprise).
 
 Upstash reserves the right to change the terms of this SLA by publishing updated
 terms on its website, such change to be effective as of the date of publication.
@@ -52,4 +52,4 @@ To receive uptime SLA guarantees for your resources, you need to upgrade to eith
 
 You can activate Prod Pack on the resource details page in the console. For Enterprise plans, contact [support@upstash.com](mailto:support@upstash.com).
 
-Learn more about [Prod Pack and Enterprise features](/redis/overall/enterprise).
+Learn more about [Prod Pack and Enterprise features for Redis](/redis/overall/enterprise) or [QStash](/qstash/overall/enterprise).

--- a/docs.json
+++ b/docs.json
@@ -965,6 +965,7 @@
                 "pages": [
                   "qstash/overall/getstarted",
                   "qstash/overall/pricing",
+                  "qstash/overall/enterprise",
                   "qstash/overall/apiexamples",
                   "qstash/overall/compare",
                   "qstash/overall/changelog",

--- a/qstash/overall/enterprise.mdx
+++ b/qstash/overall/enterprise.mdx
@@ -1,0 +1,51 @@
+---
+title: Prod Pack & Enterprise
+---
+
+Upstash has Prod Pack and Enterprise plans for customers with critical production workloads. Prod Pack and Enterprise plans include additional monitoring and security features in addition to higher capacity limits and more powerful resources.
+
+Prod Pack add-on is available for both pay-as-you-go and fixed-price plans. Enterprise plans are custom plans with additional features and higher limits.
+
+# Prod Pack Features
+Below features are included with Prod Pack.
+
+### Uptime SLA
+All Prod Pack accounts come with an SLA guaranteeing 99.99% uptime. For mission-critical messaging where uptime is crucial, we recommend Prod Pack plans. Learn more about [Uptime SLA](/common/help/sla).
+
+### SOC-2 Type 2 Report
+We have a SOC 2 Type 2 report available for our Prod Pack and Enterprise plans. You can request access to the report by contacting [support@upstash.com](mailto:support@upstash.com).
+
+### Prometheus Metrics
+
+Prometheus is an open-source monitoring system widely used for monitoring and alerting in cloud-native and containerized environments.
+
+Upstash Prod Pack and Enterprise plans offer Prometheus metrics collection, enabling you to monitor your QStash messages with Prometheus in addition to console metrics. Learn more about [Prometheus integration](/qstash/integrations/prometheus).
+
+### Datadog Integration
+
+Upstash Prod Pack and Enterprise plans include integration with Datadog, allowing you to monitor your QStash messages with Datadog in addition to console metrics. Learn more about [Datadog integration](/qstash/integrations/datadog).
+
+
+# Enterprise Features
+
+All Prod Pack features are included in the Enterprise plan. Additionally, Enterprise plans include:
+
+### 100M+ Messages Daily
+Enterprise plans support 100 million or more messages per day, suitable for high-volume production workloads.
+
+### Unlimited Bandwidth
+Enterprise plans include unlimited bandwidth, ensuring no data transfer limits for your messaging needs.
+
+### SAML SSO
+Single Sign-On (SSO) allows you to use your existing identity provider to authenticate users for your Upstash account. This feature is available upon request for Enterprise customers.
+
+### Professional Support with SLA
+Enterprise plans include access to our professional support with response time SLAs and priority access to our support team. Check out the [support page](/common/help/prosupport) for more details.
+
+### Dedicated Resources for Isolation
+Enterprise customers receive dedicated resources to ensure isolation and consistent performance for their messaging workloads.
+
+## How to Upgrade
+
+You can activate Prod Pack in the QStash settings page in the console. For the Enterprise plan, contact [support@upstash.com](mailto:support@upstash.com).
+

--- a/redis/overall/enterprise.mdx
+++ b/redis/overall/enterprise.mdx
@@ -16,7 +16,7 @@ Prod Pack are an add-on per database available to both pay-as-you-go and fixed-p
 These features are available on Prod Pack databases.
 
 ### Uptime SLA
-All Prod Pack databases come with an SLA guaranteeing 99.99% uptime. For mission-critical data where uptime is crucial, we recommend Prod Pack plans.
+All Prod Pack databases come with an SLA guaranteeing 99.99% uptime. For mission-critical data where uptime is crucial, we recommend Prod Pack plans. Learn more about [Uptime SLA](/common/help/sla).
 
 ### RBAC
 Role-Based Access Control (RBAC) is a security model that manages database access. You can create multiple users with different roles to control their actions on your databases.
@@ -30,11 +30,11 @@ We have a SOC 2 Type 2 report available for our Prod Pack and Enterprise plans. 
 
 Prometheus is an open-source monitoring system widely used for monitoring and alerting in cloud-native and containerized environments.
 
-Upstash Prod Pack and Enterprise plans offer Prometheus metrics collection, enabling you to monitor your Redis databases with Prometheus in addition to console metrics.
+Upstash Prod Pack and Enterprise plans offer Prometheus metrics collection, enabling you to monitor your Redis databases with Prometheus in addition to console metrics. Learn more about [Prometheus integration](/redis/integrations/prometheus).
 
 ### Datadog Integration
 
-Upstash Prod Pack and Enterprise plans include integration with Datadog, allowing you to monitor your Redis databases with Datadog in addition to console metrics.
+Upstash Prod Pack and Enterprise plans include integration with Datadog, allowing you to monitor your Redis databases with Datadog in addition to console metrics. Learn more about [Datadog integration](/redis/howto/datadog).
 
 ### More metrics on the Console
 


### PR DESCRIPTION
- Add new qstash/overall/enterprise.mdx documenting Prod Pack and Enterprise features
- Add QStash enterprise page to navigation in docs.json
- Update common/help/sla.mdx to reference QStash alongside Redis
- Add missing links to Redis enterprise.mdx (SLA, Prometheus, Datadog)