### PR TITLE
docs: fix grammar in workflow update description

### DIFF
--- a/workflow/howto/changes.mdx
+++ b/workflow/howto/changes.mdx
@@ -6,7 +6,7 @@ Workflows are composed of multiple steps. When you modify workflow code, it's im
 
 ## Issues
 
-You cannot change the step order of a existing workflow.
+You cannot change the step order of an existing workflow.
 
 If your code changes remove or reorder existing steps, in-progress workflows may attempt to continue from a point that no longer exists. This can lead to workflow failures, typically resulting in the following error:
 


### PR DESCRIPTION
Fixes a minor grammatical issue in the Upstash Workflow documentation.

### What changed?

Replaced “a existing” with “an existing” for correct article usage.

### Checklist

-  Documentation-only change

-  No functional or behavioral impact