### PR TITLE
DX-2698: document multi-label support in workflow docs

### DIFF
--- a/_snippets/workflow/logs.mdx
+++ b/_snippets/workflow/logs.mdx
@@ -28,8 +28,13 @@
         The Unix timestamp (in milliseconds) when the workflow run was completed, if applicable.
     </ResponseField>
 
-    <ResponseField name="label" type="string">
-    The label of the run assigned by the user on trigger.
+    <ResponseField name="labels" type="string[]">
+    The labels of the run assigned by the user on trigger.
+    </ResponseField>
+
+    <ResponseField name="label" type="string" deprecated>
+    Deprecated. Use `labels` instead. When a run has multiple labels, this only
+    contains the first one.
     </ResponseField>
 
     <ResponseField name="failureFunction" type="FailureFunction">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -41299,8 +41299,9 @@ Pass an object with a `filter` field containing one or more filter criteria:
             Cancel workflows whose URL starts with this prefix. Cannot be combined with `workflowUrl`.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Cancel workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Cancel workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>
@@ -41460,8 +41461,9 @@ await client.dlq.delete({ dlqIds: ["dlq-123", "dlq-456"] });
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Delete workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Delete workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>
@@ -41574,8 +41576,9 @@ DLQ messages represent failed workflow or QStash deliveries that could not be re
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Filter by workflow label.
+        <ParamField body="label" type="string | string[]" optional>
+            Filter by workflow label. Pass an array to match runs that have any
+            of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>
@@ -41671,8 +41674,9 @@ Pass an object with a `filter` field:
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Restart workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Restart workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>
@@ -41834,8 +41838,9 @@ Pass an object with a `filter` field:
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Resume workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Resume workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>
@@ -42006,8 +42011,9 @@ The `logs` method retrieves workflow run logs using the [List Workflow Runs API]
             Filter by the exact workflow URL.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Filter by workflow label.
+        <ParamField body="label" type="string | string[]" optional>
+            Filter by workflow label. Pass an array to match runs that have any
+            of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="workflowCreatedAt" type="number" optional>
@@ -42073,8 +42079,13 @@ The `logs` method retrieves workflow run logs using the [List Workflow Runs API]
         The Unix timestamp (in milliseconds) when the workflow run was completed, if applicable.
     </ResponseField>
 
-    <ResponseField name="label" type="string">
-    The label of the run assigned by the user on trigger.
+    <ResponseField name="labels" type="string[]">
+    The labels of the run assigned by the user on trigger.
+    </ResponseField>
+
+    <ResponseField name="label" type="string" deprecated>
+    Deprecated. Use `labels` instead. When a run has multiple labels, this only
+    contains the first one.
     </ResponseField>
 
     <ResponseField name="failureFunction" type="FailureFunction">
