### PR TITLE
improve Redis discoverability and clean up compatibility page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -75,7 +75,7 @@
                 "pages": [
                   "redis/overall/getstarted",
                   "redis/overall/pricing",
-                  "redis/overall/rediscompatibility",
+                  "redis/overall/compatibility",
                   "redis/overall/changelog",
                   "redis/overall/usecases",
                   "redis/overall/compare",
@@ -1890,6 +1890,14 @@
     ]
   },
   "redirects": [
+    {
+      "source": "/redis/overall/rediscompatibility",
+      "destination": "/redis/overall/compatibility"
+    },
+    {
+      "source": "/docs/redis/overall/rediscompatibility",
+      "destination": "/redis/overall/compatibility"
+    },
     {
       "source": "/box/overall/stream",
       "destination": "/box/overall/agent"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15208,7 +15208,7 @@ Upstash works for all the common usecases for Redis®. You can use Upstash in yo
 
 ## Do you support all Redis® API?
 
-Most of them. See [Redis® API Compatibility](/docs/redis/overall/rediscompatibility) for the list of supported commands.
+Most of them. See [Redis® API Compatibility](/docs/redis/overall/compatibility) for the list of supported commands.
 
 ## Can I use any Redis client?
 
@@ -17318,6 +17318,10 @@ output = result.get(timeout=10)
 print(f"Task result: {output}")  # Outputs '10'
 ```
 
+## Billing Optimization
+
+Celery workers poll Redis continuously, even when there is no queue activity. This can incur extra costs because Upstash charges per request on the Pay-As-You-Go plan. With [our Fixed plans](/docs/redis/overall/pricing#all-plans-and-limits), **we recommend switching to a Fixed plan to avoid increased command count and high costs in Celery use cases.**
+
 ## Conclusion
 
 To see a more detailed example of using Celery with Upstash Redis, check out the [Job Processor with Celery example](https://upstash.com/examples/jobprocessorwithcelery) on our website.
@@ -18160,6 +18164,10 @@ In this section, we will compare Upstash with alternative cloud based solutions.
   functions at Cloudflare Workers.
 * **Durability:** Upstash persists your data to the block storage instantly in
   addition to the memory, so you can use it as your primary database.
+* **Full-text search:** Upstash offers [Upstash Redis Search](/docs/redis/search/introduction), a fast
+  Tantivy-based full-text search extension that works with JSON, Hashes, and Strings out of the box
+  and stays automatically in sync as you write.
+* **JSON:** Upstash supports the `JSON.*` commands natively. See [compatibility](/docs/redis/overall/compatibility).
 
 ## AWS DynamoDB
 
@@ -18231,14 +18239,13 @@ traffic?**
 Most of the serverless products start to lose their spell if the service
 receives steady and high traffic as it starts to cost higher than
 server/instance based pricing models. To overcome this situation we give you
-option to purchase Pro Plan. In Pro plan you can set fixed
-price per month with a restriction on max throughput and data size. For high and
-steady throughput use cases, enterprise databases cost less than serverless one.
+the option to switch to a [Fixed plan](/docs/redis/overall/pricing). On a Fixed plan you set a
+fixed price per month with a restriction on max throughput and data size. For high and
+steady throughput use cases, Fixed plans cost less than pay-as-you-go.
 The good thing is you can start your database with pay-as-you-go pricing and
-move it enterprise when you want. See [enterprise plans](/docs/redis/overall/enterprise) for more
-information.
+move to a Fixed plan when you want. See [pricing](/docs/redis/overall/pricing) and [enterprise plans](/docs/redis/overall/enterprise) for more information.
 
-Even if you choose not to upgrade to the Pro plan, Upstash guarantees
+Even if you choose not to upgrade to a Fixed plan, Upstash guarantees
 transparent billing without any unexpected surprises. Each Upstash database has
 a predefined monthly maximum price, known as the "Ceiling Price." For
 pay-as-you-go (PAYG) databases, this ceiling price is set at \$360 per month.
@@ -18246,184 +18253,27 @@ Therefore, even if your application experiences a significant surge in traffic,
 such as reaching the front page of HackerNews, your Upstash database will not
 exceed a maximum cost of \$360 per month.
 
-# Prod Pack & Enterprise
-Source: https://upstash.com/docs/redis/overall/enterprise
-
-Upstash has Prod Pack and Enterprise plans for customers with critical production workloads. Prod Pack and Enterprise plans include additional monitoring and security features in addition to higher capacity limits and more powerful resources
-
-Prod Pack -> Per database
-
-Enterprise contract -> Per account
-
-Prod Pack are an add-on per database available to both pay-as-you-go and fixed-price plans, not per account. You can have databases on different plans in the same account and each is charged separately. Meanwhile, Enterprise plans are per account, not per database. All of your databases can be included in the same Enterprise plan covering all of your databases.
-
-All features of Prod Pack and Enterprise plan for Upstash Redis are detailed below.
-
-## How to Upgrade
-
-You can activate Prod Pack on the database details page in the [Upstash Console](https://upstash.com/dashboard/redis). For the Enterprise plan, please create a request through the or contact [support@upstash.com](mailto:support@upstash.com).
-
-# Prod Pack Features
-These features are available on databases with Prod Pack.
-
-### Uptime SLA
-All Prod Pack databases come with an SLA guaranteeing 99.99% uptime. For mission-critical data where uptime is crucial, we recommend Prod Pack plans. Learn more about [Uptime SLA](/docs/common/help/sla).
-
-### SOC-2 Type 2 Compliance & Report
-SOC-2 Type 2 controls apply at the platform level. Prod Pack adds customer-facing compliance support, including SOC-2 report access, contractual commitments, and audit-ready features such as encryption at rest, credential protection, and advanced monitoring. Once enabled, you can request the report through the [Upstash Trust Center](https://trust.upstash.com/) or by contacting [support@upstash.com](mailto:support@upstash.com).
-
-### Multi-Zone High Availability
-
-With Prod Pack add-on, regions of your database are deployed with [multi-zone high availability](/docs/redis/features/replication#high-availability). If one replica or availability zone fails, another replica in a different zone continues serving traffic in the same region. This ensures that your database remains available without any additional latency.
-
-### More Backup Capability
-
-Backups up to 3 days are possible with the Prod Pack add-on.
-
-### Encryption at Rest
-
-Encrypts the block storage where your data is persisted and stored.
-
-### Prometheus Metrics
-
-Prometheus is an open-source monitoring system widely used for monitoring and alerting in cloud-native and containerized environments.
-
-Upstash Prod Pack and Enterprise plans offer Prometheus metrics collection, enabling you to monitor your Redis databases with Prometheus in addition to console metrics. Learn more about [Prometheus integration](/docs/redis/integrations/prometheus).
-
-### Datadog Integration
-
-Upstash Prod Pack and Enterprise plans include integration with Datadog, allowing you to monitor your Redis databases with Datadog in addition to console metrics. Learn more about [Datadog integration](/docs/redis/howto/datadog).
-
-### More metrics on the Console
-
-Max interval of the metrics that are available on the Upstash Console increases from one week to one month for databases with Prod Pack.
-
-# Enterprise Features
-
-All Prod Pack features are included in the Enterprise plan. Additionally, Enterprise plans include:
-
-### Custom Limits
-Get a custom-tailored plan for your Upstash Redis databases to handle the growing demands of your business at any scale, such as 100K+ commands per second, unlimited bandwidth, and higher storage limits.
-
-### SAML SSO
-Single Sign-On (SSO) allows you to use your existing identity provider to authenticate users for your Upstash account. This feature is available upon request for Enterprise customers.
-
-### Unlimited Database Count
-Enterprise plans include unlimited database count, allowing you to scale your infrastructure without database count restrictions.
-
-### Professional Support
-All of the databases in the Enterprise plan get access to our professional support. The plan includes response time SLAs and priority access to our support team. Check out the [support page](/docs/common/help/prosupport) for more details.
-
-### Dedicated Resources for Isolation
-Enterprise customers receive dedicated resources to ensure isolation and consistent performance for their database workloads.
-
-### VPC Peering and Private Links
-VPC Peering and Private Links enable you to connect your databases to your VPCs and other private networks, enhancing isolation and security while reducing data transfer costs. This feature is available upon request for Enterprise customers.
-
-### Configurable Backups
-Hourly backups with customizable retention are available upon request for Enterprise customers.
-
-### Access Logs
-Enterprise customers can request access logs to the databases.
-
-### HIPAA Compliance
-A Business Associate Agreement (BAA) and HIPAA compliance enablement is available with our Enterprise plan.
-
-# Getting Started
-Source: https://upstash.com/docs/redis/overall/getstarted
-
-Upstash Redis is a **highly available, infinitely scalable** Redis-compatible database:
-
-* 99.99% uptime guarantee with auto-scaling ([Prod Pack](/docs/redis/overall/enterprise#prod-pack-features))
-* Ultra-low latency worldwide
-* Multi-region replication
-* Multi-Zone High Availability ([Prod Pack](/docs/redis/overall/enterprise#prod-pack-features))
-* Durable, persistent storage without sacrificing performance
-* Automatic backups
-* Optional SOC-2 compliance, encryption at rest and much more
-
-<Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
-</Tip>
-
-***
-
-## 1. Create an Upstash Redis Database
-
-Once you're logged in, create a database by clicking `+ Create Database` in the upper right corner. A dialog opens up:
-
-  <img />
-
-**Database Name:** Enter a name for your database.
-
-**Primary Region and Read Regions:** For optimal performance, select the Primary Region closest to where most of your writes will occur. Select the read region(s) where most of your reads will occur.
-
-Once you click `Next` and select a plan, your database is running and ready to connect:
-
-  <img width="100%" />
-
-***
-
-## 2. Connect to Your Database
-
-You can connect to Upstash Redis with any Redis client. For simplicity, we'll use `redis-cli`. See the [Connect Your Client](../howto/connectclient) section for connecting via our TypeScript or Python SDKs and other clients.
-
-The Redis CLI is included in the official Redis distribution. If you don't
-have Redis installed, you can get it [here](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/).
-
-Connect to your database and execute commands on it:
-
-```bash
-> redis-cli --tls -a PASSWORD -h ENDPOINT -p PORT
-ENDPOINT:PORT> set counter 0
-OK
-ENDPOINT:PORT> get counter
-"0"
-ENDPOINT:PORT> incr counter
-(int) 1
-ENDPOINT:PORT> incr counter
-(int) 2
-```
-
-As you run commands, you'll see updates to your database metrics in (almost) real-time. These database metrics are refreshed every 10 seconds.
-
-  <img width="100%" />
-
-Congratulations! You have created an ultra-fast Upstash Redis database! 🎉
-
-<Check>
-**New: Manage Upstash Redis From Cursor (optional)**
-
-Manage Upstash Redis databases from Cursor and other AI tools by using our [MCP server](/docs/redis/integrations/mcp).
-</Check>
-
-# llms.txt
-Source: https://upstash.com/docs/redis/overall/llms-txt
-
-# Pricing & Limits
-Source: https://upstash.com/docs/redis/overall/pricing
-
-Please check our [pricing page](https://upstash.com/pricing/redis) for the most up-to-date information on pricing and limits.
-
-# Pricing & Limits
-Source: https://upstash.com/docs/redis/overall/pricingold
-
-# Python SDK
-Source: https://upstash.com/docs/redis/overall/pythonredis
-
-# Rate Limit SDK
-Source: https://upstash.com/docs/redis/overall/ratelimit
-
-# Typescript SDK
-Source: https://upstash.com/docs/redis/overall/redis
-
-# Redis® API Compatibility
-Source: https://upstash.com/docs/redis/overall/rediscompatibility
+# Redis® API Compatibility: supported commands, modules, and protocols
+Source: https://upstash.com/docs/redis/overall/compatibility
+
+<Note>
+Upstash supports both native Redis TCP and HTTPS REST. Use either.
+</Note>
 
 Upstash supports Redis client protocol up to version `8.2`. We are also gradually adding changes introduced in later versions.
 
 Most of the unsupported items are in our roadmap. If you need a feature that we do not support, please drop a note to [support@upstash.com](mailto:support@upstash.com).
 So we can inform you when we are planning to support it.
+
+***
+
+## Module Compatibility
+
+| Redis module | Status on Upstash |
+| --- | --- |
+| RedisJSON | Supported. All `JSON.*` commands are available (see below). |
+| RediSearch | Supported via [Upstash Redis Search](/docs/redis/search/introduction). |
+| RedisTimeSeries | Not supported. Use sorted sets with timestamps for time-series patterns. |
 
 ***
 
@@ -18558,6 +18408,8 @@ So we can inform you when we are planning to support it.
 </Accordion>
 
 <Accordion title="JSON" icon="brackets-curly">
+To query inside JSON values (full-text, fuzzy, phrase, regex), see [Upstash Redis Search](/docs/redis/search/introduction).
+
 <CardGroup cols={2}>
 <Card title="JSON.ARRAPPEND" href="https://redis.io/docs/latest/commands/json.arrappend/">Append values to JSON array</Card>
 <Card title="JSON.ARRINDEX" href="https://redis.io/docs/latest/commands/json.arrindex/">Find index of value in array</Card>
@@ -18778,19 +18630,215 @@ We run command integration tests from the following Redis clients after each cod
 * **[Go-Redis](https://github.com/go-redis/redis)**
 * **[Redis-py](https://github.com/redis/redis-py)**
 
+# Prod Pack & Enterprise
+Source: https://upstash.com/docs/redis/overall/enterprise
+
+Upstash has Prod Pack and Enterprise plans for customers with critical production workloads. Prod Pack and Enterprise plans include additional monitoring and security features in addition to higher capacity limits and more powerful resources
+
+Prod Pack -> Per database
+
+Enterprise contract -> Per account
+
+Prod Pack are an add-on per database available to both pay-as-you-go and fixed-price plans, not per account. You can have databases on different plans in the same account and each is charged separately. Meanwhile, Enterprise plans are per account, not per database. All of your databases can be included in the same Enterprise plan covering all of your databases.
+
+All features of Prod Pack and Enterprise plan for Upstash Redis are detailed below.
+
+## How to Upgrade
+
+You can activate Prod Pack on the database details page in the [Upstash Console](https://upstash.com/dashboard/redis). For the Enterprise plan, please create a request through the or contact [support@upstash.com](mailto:support@upstash.com).
+
+# Prod Pack Features
+These features are available on databases with Prod Pack.
+
+### Uptime SLA
+All Prod Pack databases come with an SLA guaranteeing 99.99% uptime. For mission-critical data where uptime is crucial, we recommend Prod Pack plans. Learn more about [Uptime SLA](/docs/common/help/sla).
+
+### SOC-2 Type 2 Compliance & Report
+SOC-2 Type 2 controls apply at the platform level. Prod Pack adds customer-facing compliance support, including SOC-2 report access, contractual commitments, and audit-ready features such as encryption at rest, credential protection, and advanced monitoring. Once enabled, you can request the report through the [Upstash Trust Center](https://trust.upstash.com/) or by contacting [support@upstash.com](mailto:support@upstash.com).
+
+### Multi-Zone High Availability
+
+With Prod Pack add-on, regions of your database are deployed with [multi-zone high availability](/docs/redis/features/replication#high-availability). If one replica or availability zone fails, another replica in a different zone continues serving traffic in the same region. This ensures that your database remains available without any additional latency.
+
+### More Backup Capability
+
+Backups up to 3 days are possible with the Prod Pack add-on.
+
+### Encryption at Rest
+
+Encrypts the block storage where your data is persisted and stored.
+
+### Prometheus Metrics
+
+Prometheus is an open-source monitoring system widely used for monitoring and alerting in cloud-native and containerized environments.
+
+Upstash Prod Pack and Enterprise plans offer Prometheus metrics collection, enabling you to monitor your Redis databases with Prometheus in addition to console metrics. Learn more about [Prometheus integration](/docs/redis/integrations/prometheus).
+
+### Datadog Integration
+
+Upstash Prod Pack and Enterprise plans include integration with Datadog, allowing you to monitor your Redis databases with Datadog in addition to console metrics. Learn more about [Datadog integration](/docs/redis/howto/datadog).
+
+### More metrics on the Console
+
+Max interval of the metrics that are available on the Upstash Console increases from one week to one month for databases with Prod Pack.
+
+# Enterprise Features
+
+All Prod Pack features are included in the Enterprise plan. Additionally, Enterprise plans include:
+
+### Custom Limits
+Get a custom-tailored plan for your Upstash Redis databases to handle the growing demands of your business at any scale, such as 100K+ commands per second, unlimited bandwidth, and higher storage limits.
+
+### SAML SSO
+Single Sign-On (SSO) allows you to use your existing identity provider to authenticate users for your Upstash account. This feature is available upon request for Enterprise customers.
+
+### Unlimited Database Count
+Enterprise plans include unlimited database count, allowing you to scale your infrastructure without database count restrictions.
+
+### Professional Support
+All of the databases in the Enterprise plan get access to our professional support. The plan includes response time SLAs and priority access to our support team. Check out the [support page](/docs/common/help/prosupport) for more details.
+
+### Dedicated Resources for Isolation
+Enterprise customers receive dedicated resources to ensure isolation and consistent performance for their database workloads.
+
+### VPC Peering and Private Links
+VPC Peering and Private Links enable you to connect your databases to your VPCs and other private networks, enhancing isolation and security while reducing data transfer costs. This feature is available upon request for Enterprise customers.
+
+### Configurable Backups
+Hourly backups with customizable retention are available upon request for Enterprise customers.
+
+### Access Logs
+Enterprise customers can request access logs to the databases.
+
+### HIPAA Compliance
+A Business Associate Agreement (BAA) and HIPAA compliance enablement is available with our Enterprise plan.
+
+# Getting Started
+Source: https://upstash.com/docs/redis/overall/getstarted
+
+Upstash Redis is a **highly available, infinitely scalable** Redis-compatible database:
+
+* 99.99% uptime guarantee with auto-scaling ([Prod Pack](/docs/redis/overall/enterprise#prod-pack-features))
+* Ultra-low latency worldwide
+* Multi-region replication
+* Multi-Zone High Availability ([Prod Pack](/docs/redis/overall/enterprise#prod-pack-features))
+* Durable, persistent storage without sacrificing performance
+* Automatic backups
+* Optional SOC-2 compliance, encryption at rest and much more
+
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
+***
+
+## 1. Create an Upstash Redis Database
+
+Once you're logged in, create a database by clicking `+ Create Database` in the upper right corner. A dialog opens up:
+
+  <img />
+
+**Database Name:** Enter a name for your database.
+
+**Primary Region and Read Regions:** For optimal performance, select the Primary Region closest to where most of your writes will occur. Select the read region(s) where most of your reads will occur.
+
+Once you click `Next` and select a plan, your database is running and ready to connect:
+
+  <img width="100%" />
+
+***
+
+## 2. Connect to Your Database
+
+You can connect to Upstash Redis with any Redis client. For simplicity, we'll use `redis-cli`. See the [Connect Your Client](../howto/connectclient) section for connecting via our TypeScript or Python SDKs and other clients.
+
+The Redis CLI is included in the official Redis distribution. If you don't
+have Redis installed, you can get it [here](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/).
+
+Connect to your database and execute commands on it:
+
+```bash
+> redis-cli --tls -a PASSWORD -h ENDPOINT -p PORT
+ENDPOINT:PORT> set counter 0
+OK
+ENDPOINT:PORT> get counter
+"0"
+ENDPOINT:PORT> incr counter
+(int) 1
+ENDPOINT:PORT> incr counter
+(int) 2
+```
+
+As you run commands, you'll see updates to your database metrics in (almost) real-time. These database metrics are refreshed every 10 seconds.
+
+  <img width="100%" />
+
+Congratulations! You have created an ultra-fast Upstash Redis database! 🎉
+
+<Check>
+**New: Manage Upstash Redis From Cursor (optional)**
+
+Manage Upstash Redis databases from Cursor and other AI tools by using our [MCP server](/docs/redis/integrations/mcp).
+</Check>
+
+## Next steps
+
+* [Connect your client](../howto/connectclient): TypeScript, Python, Go, Java, and other Redis clients.
+* [Use cases](/docs/redis/overall/usecases): caching, rate limiting, queues, pub/sub, AI workloads, and more.
+* [Upstash Redis Search](/docs/redis/search/introduction): full-text search built into Upstash Redis.
+* [REST API](/docs/redis/features/restapi): connect from edge and serverless runtimes where TCP is restricted.
+
+# llms.txt
+Source: https://upstash.com/docs/redis/overall/llms-txt
+
+# Pricing & Limits
+Source: https://upstash.com/docs/redis/overall/pricing
+
+Please check our [pricing page](https://upstash.com/pricing/redis) for the most up-to-date information on pricing and limits.
+
+## Choosing a plan
+
+Upstash Redis has two paid plans:
+
+* **Pay-As-You-Go (PAYG).** Billed per request. Best for variable or low-volume workloads where command count is unpredictable, such as caching in serverless functions, edge workloads, and apps that scale to zero. A monthly ceiling price caps your maximum cost.
+* **Fixed plans.** A flat monthly price with a cap on throughput and data size. Usually cheaper than PAYG for sustained, high-throughput workloads where command count is consistently high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and cron jobs are a common fit.
+
+You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](#all-plans-and-limits) for the full breakdown.
+
+# Pricing & Limits
+Source: https://upstash.com/docs/redis/overall/pricingold
+
+# Python SDK
+Source: https://upstash.com/docs/redis/overall/pythonredis
+
+# Rate Limit SDK
+Source: https://upstash.com/docs/redis/overall/ratelimit
+
+# Typescript SDK
+Source: https://upstash.com/docs/redis/overall/redis
+
 # Use Cases
 Source: https://upstash.com/docs/redis/overall/usecases
 
-The data store behind Upstash is [compatible](../overall/rediscompatibility)
+The data store behind Upstash is [compatible](/docs/redis/overall/compatibility)
 with almost all Redis® API. So you can use Upstash for the Redis®' popular use
 cases such as:
 
 * General caching
 * Session caching
+* Rate limiting (see [`@upstash/ratelimit`](https://github.com/upstash/ratelimit))
+* Queues and background jobs (works with [Sidekiq](/docs/redis/integrations/sidekiq), [BullMQ](/docs/redis/integrations/bullmq), [Celery](/docs/redis/integrations/celery))
+* Distributed locking
+* Pub/Sub
+* Feature flags
+* Full-text search inside Redis with [Upstash Redis Search](/docs/redis/search/introduction) (auto-synced, works with JSON, Hashes, and Strings out of the box)
 * Leaderboards
-* Queues
+* Recommendations
 * Usage metering (counting)
 * Content filtering
+* LLM response caching, chat history, and agent memory for AI applications
+
+Upstash runs anywhere your application runs: traditional servers and containers (EC2, Render, Fly.io, Railway, Kubernetes) over native Redis TCP, serverless functions (AWS Lambda, Vercel Functions, Google Cloud Functions) over TCP or REST, and edge runtimes (Cloudflare Workers, Vercel Edge, Deno Deploy) over the REST API.
 
 Check Salvatore's [blog](http://antirez.com/post/take-advantage-of-redis-adding-it-to-your-stack.html) post. You can find lots of similar articles about the common use cases of Redis.
 
@@ -34188,6 +34236,10 @@ Source: https://upstash.com/docs/search/overall/whatisupstashsearch
 Upstash Search is a **simple, lightweight, and scalable way to add AI-powered search to your app**.
 
 We combine full-text and semantic search for highly relevant results. Search works out of the box and scales to massive data sizes with zero infrastructure to manage.
+
+<Note>
+Looking for full-text search inside an Upstash Redis database instead? See [Upstash Redis Search](/docs/redis/search/introduction), a full-text search extension built into Upstash Redis. Upstash Search (this page) is a standalone product that combines full-text and semantic search.
+</Note>
 
 ***
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18179,8 +18179,8 @@ In this section, we will compare Upstash with alternative cloud based solutions.
   begin utilizing advanced features such as DAX or Global Tables, you might
   encounter unexpected expenses on your AWS bill. In contrast, Upstash offers a
   more transparent pricing policy, ensuring that you are not taken by surprise.
-  With Upstash, there are limits in place to cap your maximum costs, providing
-  clarity and preventing any unwelcome surprises in your billing.
+  With Upstash, you can optionally set a budget to cap your maximum costs,
+  providing clarity and preventing any unwelcome surprises in your billing.
 
 * **Portability:** DynamoDB is exclusive to AWS and cannot be used outside of
   the AWS platform. However, Redis is supported by numerous cloud providers and
@@ -18245,35 +18245,23 @@ steady throughput use cases, Fixed plans cost less than pay-as-you-go.
 The good thing is you can start your database with pay-as-you-go pricing and
 move to a Fixed plan when you want. See [pricing](/docs/redis/overall/pricing) and [enterprise plans](/docs/redis/overall/enterprise) for more information.
 
-Even if you choose not to upgrade to a Fixed plan, Upstash guarantees
-transparent billing without any unexpected surprises. Each Upstash database has
-a predefined monthly maximum price, known as the "Ceiling Price." For
-pay-as-you-go (PAYG) databases, this ceiling price is set at \$360 per month.
-Therefore, even if your application experiences a significant surge in traffic,
-such as reaching the front page of HackerNews, your Upstash database will not
-exceed a maximum cost of \$360 per month.
+Even if you choose not to upgrade to a Fixed plan, Upstash gives you control
+over your spending through optional budgets. By default, there is no monthly
+price ceiling on a pay-as-you-go database, but you can set a budget to cap
+your costs. When a database hits its configured budget, its operations are
+stopped, ensuring you never exceed the amount you've set.
 
 # Redis® API Compatibility: supported commands, modules, and protocols
 Source: https://upstash.com/docs/redis/overall/compatibility
 
 <Note>
-Upstash supports both native Redis TCP and HTTPS REST. Use either.
+  Upstash supports both native Redis TCP and HTTPS REST.
 </Note>
 
 Upstash supports Redis client protocol up to version `8.2`. We are also gradually adding changes introduced in later versions.
 
 Most of the unsupported items are in our roadmap. If you need a feature that we do not support, please drop a note to [support@upstash.com](mailto:support@upstash.com).
 So we can inform you when we are planning to support it.
-
-***
-
-## Module Compatibility
-
-| Redis module | Status on Upstash |
-| --- | --- |
-| RedisJSON | Supported. All `JSON.*` commands are available (see below). |
-| RediSearch | Supported via [Upstash Redis Search](/docs/redis/search/introduction). |
-| RedisTimeSeries | Not supported. Use sorted sets with timestamps for time-series patterns. |
 
 ***
 
@@ -18803,7 +18791,7 @@ Upstash Redis has two paid plans:
 * **Pay-As-You-Go (PAYG).** Billed per request. Best for variable or low-volume workloads where command count is unpredictable, such as caching in serverless functions, edge workloads, and apps that scale to zero. A monthly ceiling price caps your maximum cost.
 * **Fixed plans.** A flat monthly price with a cap on throughput and data size. Usually cheaper than PAYG for sustained, high-throughput workloads where command count is consistently high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and cron jobs are a common fit.
 
-You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](#all-plans-and-limits) for the full breakdown.
+You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](https://upstash.com/pricing) for the full breakdown.
 
 # Pricing & Limits
 Source: https://upstash.com/docs/redis/overall/pricingold

--- a/llms.txt
+++ b/llms.txt
@@ -307,6 +307,7 @@
 - [Sidekiq with Upstash Redis](https://upstash.com/docs/redis/integrations/sidekiq.md)
 - [Changelog](https://upstash.com/docs/redis/overall/changelog.md)
 - [Compare](https://upstash.com/docs/redis/overall/compare.md)
+- [Redis® API Compatibility: supported commands, modules, and protocols](https://upstash.com/docs/redis/overall/compatibility.md)
 - [Prod Pack & Enterprise](https://upstash.com/docs/redis/overall/enterprise.md)
 - [Getting Started](https://upstash.com/docs/redis/overall/getstarted.md): Create an Upstash Redis database in seconds
 - [llms.txt](https://upstash.com/docs/redis/overall/llms-txt.md)
@@ -315,7 +316,6 @@
 - [Python SDK](https://upstash.com/docs/redis/overall/pythonredis.md)
 - [Rate Limit SDK](https://upstash.com/docs/redis/overall/ratelimit.md)
 - [Typescript SDK](https://upstash.com/docs/redis/overall/redis.md)
-- [Redis® API Compatibility](https://upstash.com/docs/redis/overall/rediscompatibility.md)
 - [Use Cases](https://upstash.com/docs/redis/overall/usecases.md)
 - [AWS Lambda](https://upstash.com/docs/redis/quickstarts/aws-lambda.md)
 - [Azure Functions](https://upstash.com/docs/redis/quickstarts/azure-functions.md)

--- a/redis/help/faq.mdx
+++ b/redis/help/faq.mdx
@@ -18,7 +18,7 @@ Upstash works for all the common usecases for Redis®. You can use Upstash in yo
 
 ## Do you support all Redis® API?
 
-Most of them. See [Redis® API Compatibility](/redis/overall/rediscompatibility) for the list of supported commands.
+Most of them. See [Redis® API Compatibility](/redis/overall/compatibility) for the list of supported commands.
 
 ## Can I use any Redis client?
 

--- a/redis/integrations/celery.mdx
+++ b/redis/integrations/celery.mdx
@@ -83,6 +83,10 @@ output = result.get(timeout=10)
 print(f"Task result: {output}")  # Outputs '10'
 ```
 
+## Billing Optimization
+
+Celery workers poll Redis continuously, even when there is no queue activity. This can incur extra costs because Upstash charges per request on the Pay-As-You-Go plan. With [our Fixed plans](/redis/overall/pricing#all-plans-and-limits), **we recommend switching to a Fixed plan to avoid increased command count and high costs in Celery use cases.**
+
 ## Conclusion
 
 To see a more detailed example of using Celery with Upstash Redis, check out the [Job Processor with Celery example](https://upstash.com/examples/jobprocessorwithcelery) on our website.

--- a/redis/overall/compare.mdx
+++ b/redis/overall/compare.mdx
@@ -45,6 +45,10 @@ In this section, we will compare Upstash with alternative cloud based solutions.
   functions at Cloudflare Workers.
 - **Durability:** Upstash persists your data to the block storage instantly in
   addition to the memory, so you can use it as your primary database.
+- **Full-text search:** Upstash offers [Upstash Redis Search](/redis/search/introduction), a fast
+  Tantivy-based full-text search extension that works with JSON, Hashes, and Strings out of the box
+  and stays automatically in sync as you write.
+- **JSON:** Upstash supports the `JSON.*` commands natively. See [compatibility](/redis/overall/compatibility).
 
 ## AWS DynamoDB
 
@@ -118,14 +122,13 @@ traffic?**
 Most of the serverless products start to lose their spell if the service
 receives steady and high traffic as it starts to cost higher than
 server/instance based pricing models. To overcome this situation we give you
-option to purchase Pro Plan. In Pro plan you can set fixed
-price per month with a restriction on max throughput and data size. For high and
-steady throughput use cases, enterprise databases cost less than serverless one.
+the option to switch to a [Fixed plan](/redis/overall/pricing). On a Fixed plan you set a
+fixed price per month with a restriction on max throughput and data size. For high and
+steady throughput use cases, Fixed plans cost less than pay-as-you-go.
 The good thing is you can start your database with pay-as-you-go pricing and
-move it enterprise when you want. See [enterprise plans](/redis/overall/enterprise) for more
-information.
+move to a Fixed plan when you want. See [pricing](/redis/overall/pricing) and [enterprise plans](/redis/overall/enterprise) for more information.
 
-Even if you choose not to upgrade to the Pro plan, Upstash guarantees
+Even if you choose not to upgrade to a Fixed plan, Upstash guarantees
 transparent billing without any unexpected surprises. Each Upstash database has
 a predefined monthly maximum price, known as the "Ceiling Price." For
 pay-as-you-go (PAYG) databases, this ceiling price is set at \$360 per month.

--- a/redis/overall/compare.mdx
+++ b/redis/overall/compare.mdx
@@ -60,8 +60,8 @@ In this section, we will compare Upstash with alternative cloud based solutions.
   begin utilizing advanced features such as DAX or Global Tables, you might
   encounter unexpected expenses on your AWS bill. In contrast, Upstash offers a
   more transparent pricing policy, ensuring that you are not taken by surprise.
-  With Upstash, there are limits in place to cap your maximum costs, providing
-  clarity and preventing any unwelcome surprises in your billing.
+  With Upstash, you can optionally set a budget to cap your maximum costs,
+  providing clarity and preventing any unwelcome surprises in your billing.
 
 - **Portability:** DynamoDB is exclusive to AWS and cannot be used outside of
   the AWS platform. However, Redis is supported by numerous cloud providers and
@@ -128,10 +128,8 @@ steady throughput use cases, Fixed plans cost less than pay-as-you-go.
 The good thing is you can start your database with pay-as-you-go pricing and
 move to a Fixed plan when you want. See [pricing](/redis/overall/pricing) and [enterprise plans](/redis/overall/enterprise) for more information.
 
-Even if you choose not to upgrade to a Fixed plan, Upstash guarantees
-transparent billing without any unexpected surprises. Each Upstash database has
-a predefined monthly maximum price, known as the "Ceiling Price." For
-pay-as-you-go (PAYG) databases, this ceiling price is set at \$360 per month.
-Therefore, even if your application experiences a significant surge in traffic,
-such as reaching the front page of HackerNews, your Upstash database will not
-exceed a maximum cost of \$360 per month.
+Even if you choose not to upgrade to a Fixed plan, Upstash gives you control
+over your spending through optional budgets. By default, there is no monthly
+price ceiling on a pay-as-you-go database, but you can set a budget to cap
+your costs. When a database hits its configured budget, its operations are
+stopped, ensuring you never exceed the amount you've set.

--- a/redis/overall/compatibility.mdx
+++ b/redis/overall/compatibility.mdx
@@ -4,23 +4,13 @@ sidebarTitle: "Compatibility"
 ---
 
 <Note>
-Upstash supports both native Redis TCP and HTTPS REST. Use either.
+  Upstash supports both native Redis TCP and HTTPS REST.
 </Note>
 
 Upstash supports Redis client protocol up to version `8.2`. We are also gradually adding changes introduced in later versions.
 
 Most of the unsupported items are in our roadmap. If you need a feature that we do not support, please drop a note to [support@upstash.com](mailto:support@upstash.com).
 So we can inform you when we are planning to support it.
-
----
-
-## Module Compatibility
-
-| Redis module | Status on Upstash |
-| --- | --- |
-| RedisJSON | Supported. All `JSON.*` commands are available (see below). |
-| RediSearch | Supported via [Upstash Redis Search](/redis/search/introduction). |
-| RedisTimeSeries | Not supported. Use sorted sets with timestamps for time-series patterns. |
 
 ---
 

--- a/redis/overall/compatibility.mdx
+++ b/redis/overall/compatibility.mdx
@@ -1,11 +1,26 @@
 ---
-title: Redis® API Compatibility
+title: "Redis® API Compatibility: supported commands, modules, and protocols"
+sidebarTitle: "Compatibility"
 ---
+
+<Note>
+Upstash supports both native Redis TCP and HTTPS REST. Use either.
+</Note>
 
 Upstash supports Redis client protocol up to version `8.2`. We are also gradually adding changes introduced in later versions.
 
 Most of the unsupported items are in our roadmap. If you need a feature that we do not support, please drop a note to [support@upstash.com](mailto:support@upstash.com).
 So we can inform you when we are planning to support it.
+
+---
+
+## Module Compatibility
+
+| Redis module | Status on Upstash |
+| --- | --- |
+| RedisJSON | Supported. All `JSON.*` commands are available (see below). |
+| RediSearch | Supported via [Upstash Redis Search](/redis/search/introduction). |
+| RedisTimeSeries | Not supported. Use sorted sets with timestamps for time-series patterns. |
 
 ---
 
@@ -140,6 +155,8 @@ So we can inform you when we are planning to support it.
 </Accordion>
 
 <Accordion title="JSON" icon="brackets-curly">
+To query inside JSON values (full-text, fuzzy, phrase, regex), see [Upstash Redis Search](/redis/search/introduction).
+
 <CardGroup cols={2}>
 <Card title="JSON.ARRAPPEND" href="https://redis.io/docs/latest/commands/json.arrappend/">Append values to JSON array</Card>
 <Card title="JSON.ARRINDEX" href="https://redis.io/docs/latest/commands/json.arrindex/">Find index of value in array</Card>

--- a/redis/overall/getstarted.mdx
+++ b/redis/overall/getstarted.mdx
@@ -73,3 +73,10 @@ Congratulations! You have created an ultra-fast Upstash Redis database! 🎉
 
 Manage Upstash Redis databases from Cursor and other AI tools by using our [MCP server](/redis/integrations/mcp).
 </Check>
+
+## Next steps
+
+- [Connect your client](../howto/connectclient): TypeScript, Python, Go, Java, and other Redis clients.
+- [Use cases](/redis/overall/usecases): caching, rate limiting, queues, pub/sub, AI workloads, and more.
+- [Upstash Redis Search](/redis/search/introduction): full-text search built into Upstash Redis.
+- [REST API](/redis/features/restapi): connect from edge and serverless runtimes where TCP is restricted.

--- a/redis/overall/pricing.mdx
+++ b/redis/overall/pricing.mdx
@@ -4,3 +4,12 @@ url: https://upstash.com/pricing/redis
 ---
 
 Please check our [pricing page](https://upstash.com/pricing/redis) for the most up-to-date information on pricing and limits.
+
+## Choosing a plan
+
+Upstash Redis has two paid plans:
+
+- **Pay-As-You-Go (PAYG).** Billed per request. Best for variable or low-volume workloads where command count is unpredictable, such as caching in serverless functions, edge workloads, and apps that scale to zero. A monthly ceiling price caps your maximum cost.
+- **Fixed plans.** A flat monthly price with a cap on throughput and data size. Usually cheaper than PAYG for sustained, high-throughput workloads where command count is consistently high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and cron jobs are a common fit.
+
+You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](#all-plans-and-limits) for the full breakdown.

--- a/redis/overall/pricing.mdx
+++ b/redis/overall/pricing.mdx
@@ -12,4 +12,4 @@ Upstash Redis has two paid plans:
 - **Pay-As-You-Go (PAYG).** Billed per request. Best for variable or low-volume workloads where command count is unpredictable, such as caching in serverless functions, edge workloads, and apps that scale to zero. A monthly ceiling price caps your maximum cost.
 - **Fixed plans.** A flat monthly price with a cap on throughput and data size. Usually cheaper than PAYG for sustained, high-throughput workloads where command count is consistently high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and cron jobs are a common fit.
 
-You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](#all-plans-and-limits) for the full breakdown.
+You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](https://upstash.com/pricing) for the full breakdown.

--- a/redis/overall/usecases.mdx
+++ b/redis/overall/usecases.mdx
@@ -2,16 +2,25 @@
 title: Use Cases
 ---
 
-The data store behind Upstash is [compatible](../overall/rediscompatibility)
+The data store behind Upstash is [compatible](/redis/overall/compatibility)
 with almost all Redis® API. So you can use Upstash for the Redis®' popular use
 cases such as:
 
 - General caching
 - Session caching
+- Rate limiting (see [`@upstash/ratelimit`](https://github.com/upstash/ratelimit))
+- Queues and background jobs (works with [Sidekiq](/redis/integrations/sidekiq), [BullMQ](/redis/integrations/bullmq), [Celery](/redis/integrations/celery))
+- Distributed locking
+- Pub/Sub
+- Feature flags
+- Full-text search inside Redis with [Upstash Redis Search](/redis/search/introduction) (auto-synced, works with JSON, Hashes, and Strings out of the box)
 - Leaderboards
-- Queues
+- Recommendations
 - Usage metering (counting)
 - Content filtering
+- LLM response caching, chat history, and agent memory for AI applications
+
+Upstash runs anywhere your application runs: traditional servers and containers (EC2, Render, Fly.io, Railway, Kubernetes) over native Redis TCP, serverless functions (AWS Lambda, Vercel Functions, Google Cloud Functions) over TCP or REST, and edge runtimes (Cloudflare Workers, Vercel Edge, Deno Deploy) over the REST API.
 
 Check Salvatore's [blog](http://antirez.com/post/take-advantage-of-redis-adding-it-to-your-stack.html) post. You can find lots of similar articles about the common use cases of Redis.
 

--- a/search/overall/whatisupstashsearch.mdx
+++ b/search/overall/whatisupstashsearch.mdx
@@ -7,6 +7,10 @@ Upstash Search is a **simple, lightweight, and scalable way to add AI-powered se
 
 We combine full-text and semantic search for highly relevant results. Search works out of the box and scales to massive data sizes with zero infrastructure to manage.
 
+<Note>
+Looking for full-text search inside an Upstash Redis database instead? See [Upstash Redis Search](/redis/search/introduction), a full-text search extension built into Upstash Redis. Upstash Search (this page) is a standalone product that combines full-text and semantic search.
+</Note>
+
 ---
 
 ## Lightweight & Efficient


### PR DESCRIPTION
Surface Upstash Redis Search across the Redis docs, expand use cases, add plan-choice guidance, and rename `rediscompatibility` -> `compatibility` (with redirects).