### PR TITLE
Clarify backup operation warnings with specific unavailable operations

### DIFF
--- a/redis/features/backup.mdx
+++ b/redis/features/backup.mdx
@@ -7,7 +7,8 @@ You can create backups of your Redis database and restore them when needed. Back
 ## Creating a Backup
 
 <Info>
-  During the backup process, your database will be temporarily locked. Certain operations will be unavailable during this time.
+  During a backup operation, certain administrative operations will be temporarily unavailable: Backup operations, database config changes, plan and region setup, transferring database.
+  Regular Redis commands (GET, SET, etc.) are not blocked and continue to work normally.
 </Info>
 
 There are two ways to create a backup of your database:

--- a/redis/howto/migratefromregionaltoglobal.mdx
+++ b/redis/howto/migratefromregionaltoglobal.mdx
@@ -42,7 +42,8 @@ If your regional database is hosted in AWS, you can use Upstash's backup/restore
    - Wait for the backup process to complete
 
    <Info>
-     During backup creation, some database operations will be temporarily unavailable.
+     During a backup operation, certain administrative operations will be temporarily unavailable: Backup operations, database config changes, plan and region setup, transferring database.
+     Regular Redis commands (GET, SET, etc.) are not blocked and continue to work normally.
    </Info>
 
 2. Restore the backup to your global database:


### PR DESCRIPTION
## Summary
Updates backup warnings in Redis documentation to clearly specify which administrative operations are unavailable during backup operations and emphasize that regular Redis commands continue to work normally.

## Changes
- Updated warning in `redis/features/backup.mdx` (Backup/Restore section)
- Updated warning in `redis/howto/migratefromregionaltoglobal.mdx` (Migration guide)

## Details
The warnings now specify that during a backup operation, the following administrative operations are temporarily unavailable:
- Backup operations
- Database config changes
- Plan and region setup
- Transferring database

The warnings also explicitly state that regular Redis commands (GET, SET, etc.) are not blocked and continue to work normally during backup operations.