### PR TITLE
docs: deprecate Heroku and DigitalOcean marketplace integrations

### DIFF
--- a/_snippets/faq-snippet.mdx
+++ b/_snippets/faq-snippet.mdx
@@ -24,7 +24,7 @@ Yes, Upstash is compatible Redis client protocol.
 
 ## Which cloud providers do you support?
 
-Initially we have AWS and GCP. Digital Ocean is planned.
+Upstash Redis supports AWS and GCP regions.
 
 ## Which regions do you support in AWS?
 

--- a/_snippets/faq-snippet.mdx
+++ b/_snippets/faq-snippet.mdx
@@ -24,7 +24,7 @@ Yes, Upstash is compatible Redis client protocol.
 
 ## Which cloud providers do you support?
 
-Upstash Redis supports AWS and GCP regions.
+Upstash Redis is available on AWS, GCP and Fly.io.
 
 ## Which regions do you support in AWS?
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14933,7 +14933,7 @@ Yes, Upstash is compatible Redis client protocol.
 
 ## Which cloud providers do you support?
 
-Initially we have AWS and GCP. Digital Ocean is planned.
+Upstash Redis supports AWS and GCP regions.
 
 ## Which regions do you support in AWS?
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14933,7 +14933,7 @@ Yes, Upstash is compatible Redis client protocol.
 
 ## Which cloud providers do you support?
 
-Upstash Redis supports AWS and GCP regions.
+Upstash Redis is available on AWS, GCP and Fly.io.
 
 ## Which regions do you support in AWS?
 

--- a/redis/help/faq.mdx
+++ b/redis/help/faq.mdx
@@ -26,7 +26,7 @@ Yes, Upstash is compatible Redis client protocol.
 
 ## Which cloud providers do you support?
 
-Initially we have AWS and GCP. Digital Ocean is planned.
+Upstash Redis supports AWS and GCP regions.
 
 ## Which regions do you support in AWS?
 

--- a/redis/help/faq.mdx
+++ b/redis/help/faq.mdx
@@ -26,7 +26,7 @@ Yes, Upstash is compatible Redis client protocol.
 
 ## Which cloud providers do you support?
 
-Upstash Redis supports AWS and GCP regions.
+Upstash Redis is available on AWS, GCP and Fly.io.
 
 ## Which regions do you support in AWS?
 

--- a/redis/quickstarts/digitalocean.mdx
+++ b/redis/quickstarts/digitalocean.mdx
@@ -6,10 +6,16 @@ title: "DigitalOcean"
   file="redis/start-redis-snippet.mdx"
 />
 
-<Info>
-  Upstash has native integration with [DigitalOcean Add-On
-  Marketplace](https://marketplace.digitalocean.com/add-ons/upstash-redis).
-</Info>
+<Warning>
+  Upstash Redis on DigitalOcean is deprecated and will be permanently shut down
+  on **August 31, 2026**. After this date, DigitalOcean-created Upstash Redis
+  databases will no longer be available or supported.
+
+  To continue operating without interruption, migrate to a standard Upstash
+  Redis database before the shutdown date. Migration is based on RDB
+  export/import, and billing will move from DigitalOcean to Upstash after you
+  create and use the new database.
+</Warning>
 
 This quickstart shows how to create an Upstash for Redis® Database from
 DigitalOcean Add-On Marketplace.

--- a/workflow/quickstarts/astro.mdx
+++ b/workflow/quickstarts/astro.mdx
@@ -166,7 +166,7 @@ When deploying your Astro app with Upstash Workflow to production, there are a f
 
 2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
 
-3. **Deployment**: Deploy your Astro app to production as you normally would, for example to Vercel, Heroku, or AWS.
+3. **Deployment**: Deploy your Astro app to production as you normally would, for example to Vercel or AWS.
 
 4. **Verify Workflow Endpoint**: After deployment, verify that your workflow endpoint is accessible by making a POST request to your production URL:
 

--- a/workflow/quickstarts/express.mdx
+++ b/workflow/quickstarts/express.mdx
@@ -171,7 +171,7 @@ When deploying your Hono app with Upstash Workflow to production, there are a fe
 
 2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
 
-3. **Deployment**: Deploy your Express.js app to production as you normally would, for example to fly.io, Heroku, or AWS.
+3. **Deployment**: Deploy your Express.js app to production as you normally would, for example to fly.io or AWS.
 
 4. **Verify Workflow Endpoint**: After deployment, verify that your workflow endpoint is accessible by making a POST request to your production URL:
 


### PR DESCRIPTION
## Summary
- remove Heroku references from docs examples
- add a DigitalOcean deprecation warning to the existing Redis quickstart
- clean up stale Redis FAQ cloud-provider wording and regenerate llms-full.txt

## Verification
- npm run check (from llms/)
- git diff --check HEAD~1..HEAD
- rg -n -i "heroku|Digital Ocean is planned|Initially we have|Upstash has native integration with" .
- curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3333/redis/quickstarts/digitalocean
- curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3333/redis/help/faq