### PR TITLE
docs: add support for prefix option for $fuzzy operator (redis-js#1405)

### DIFF
--- a/search/features/filtering.mdx
+++ b/search/features/filtering.mdx
@@ -287,6 +287,50 @@ country = 'Germany' OR country = 'Turkey' OR country = 'France'
 
 ---
 
+#### Fuzzy
+
+The `fuzzy` operator filters content whose values match the given string with typo tolerance. This is useful for handling misspellings and variations in text.
+
+It is applicable to _string_ values.
+
+The fuzzy operator supports the following options:
+
+- `value`: The search string (required)
+- `distance`: Edit distance tolerance (optional, defaults to the system setting). Controls how many character differences are allowed.
+- `transpositionCostOne`: Whether character transpositions (swapping adjacent characters) cost 1 edit distance instead of 2 (optional, defaults to false).
+- `prefix`: Whether to match by prefix, allowing the value to match the beginning of words (optional, defaults to false).
+
+<Tabs>
+<Tab title="String">
+```SQL
+product_name = {$fuzzy: 'laptop'}
+```
+</Tab>
+<Tab title="With options">
+```SQL
+product_name = {$fuzzy: {value: 'laptop', distance: 1}}
+```
+</Tab>
+<Tab title="With prefix matching">
+```SQL
+product_name = {$fuzzy: {value: 'lap', distance: 1, prefix: true}}
+```
+</Tab>
+<Tab title="TypeScript">
+```ts
+const results = await index.search({
+  query: "search term",
+  limit: 10,
+  filter: {
+    product_name: { $fuzzy: { value: "laptop", distance: 1, prefix: true } }
+  }
+});
+```
+</Tab>
+</Tabs>
+
+---
+
 #### Not In
 
 The `not in` operator filters content whose values are not equal to any of the given literals.

--- a/search/sdks/ts/commands/search.mdx
+++ b/search/sdks/ts/commands/search.mdx
@@ -79,4 +79,26 @@ const searchResults = await index.search({
 console.log(searchResults);
 ```
 
+```typescript Search with Fuzzy Filter (Typo Tolerance)
+const searchResults = await index.search({
+  query: "space opera",
+  limit: 2,
+  filter: {
+    title: { $fuzzy: { value: "spcae", distance: 1 } }
+  }
+});
+console.log(searchResults);
+```
+
+```typescript Search with Fuzzy Prefix Filter
+const searchResults = await index.search({
+  query: "space",
+  limit: 2,
+  filter: {
+    author: { $fuzzy: { value: "smi", prefix: true } }
+  }
+});
+console.log(searchResults);
+```
+
 </RequestExample>


### PR DESCRIPTION
## Automated documentation update

Updates docs based on [redis-js#1405](https://github.com/upstash/redis-js/pull/1405).

### Source PR
- **Title:** feat: add support for prefix option for $fuzzy operator
- **Stats:** 4 files, +11 -2
