### PR TITLE
docs: add support for prefix option for $fuzzy operator (redis-js#1405)

### DIFF
--- a/search/features/filtering.mdx
+++ b/search/features/filtering.mdx
@@ -149,7 +149,7 @@ const searchResults = await index.search({
 </CodeGroup>
 
 
-All the operations below except for filtering array elements and nested objects are supported in the typesafe filters.
+All the operations below except for filtering array elements and nested objects are supported in the typesafe filters. Additionally, there are [TypeSafe-only operators](#typesafe-only-operators-typescript) that are exclusively available in the TypeScript SDK.
 
 ---
 
@@ -346,6 +346,65 @@ The `has not field` operator filters content which do not have the given JSON fi
 ```SQL
 HAS NOT FIELD geography.coordinates.longitude
 ```
+
+---
+
+## TypeSafe-Only Operators (TypeScript)
+
+The following operators are only available when using TypeSafe filters in the TypeScript SDK.
+
+#### Fuzzy
+
+The `fuzzy` operator filters content using fuzzy matching, which allows for typo tolerance and approximate string matching. This is particularly useful for handling user input with spelling errors.
+
+It is applicable to _string_ values in TypeSafe filters.
+
+The fuzzy operator accepts an object with the following properties:
+
+- `value` (string, required): The string to match against
+- `distance` (number, optional): The maximum edit distance (Levenshtein distance) allowed. Common values are 1 or 2.
+- `transpositionCostOne` (boolean, optional): Whether transpositions (adjacent character swaps) count as a single edit operation. Defaults to `false`.
+- `prefix` (boolean, optional): When enabled, matches strings that start with the fuzzy-matched value. Useful for prefix-based searches with typo tolerance.
+
+<CodeGroup>
+
+```ts Basic Fuzzy Matching
+const searchResults = await index.search({
+  query: "search query",
+  filter: {
+    name: { $fuzzy: "Jon" } // Matches "John", "Joan", etc.
+  }
+});
+```
+
+```ts Fuzzy with Distance
+const searchResults = await index.search({
+  query: "search query",
+  filter: {
+    name: { $fuzzy: { value: "Jon", distance: 1 } } // Matches with 1 character difference
+  }
+});
+```
+
+```ts Fuzzy with Transposition
+const searchResults = await index.search({
+  query: "search query",
+  filter: {
+    name: { $fuzzy: { value: "Jon", distance: 1, transpositionCostOne: true } }
+  }
+});
+```
+
+```ts Fuzzy with Prefix
+const searchResults = await index.search({
+  query: "search query",
+  filter: {
+    name: { $fuzzy: { value: "lep", distance: 1, prefix: true } } // Matches strings like "leopard", "lepton" with 1 edit
+  }
+});
+```
+
+</CodeGroup>
 
 ---
 


### PR DESCRIPTION
## Automated documentation update

Updates docs based on [redis-js#1405](https://github.com/upstash/redis-js/pull/1405).

### Source PR
- **Title:** feat: add support for prefix option for $fuzzy operator
- **Stats:** 4 files, +11 -2
