### PR TITLE
docs(qstash): note queue parallelism must be greater than 0

### DIFF
--- a/qstash/openapi.yaml
+++ b/qstash/openapi.yaml
@@ -1393,8 +1393,9 @@ paths:
                 parallelism:
                   type: integer
                   default: 1
+                  minimum: 1
                   description: |
-                    The number of parallel consumers consuming from the queue
+                    The number of parallel consumers consuming from the queue. Must be greater than 0.
       responses:
         '200':
           description: Queue created or updated successfully


### PR DESCRIPTION
## Summary
- Add `minimum: 1` constraint and clarify in the description that queue `parallelism` must be greater than 0 in the QStash OpenAPI upsert-queue endpoint.

## Test plan
- [x] Verify the OpenAPI schema renders correctly in the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)