### PR TITLE
Remove connection limits from Redis pricing documentation

### DIFF
--- a/redis/overall/pricing.mdx
+++ b/redis/overall/pricing.mdx
@@ -22,18 +22,18 @@ For consistent loads with predictable costs.
 
 
 ## All Plans and Limits
-| Plan | Price | Read Region Price | Max Data Size | Max Bw GB Monthly | Max Req Per Sec | Max Request Size | Max Record | Max Connections | 
-| ---: | ---: | ---: | ---: | ---: |----------------:|-----------------:|-----------:|----------------:| 
-| Free | $0 | $0 | 256MB | 10G |             10000 |             10MB |      100MB |           10000 |  
-| Pay-as-you-go | $0 | $0 | 100GB | Unlimited |           10000 |             10MB |      100MB |           10000 | 
-| Fixed 250MB | $10 | $5 | 250MB | 50GB |           10000 |             10MB |      100MB |             10000 | 
-| Fixed 1GB | $20 | $10 | 1GB | 100GB |           10000 |             10MB |      200MB |            10000 | 
-| Fixed 5GB | $100 | $50 | 5GB | 500GB |           10000 |             20MB |      300MB |            10000 |
-| Fixed 10GB | $200 | $100 | 10GB | 1TB |           10000 |             30MB |      400MB |           10000 |
-| Fixed 50GB | $400 | $200 | 50GB | 5TB |           10000 |             50MB |      500MB |           10000 |
-| Fixed 100GB | $800 | $400 | 100GB | 10TB |           16000 |             75MB |        1GB |           10000 |
-| Fixed 500GB | $1500 | $750 | 500GB | 20TB |           16000 |            100MB |        5GB |          100000 |
-| Enterprise | Custom | Custom | 10TB | Unlimited |           Custom |            500MB |        5GB |          100000 |
+| Plan | Price | Read Region Price | Max Data Size | Max Bw GB Monthly | Max Req Per Sec | Max Request Size | Max Record |
+| ---: | ---: | ---: | ---: | ---: |----------------:|-----------------:|-----------:|
+| Free | $0 | $0 | 256MB | 10G |             10000 |             10MB |      100MB |
+| Pay-as-you-go | $0 | $0 | 100GB | Unlimited |           10000 |             10MB |      100MB |
+| Fixed 250MB | $10 | $5 | 250MB | 50GB |           10000 |             10MB |      100MB |
+| Fixed 1GB | $20 | $10 | 1GB | 100GB |           10000 |             10MB |      200MB |
+| Fixed 5GB | $100 | $50 | 5GB | 500GB |           10000 |             20MB |      300MB |
+| Fixed 10GB | $200 | $100 | 10GB | 1TB |           10000 |             30MB |      400MB |
+| Fixed 50GB | $400 | $200 | 50GB | 5TB |           10000 |             50MB |      500MB |
+| Fixed 100GB | $800 | $400 | 100GB | 10TB |           16000 |             75MB |        1GB |
+| Fixed 500GB | $1500 | $750 | 500GB | 20TB |           16000 |            100MB |        5GB |
+| Enterprise | Custom | Custom | 10TB | Unlimited |           Custom |            500MB |        5GB |
 
 
 ## Prod Pack
@@ -122,8 +122,6 @@ For each database the first 1GB is free. Beyond that, the storage cost is charge
 ### What happens when I hit limits on pay-as-you-go plan?
 For each limit exceeded, you will be notified via email. We will do our best to keep your database running but we may rate limit depending on the case.
 
-For concurrent connections, if you hit the limit, your database will start rejecting new connections. This can cause extra latency on your clients.
-
 For max request size, the requests exceeding the limit will be rejected with an exception.
 
 For max record size, the collection that exceeds the limit will stop accepting new records.
@@ -134,8 +132,6 @@ For bandwidth and storage, there are no limits but you can set a budget limit to
 For each limit exceeded, you will be notified via email.
 
 When your database hits the bandwidth and storage limits and if you have enabled auto-upgrade, your database will be upgraded to the one upper tier. When auto-upgrade is not enabled, your database will be rate limited which means your traffic will be blocked for bandwidth case, your write operations will be blocked for storage case.
-
-For concurrent connections, if you hit the limit, your database will start rejecting new connections. This can cause extra latency on your clients.
 
 For max request size, the requests exceeding the limit will be rejected with an exception.
 


### PR DESCRIPTION
Connection limits have been removed from all Redis plans. This update removes the Max Connections column from the pricing table and deletes references to concurrent connection limits from the FAQ sections.