@@ -42364,6 +42375,20 @@ const { runs } = await client.logs({
 })
 ```
 
+### Filter by multiple labels
+
+Passing an array matches runs that have any of the given labels (OR semantics).
+For example, with runs labelled `["label-1", "label-2"]` and `["label-2", "label-3"]`,
+filtering by `["label-1", "label-2"]` returns both.
+
+```ts
+const { runs } = await client.logs({
+  filter: {
+    label: ["label-1", "label-2"],
+  }
+})
+```
+
 # client.notify
 Source: https://upstash.com/docs/workflow/basics/client/notify
 
@@ -42526,9 +42551,13 @@ You can also trigger multiple workflow runs in a single call by passing an array
   Unix timestamp in seconds.
 </ParamField>
 
-<ParamField body="label" type="string">
+<ParamField body="label" type="string | string[]">
   An optional label to assign to the workflow run.
   This can be useful for identifying and filtering runs in the dashboard or logs.
+
+  Pass an array to attach multiple labels to a single workflow run. The run will
+  then match a [logs](/docs/workflow/basics/client/logs) or DLQ filter for any of its
+  labels (OR semantics).
 </ParamField>
 
 <ParamField body="disableTelemetry" type="boolean">
@@ -42702,8 +42731,14 @@ The context object provides:
   The QStash client instance used by the workflow endpoint.
 </ParamField>
 
-<ParamField path="label" type="srting | undefined">
-  The label of the current workflow run, if set in [client.trigger](/docs/workflow/basics/client/trigger).
+<ParamField path="labels" type="string[]">
+  The labels attached to the current workflow run, if set in [client.trigger](/docs/workflow/basics/client/trigger).
+  Defaults to an empty array when no label was set.
+</ParamField>
+
+<ParamField path="label" type="string | undefined" deprecated>
+  Deprecated. Use `labels` instead. When a run has multiple labels, this only
+  returns the first one.
 </ParamField>
 
 ## Context Object Functions
@@ -44318,6 +44353,11 @@ Source: https://upstash.com/docs/workflow/changelog
 <Note>
   We have moved the roadmap and the changelog to [Github Discussions](https://github.com/orgs/upstash/discussions) starting from October 2025.Now you can follow `In Progress` features. You can see that your `Feature Requests` are recorded. You can vote for them and comment your specific use-cases to shape the feature to your needs.
 </Note>
+
+<Update label="June 2026">
+* **TypeScript SDK (`workflow-js`):**
+    * Multiple labels per workflow run are now supported. `label` on [`client.trigger`](/docs/workflow/basics/client/trigger) and `context.invoke` accepts `string | string[]`, and log/DLQ/cancel filters accept an array to match runs that have any of the given labels (OR semantics). Workflow run logs now expose a `labels: string[]` field, and `context.labels: string[]` replaces the now-deprecated `context.label`.
+</Update>
 
 <Update label="March 2026">
 * **TypeScript SDK (`workflow-js`):**

--- a/workflow/basics/client/cancel.mdx
+++ b/workflow/basics/client/cancel.mdx
@@ -31,8 +31,9 @@ Pass an object with a `filter` field containing one or more filter criteria:
             Cancel workflows whose URL starts with this prefix. Cannot be combined with `workflowUrl`.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Cancel workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Cancel workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>

--- a/workflow/basics/client/dlq/delete.mdx
+++ b/workflow/basics/client/dlq/delete.mdx
@@ -35,8 +35,9 @@ await client.dlq.delete({ dlqIds: ["dlq-123", "dlq-456"] });
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Delete workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Delete workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>

--- a/workflow/basics/client/dlq/list.mdx
+++ b/workflow/basics/client/dlq/list.mdx
@@ -30,8 +30,9 @@ DLQ messages represent failed workflow or QStash deliveries that could not be re
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Filter by workflow label.
+        <ParamField body="label" type="string | string[]" optional>
+            Filter by workflow label. Pass an array to match runs that have any
+            of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>

--- a/workflow/basics/client/dlq/restart.mdx
+++ b/workflow/basics/client/dlq/restart.mdx
@@ -32,8 +32,9 @@ Pass an object with a `filter` field:
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Restart workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Restart workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>

--- a/workflow/basics/client/dlq/resume.mdx
+++ b/workflow/basics/client/dlq/resume.mdx
@@ -32,8 +32,9 @@ Pass an object with a `filter` field:
             Filter by workflow run ID.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Resume workflows with this label.
+        <ParamField body="label" type="string | string[]" optional>
+            Resume workflows with this label. Pass an array to match runs that
+            have any of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="fromDate" type="Date | number" optional>

--- a/workflow/basics/client/logs.mdx
+++ b/workflow/basics/client/logs.mdx
@@ -38,8 +38,9 @@ The `logs` method retrieves workflow run logs using the [List Workflow Runs API]
             Filter by the exact workflow URL.
         </ParamField>
 
-        <ParamField body="label" type="string" optional>
-            Filter by workflow label.
+        <ParamField body="label" type="string | string[]" optional>
+            Filter by workflow label. Pass an array to match runs that have any
+            of the given labels (OR semantics).
         </ParamField>
 
         <ParamField body="workflowCreatedAt" type="number" optional>
@@ -119,6 +120,20 @@ const { runs } = await client.logs({
     label: "my-workflow",
     fromDate: new Date("2024-01-01"),
     toDate: new Date("2024-06-01"),
+  }
+})
+```
+
+### Filter by multiple labels
+
+Passing an array matches runs that have any of the given labels (OR semantics).
+For example, with runs labelled `["label-1", "label-2"]` and `["label-2", "label-3"]`,
+filtering by `["label-1", "label-2"]` returns both.
+
+```ts
+const { runs } = await client.logs({
+  filter: {
+    label: ["label-1", "label-2"],
   }
 })
 ```

