### PR TITLE
Update migratefromregionaltoglobal.mdx

### DIFF
--- a/redis/howto/migratefromregionaltoglobal.mdx
+++ b/redis/howto/migratefromregionaltoglobal.mdx
@@ -24,15 +24,11 @@ Before starting the migration, make sure you have:
 
 ## Migration Process
 
-There are several official ways to migrate your data:
+You can migrate your data without leaving Upstash Console:
 
    <Warning>
      If you are using RBAC, please note that they are not migrated automatically. You need to redefine ACL users for new the global database after migration.
    </Warning>
-
-### 1. Using Backup/Restore (Recommended for AWS Regional Databases)
-
-If your regional database is hosted in AWS, you can use Upstash's backup/restore feature:
 
 1. Create a backup of your regional database:
    - Go to your regional database details page
@@ -57,20 +53,6 @@ If your regional database is hosted in AWS, you can use Upstash's backup/restore
    <Warning>
      The restore operation will flush (delete) all existing data in your (destination) global database before restoring the backup.
    </Warning>
-
-### 2. Using Upstash Console Migration Wizard
-
-The easiest way to migrate your data is using the Upstash Console's built-in migration wizard:
-
-1. Go to [Upstash Console](https://console.upstash.com)
-2. In the database list page, click the `Import` button
-3. Select your source (regional) database
-4. Select your destination (global) database
-5. Follow the wizard instructions to complete the migration
-
-<Info>
-  Note: The destination database will be flushed before migration starts.
-</Info>
 
 ## Verification
 


### PR DESCRIPTION
cleanup: 
- remove the second option which was the same as option one. 
- Also we support backups on GCP now too, so removed AWS specific wording