### PR TITLE
Update eviction policy link to latest Redis documentation

### DIFF
--- a/redis/features/eviction.mdx
+++ b/redis/features/eviction.mdx
@@ -27,7 +27,7 @@ cache to adapt to evolving data needs while maintaining optimal performance.
 Upstash currently uses a single eviction algorithm, called
 **optimistic-volatile**, which is a combination of _volatile-random_ and
 _allkeys-random_ eviction policies available in
-[the original Redis](https://redis.io/docs/manual/eviction/#eviction-policies).
+[the original Redis](https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/).
 
 Initially, Upstash employs random sampling to select keys for eviction, giving
 priority to keys marked with a TTL (expire field). If there is a shortage of


### PR DESCRIPTION
The previous link on eviction notice returned a 404, this PR updates it with the latest link from Redis docs.