### PR TITLE
fix: improve prosupport page image display

### DIFF
--- a/common/help/prosupport.mdx
+++ b/common/help/prosupport.mdx
@@ -36,7 +36,9 @@ As a Professional Support Customer, below are the **two methods** to reach out t
 #### Starting a Chat
 You will see a chatbox on the bottom right when viewing Upstash console, docs and website. Once you initiate a chat, Professional Support customers will be prompted to select a severity level:
 
-<img noZoom width="300" height="100" src="/img/pro-support/image.png" />
+<Frame>
+  <img src="/img/pro-support/image.png" width="400" />
+</Frame>
 
 <Note>
 To be able to see these options in chat, remember to sign into your Upstash Account first.


### PR DESCRIPTION
## Summary
Improves the image display on the Professional Support page by:
- Wrapping the image in a `<Frame>` component for consistent styling
- Increasing the width from 300px to 400px for better readability
- Removing the fixed height constraint to allow proper proportional scaling
- Removing `noZoom` to allow users to click/zoom if needed

This fixes the tiny image that was hard to see on the prosupport page.