### PR TITLE
Fix npm package linking in overview.mdx

### DIFF
--- a/redis/sdks/ratelimit-ts/overview.mdx
+++ b/redis/sdks/ratelimit-ts/overview.mdx
@@ -4,7 +4,7 @@ title: Overview
 
 # Upstash Rate Limit
 
-[![npm (scoped)](https://img.shields.io/npm/v/@upstash/ratelimit)](https://www.npmjs.com/package/ratelimit)
+[![npm (scoped)](https://img.shields.io/npm/v/@upstash/ratelimit)](https://www.npmjs.com/package/@upstash/ratelimit)
 
 It is the only connectionless (HTTP based) rate limiting library and designed
 for:


### PR DESCRIPTION
FIXED: npm package was linked to ratelimit package instead of @upstash/ratelimit