### PR TITLE
docs: add support for prefix option for $fuzzy operator (redis-js#1405)

### DIFF
--- a/search/features/filtering.mdx
+++ b/search/features/filtering.mdx
@@ -151,6 +151,91 @@ const searchResults = await index.search({
 
 All the operations below except for filtering array elements and nested objects are supported in the typesafe filters.
 
+### Fuzzy Matching ($fuzzy)
+
+The `$fuzzy` operator enables typo-tolerant text matching using [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). This is particularly useful for handling user input that may contain spelling errors or typos.
+
+<Note>
+  The `$fuzzy` operator is only available in TypeScript SDK typesafe filters. It is not supported in SQL-style filter strings.
+</Note>
+
+You can use `$fuzzy` in three ways:
+
+<CodeGroup>
+
+```ts Simple String
+// Shorthand: uses default distance of 1
+const searchResults = await index.search({
+  query: "products",
+  filter: {
+    name: { $fuzzy: "leptop" } // matches "laptop" with 1 edit
+  },
+});
+```
+
+```ts With Distance
+// Specify maximum Levenshtein distance
+const searchResults = await index.search({
+  query: "products",
+  filter: {
+    name: { 
+      $fuzzy: { 
+        value: "leptop", 
+        distance: 2 // allows up to 2 character edits
+      } 
+    }
+  },
+});
+```
+
+```ts With Prefix Mode
+// Enable prefix matching for autocomplete-style searches
+const searchResults = await index.search({
+  query: "products",
+  filter: {
+    name: { 
+      $fuzzy: { 
+        value: "lap", 
+        distance: 1,
+        prefix: true // matches "laptop", "lapel", etc.
+      } 
+    }
+  },
+});
+```
+
+```ts Advanced Options
+// All available options
+const searchResults = await index.search({
+  query: "products",
+  filter: {
+    name: { 
+      $fuzzy: { 
+        value: "leptop",
+        distance: 2, // max edit distance (default: 1)
+        transpositionCostOne: true, // count transpositions as 1 edit (default: false)
+        prefix: true // enable prefix matching (default: false)
+      } 
+    }
+  },
+});
+```
+
+</CodeGroup>
+
+**Parameters:**
+
+- `value` (string, required): The text to match against
+- `distance` (number, optional): Maximum Levenshtein distance allowed. Defaults to 1
+- `transpositionCostOne` (boolean, optional): When `true`, character transpositions (e.g., "laptop" → "latpop") count as 1 edit instead of 2. Defaults to `false`
+- `prefix` (boolean, optional): When `true`, enables prefix matching mode where the query acts as a prefix. Useful for autocomplete scenarios. Defaults to `false`
+
+**Common Use Cases:**
+
+- **Typo tolerance**: Handle common spelling mistakes in search queries
+- **Autocomplete**: Use `prefix: true` for real-time search suggestions
+- **Fuzzy search**: Find similar terms even with character variations
+
 ---
 
 ## Operators


### PR DESCRIPTION
## Automated documentation update

Updates docs based on [redis-js#1405](https://github.com/upstash/redis-js/pull/1405).

### Source PR
- **Title:** feat: add support for prefix option for $fuzzy operator
- **Stats:** 4 files, +11 -2