--- a/workflow/basics/client/trigger.mdx
+++ b/workflow/basics/client/trigger.mdx
@@ -76,9 +76,13 @@ You can also trigger multiple workflow runs in a single call by passing an array
   Unix timestamp in seconds.
 </ParamField>
 
-<ParamField body="label" type="string">
+<ParamField body="label" type="string | string[]">
   An optional label to assign to the workflow run.
   This can be useful for identifying and filtering runs in the dashboard or logs.
+
+  Pass an array to attach multiple labels to a single workflow run. The run will
+  then match a [logs](/workflow/basics/client/logs) or DLQ filter for any of its
+  labels (OR semantics).
 </ParamField>
 
 <ParamField body="disableTelemetry" type="boolean">

--- a/workflow/basics/context.mdx
+++ b/workflow/basics/context.mdx
@@ -67,8 +67,14 @@ The context object provides:
   The QStash client instance used by the workflow endpoint.
 </ParamField>
 
-<ParamField path="label" type="srting | undefined">
-  The label of the current workflow run, if set in [client.trigger](/workflow/basics/client/trigger).
+<ParamField path="labels" type="string[]">
+  The labels attached to the current workflow run, if set in [client.trigger](/workflow/basics/client/trigger).
+  Defaults to an empty array when no label was set.
+</ParamField>
+
+<ParamField path="label" type="string | undefined" deprecated>
+  Deprecated. Use `labels` instead. When a run has multiple labels, this only
+  returns the first one.
 </ParamField>
 
 ## Context Object Functions

--- a/workflow/changelog.mdx
+++ b/workflow/changelog.mdx
@@ -6,6 +6,11 @@ title: Changelog
   We have moved the roadmap and the changelog to [Github Discussions](https://github.com/orgs/upstash/discussions) starting from October 2025.Now you can follow `In Progress` features. You can see that your `Feature Requests` are recorded. You can vote for them and comment your specific use-cases to shape the feature to your needs.
 </Note>
 
+<Update label="June 2026">
+- **TypeScript SDK (`workflow-js`):**
+    - Multiple labels per workflow run are now supported. `label` on [`client.trigger`](/workflow/basics/client/trigger) and `context.invoke` accepts `string | string[]`, and log/DLQ/cancel filters accept an array to match runs that have any of the given labels (OR semantics). Workflow run logs now expose a `labels: string[]` field, and `context.labels: string[]` replaces the now-deprecated `context.label`.
+</Update>
+
 <Update label="March 2026">
 - **TypeScript SDK (`workflow-js`):**
     - Added optional `workflowRunId` parameter to `notify` method, enabling **lookback functionality**. When provided, notifications are stored and delivered even if sent before a workflow reaches `waitForEvent`, preventing race conditions. See [notify documentation](/workflow/basics/client/notify) and [wait-for-event guide](/workflow/features/wait-for-event#race-condition-between-wait-and-notify) for details.


### PR DESCRIPTION
Reflect workflow-js multi-label changes: label accepts string | string[] on trigger, log/DLQ/cancel filters accept arrays with OR semantics, context.labels replaces deprecated context.label, and workflow run logs expose a labels[] field.