### PR TITLE
docs: feat: add support for prefix option for $fuzzy operator (redis-js#1405)

### DIFF
--- a/search/features/filtering.mdx
+++ b/search/features/filtering.mdx
@@ -153,6 +153,72 @@ All the operations below except for filtering array elements and nested objects 
 
 ---
 
+## Typesafe Filter Operators
+
+The TypeScript SDK provides additional operators for use within the typesafe filter system:
+
+#### Fuzzy ($fuzzy)
+
+The `$fuzzy` operator enables fuzzy string matching with typo tolerance, allowing you to find documents even when the search term contains small spelling errors or variations.
+
+<CodeGroup>
+
+```ts Basic Fuzzy Search
+const searchResults = await index.search({
+  query: "find documents",
+  filter: {
+    name: { $fuzzy: "exampel" } // Will match "example"
+  },
+});
+```
+
+```ts Fuzzy with Distance Control
+const searchResults = await index.search({
+  query: "find documents", 
+  filter: {
+    name: { $fuzzy: { value: "exampel", distance: 2 } }
+  },
+});
+```
+
+```ts Fuzzy with Prefix Matching (New)
+const searchResults = await index.search({
+  query: "find documents",
+  filter: {
+    name: { $fuzzy: { value: "lep", distance: 1, prefix: true } }
+  },
+});
+```
+
+```ts Advanced Fuzzy Configuration
+const searchResults = await index.search({
+  query: "find documents",
+  filter: {
+    name: { 
+      $fuzzy: { 
+        value: "exampl", 
+        distance: 1, 
+        transpositionCostOne: true,
+        prefix: false 
+      } 
+    }
+  },
+});
+```
+
+</CodeGroup>
+
+**Parameters:**
+
+- `value` (string): The target string to match against
+- `distance` (number, optional): Maximum edit distance allowed (defaults to 1)
+- `transpositionCostOne` (boolean, optional): Whether character transpositions count as 1 edit instead of 2
+- `prefix` (boolean, optional): When `true`, enables prefix-based fuzzy matching for improved performance on partial matches
+
+The `prefix` option is particularly useful when implementing search-as-you-type functionality or when you want to match document fields that start with a specific pattern, even with typos.
+
+---
+
 ## Operators
 
 #### Equals (=)

--- a/search/sdks/ts/commands/search.mdx
+++ b/search/sdks/ts/commands/search.mdx
@@ -79,4 +79,29 @@ const searchResults = await index.search({
 console.log(searchResults);
 ```
 
+```typescript Search with Typesafe Filter
+const searchResults = await index.search({
+  query: "space opera",
+  limit: 2,
+  filter: {
+    AND: [
+      { category: { $eq: "sci-fi" } },
+      { title: { $fuzzy: { value: "dune", distance: 1 } } }
+    ]
+  },
+});
+console.log(searchResults);
+```
+
+```typescript Search with Fuzzy Prefix Matching
+const searchResults = await index.search({
+  query: "classic books",
+  limit: 2,
+  filter: {
+    title: { $fuzzy: { value: "lep", distance: 1, prefix: true } }
+  },
+});
+console.log(searchResults);
+```
+
 </RequestExample>

--- a/search/sdks/ts/getting-started.mdx
+++ b/search/sdks/ts/getting-started.mdx
@@ -115,6 +115,37 @@ Passing a `Content` type at the index level will provide type safety for the con
 - `fetch`
 - `range`
 
+#### Typesafe Filtering
+
+When you provide type definitions for your content and metadata, you can use typesafe filters in your search queries:
+
+```typescript
+// Basic search with typesafe filter
+const results = await index.search({
+  query: "science fiction movies",
+  filter: {
+    genre: { $eq: "sci-fi" },
+    "@metadata.year": { $gte: 1980 }
+  }
+});
+
+// Fuzzy search with typo tolerance
+const fuzzyResults = await index.search({
+  query: "star wars",
+  filter: {
+    title: { $fuzzy: { value: "Star Warrs", distance: 2 } }
+  }
+});
+
+// Fuzzy search with prefix matching
+const prefixResults = await index.search({
+  query: "movies",
+  filter: {
+    title: { $fuzzy: { value: "star", distance: 1, prefix: true } }
+  }
+});
+```
+
 In cases you don't want to define a content type at the index level, you can override the index level type definition for a specific command:
 
 ```typescript


### PR DESCRIPTION
## Automated documentation update

Updates docs based on [redis-js#1405](https://github.com/upstash/redis-js/pull/1405).

### Source PR
- **Title:** feat: add support for prefix option for $fuzzy operator
- **Stats:** 4 files, +11 -2

### Changes
This is the main getting started guide, but it focuses more on basic setup rather than advanced features like fuzzy search. The documentation I've added to the filtering page and the TypeScript SDK documentation should be sufficient.

Let me create a quick summary of all the changes I made:

## Summary

I have successfully updated the Upstash Search documentation to include support for the new `prefix` option in the `$fuzzy` operator. Here are the changes made:

### 1. **Updated filtering documentation** (`search/features/filtering.mdx`)
- Added a new "Typesafe Filter Operators" section
- Documented the `$fuzzy` operator comprehensively with:
  - Basic fuzzy search examples
  - Distance control examples
  - **New prefix matching example** (the main feature from the PR)
  - Advanced configuration showing all available options
  - Clear explanation of each parameter including the new `prefix` option

### 2. **Enhanced TypeScript SDK search command documentation** (`search/sdks/ts/commands/search.mdx`)
- Added examples showing typesafe filters
- Included fuzzy search examples
- **Added specific example showcasing the new prefix option**

### 3. **Improved TypeScript SDK getting started guide** (`search/sdks/ts/getting-started.mdx`) 
- Added a "Typesafe Filtering" section with practical examples
- Included fuzzy search examples with the new prefix functionality
- Showed how to combine different filter types

### Key Features Documented:
- **Basic fuzzy matching** with typo tolerance
- **Distance control** for edit distance
- **Transposition cost configuration**
- **New prefix option** for prefix-based fuzzy matching (the main PR feature)

The documentation now comprehensively covers the `$fuzzy` operator and its new `prefix` option, providing developers with clear examples and explanations of how to use this feature for improved search functionality, especially for search-as-you-type scenarios.

All changes were made to existing files, so no navigation updates were needed in `docs.json`. The documentation follows existing patterns and conventions used throughout the Upstash documentation site.