### PR TITLE
Fix QStash Redirects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1978,14 +1978,6 @@
       "destination": "/workflow/api-reference/:slug*"
     },
     {
-      "source": "/qstash/api-reference/:slug*",
-      "destination": "/qstash/api/authentication"
-    },
-    {
-      "source": "/workflow/api-reference/:slug*",
-      "destination": "/workflow/getstarted"
-    },
-    {
       "source": "/box/sdks/ts/getting-started",
       "destination": "/box/overall/quickstart"
     },


### PR DESCRIPTION
It seems, I broke the Rest API in https://github.com/upstash/docs/pull/669 All Rest API links are being redirected to
https://upstash.com/docs/workflow/getstarted or
https://upstash.com/docs/qstash/api/authentication

I am removing redirects back. This will introduce broken links. I am waiting for the mintlify team to respond to fix it.