### PR TITLE
DX-2595: recommend automatic dev server, fix local-development links

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -40680,7 +40680,7 @@ Source: https://upstash.com/docs/workflow/agents/getting-started
 
 In this guide, we will be using **Next.js**. If you're working with a different supported framework, you can find instructions on how to define a workflow endpoint in the [quickstarts](/docs/workflow/quickstarts/platforms).
 
-If you're new to **Upstash Workflow**, it's a good idea to start by exploring the [Local Development documentation](/docs/workflow/howto/local-development). This guide will help you set up and use Upstash Workflow in a local environment.
+If you're new to **Upstash Workflow**, it's a good idea to start by exploring the [Local Development documentation](/docs/workflow/howto/local-development/development-server). This guide will help you set up and use Upstash Workflow in a local environment.
 
 ##  Installation
 
@@ -40696,32 +40696,17 @@ Then, install the following packages:
 npm i @upstash/workflow @upstash/workflow-agents ai zod
 ```
 
-## Start Local QStash Server
+## Start the development server
 
-Next, start the local QStash server with the following:
-
-<CodeGroup>
-
-```bash npm
-npx @upstash/qstash-cli dev
-```
-```bash pnpm
-pnpm dlx @upstash/qstash-cli dev
-```
-</CodeGroup>
-
-For other local development options, you can refer to [the local development documentation](/docs/workflow/howto/local-development).
-
-## Set Environment Variables
-
-Once you start the QStash server, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env.local` file together with `OPENAI_API_KEY` env variable:
+Since you are using `@upstash/workflow`, set `QSTASH_DEV=true` in your `.env.local` file and the SDK will download, start, and connect to a local QStash development server automatically — no tokens or signing keys to copy over. Add your `OPENAI_API_KEY` alongside it:
 
 ```txt .env.local
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
+QSTASH_DEV=true
 
 OPENAI_API_KEY=<OPENAI_API_KEY>
 ```
+
+For manual setup, custom ports, and the `registerQStashDev()` helper for Next.js edge routes, see the [Development Server guide](/docs/workflow/howto/local-development/development-server).
 
 ## Define an endpoint
 
@@ -40821,7 +40806,7 @@ and exploration of distant celestial
 bodies.
 ```
 
-If you [run the same endpoint using a local tunnel](/docs/workflow/howto/local-development#local-tunnel-with-ngrok), you can also see how Upstash Workflow runs the agent in steps:
+If you [run the same endpoint using a local tunnel](/docs/workflow/howto/local-development/local-tunnel), you can also see how Upstash Workflow runs the agent in steps:
 
 <img />
 
@@ -43633,7 +43618,7 @@ async def example(context: AsyncWorkflowContext[Request]) -> None:
 <Info>
   The `context.call()` function can make requests to any public API endpoint. However, it cannot:
 
-  * Make requests to localhost (unless you set up a local tunnel, [here's how](http://localhost:3000/workflow/howto/local-development))
+  * Make requests to localhost (unless you set up a local tunnel, [here's how](/docs/workflow/howto/local-development/local-tunnel))
   * Make requests to internal Upstash QStash endpoints.
 </Info>
 
@@ -49731,7 +49716,7 @@ export const { POST } = serve<{ prompt: string }>(async (context) => {
 });
 ```
 
-We can either [run the app locally](/docs/workflow/howto/local-development) or deploy it. Once the app is running, we can trigger the workflow using the following code:
+We can either [run the app locally](/docs/workflow/howto/local-development/development-server) or deploy it. Once the app is running, we can trigger the workflow using the following code:
 
 ```ts
 import { Client } from "@upstash/workflow";

--- a/workflow/agents/getting-started.mdx
+++ b/workflow/agents/getting-started.mdx
@@ -4,7 +4,7 @@ title: "Getting Started"
 
 In this guide, we will be using **Next.js**. If you're working with a different supported framework, you can find instructions on how to define a workflow endpoint in the [quickstarts](/workflow/quickstarts/platforms).
 
-If you're new to **Upstash Workflow**, it's a good idea to start by exploring the [Local Development documentation](/workflow/howto/local-development). This guide will help you set up and use Upstash Workflow in a local environment.
+If you're new to **Upstash Workflow**, it's a good idea to start by exploring the [Local Development documentation](/workflow/howto/local-development/development-server). This guide will help you set up and use Upstash Workflow in a local environment.
 
 ##  Installation
 
@@ -20,32 +20,17 @@ Then, install the following packages:
 npm i @upstash/workflow @upstash/workflow-agents ai zod
 ```
 
-## Start Local QStash Server
+## Start the development server
 
-Next, start the local QStash server with the following:
-
-<CodeGroup>
-
-```bash npm
-npx @upstash/qstash-cli dev
-```
-```bash pnpm
-pnpm dlx @upstash/qstash-cli dev
-```
-</CodeGroup>
-
-For other local development options, you can refer to [the local development documentation](/workflow/howto/local-development).
-
-## Set Environment Variables
-
-Once you start the QStash server, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env.local` file together with `OPENAI_API_KEY` env variable:
+Since you are using `@upstash/workflow`, set `QSTASH_DEV=true` in your `.env.local` file and the SDK will download, start, and connect to a local QStash development server automatically — no tokens or signing keys to copy over. Add your `OPENAI_API_KEY` alongside it:
 
 ```txt .env.local
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
+QSTASH_DEV=true
 
 OPENAI_API_KEY=<OPENAI_API_KEY>
 ```
+
+For manual setup, custom ports, and the `registerQStashDev()` helper for Next.js edge routes, see the [Development Server guide](/workflow/howto/local-development/development-server).
 
 ## Define an endpoint
 
@@ -146,7 +131,7 @@ and exploration of distant celestial
 bodies.
 ```
 
-If you [run the same endpoint using a local tunnel](/workflow/howto/local-development#local-tunnel-with-ngrok), you can also see how Upstash Workflow runs the agent in steps:
+If you [run the same endpoint using a local tunnel](/workflow/howto/local-development/local-tunnel), you can also see how Upstash Workflow runs the agent in steps:
 
 <img src="/img/workflow/agents/logs/logs-getting-started.png" />
 

--- a/workflow/basics/context/call.mdx
+++ b/workflow/basics/context/call.mdx
@@ -178,6 +178,6 @@ async def example(context: AsyncWorkflowContext[Request]) -> None:
 <Info>
   The `context.call()` function can make requests to any public API endpoint. However, it cannot:
 
-  - Make requests to localhost (unless you set up a local tunnel, [here's how](http://localhost:3000/workflow/howto/local-development))
+  - Make requests to localhost (unless you set up a local tunnel, [here's how](/workflow/howto/local-development/local-tunnel))
   - Make requests to internal Upstash QStash endpoints.
 </Info>

--- a/workflow/integrations/aisdk.mdx
+++ b/workflow/integrations/aisdk.mdx
@@ -155,7 +155,7 @@ export const { POST } = serve<{ prompt: string }>(async (context) => {
 });
 ```
 
-We can either [run the app locally](/workflow/howto/local-development) or deploy it. Once the app is running, we can trigger the workflow using the following code:  
+We can either [run the app locally](/workflow/howto/local-development/development-server) or deploy it. Once the app is running, we can trigger the workflow using the following code:  
 
 ```ts
 import { Client } from "@upstash/workflow";

--- a/workflow/quickstarts/astro.mdx
+++ b/workflow/quickstarts/astro.mdx
@@ -50,24 +50,19 @@ Create a `.env` file in your project root and add your QStash token. This key is
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
-### Option 1: Local QStash Server
+### Option 1: Development Server
 
-To start the local QStash server, run:
+Since you are using `@upstash/workflow`, you can set `QSTASH_DEV=true` in your `.env` file. The SDK then downloads and connects to the local QStash development server automatically — no tokens or signing keys to copy over:
 
-```bash
-npx @upstash/qstash-cli dev
+```txt .env
+QSTASH_DEV=true
 ```
 
-Once the command runs successfully, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env` file:
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification. This lets you test workflows locally without affecting your billing.
 
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
-```
-
-This approach allows you to test workflows locally without affecting your billing. However, runs won't be logged in the Upstash Console.
+For ports, the `registerQStashDev()` helper, and other details, see the [Development Server guide](/workflow/howto/local-development/development-server).
 
 ### Option 2: Local Tunnel
 
@@ -164,7 +159,7 @@ When deploying your Astro app with Upstash Workflow to production, there are a f
 1. **Environment Variables**: Make sure that all necessary environment variables from your `.env` file are set in your Vercel project settings. For example, your `QSTASH_TOKEN`, and any other configuration variables your workflow might need.
 
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your Astro app to production as you normally would, for example to Vercel or AWS.
 
@@ -186,4 +181,4 @@ curl -X POST <DEPLOYMENT_URL>/api/workflow \
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/astro) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/cloudflare-workers.mdx
+++ b/workflow/quickstarts/cloudflare-workers.mdx
@@ -47,7 +47,7 @@ Create a `.dev.vars` file in your project root and add your QStash token. This k
 touch .dev.vars
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
 ### Option 1: Local QStash Server
 
@@ -162,7 +162,7 @@ When deploying your Cloudflare Worker with Upstash Workflow to production, there
 
 1. **Environment Variables**: Make sure that all necessary environment variables from your `.dev.vars` file are set in your Cloudflare Worker project settings. For example, your `QSTASH_TOKEN`, `ENVIRONMENT`, and any other configuration variables your workflow might need.
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your Cloudflare Worker to production as you normally would, for example using the Cloudflare CLI:
 
@@ -186,4 +186,4 @@ When deploying your Cloudflare Worker with Upstash Workflow to production, there
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/cloudflare-workers) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/express.mdx
+++ b/workflow/quickstarts/express.mdx
@@ -39,24 +39,19 @@ Create a `.env` file in your project root and add your QStash token. This key is
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
-### Option 1: Local QStash Server
+### Option 1: Development Server
 
-To start the local QStash server, run:
+Since you are using `@upstash/workflow`, you can set `QSTASH_DEV=true` in your `.env` file. The SDK then downloads and connects to the local QStash development server automatically — no tokens or signing keys to copy over:
 
-```bash
-npx @upstash/qstash-cli dev
+```txt .env
+QSTASH_DEV=true
 ```
 
-Once the command runs successfully, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env` file:
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification. This lets you test workflows locally without affecting your billing.
 
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
-```
-
-This approach allows you to test workflows locally without affecting your billing. However, runs won't be logged in the Upstash Console.
+For ports, the `registerQStashDev()` helper, and other details, see the [Development Server guide](/workflow/howto/local-development/development-server).
 
 ### Option 2: Local Tunnel
 
@@ -169,7 +164,7 @@ When deploying your Hono app with Upstash Workflow to production, there are a fe
 1. **Environment Variables**: Make sure that all necessary environment variables from your `.env` file are set in your Vercel project settings. For example, your `QSTASH_TOKEN`, and any other configuration variables your workflow might need.
 
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your Express.js app to production as you normally would, for example to fly.io or AWS.
 
@@ -191,4 +186,4 @@ curl -X POST <DEPLOYMENT_URL>/workflow \
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/express) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/fastapi.mdx
+++ b/workflow/quickstarts/fastapi.mdx
@@ -39,7 +39,7 @@ Create a `.env` file in your project root and add your QStash token. This token 
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
 ### Option 1: Local QStash Server
 
@@ -278,4 +278,4 @@ If you are using a local tunnel, you can use this ID to track the workflow run a
 
 2. Explore [the source code](https://github.com/upstash/workflow-py/tree/master/examples/fastapi) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/flask.mdx
+++ b/workflow/quickstarts/flask.mdx
@@ -39,7 +39,7 @@ Create a `.env` file in your project root and add your QStash token. This token 
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
 ### Option 1: Local QStash Server
 
@@ -278,4 +278,4 @@ If you are using a local tunnel, you can use this ID to track the workflow run a
 
 2. Explore our [the source code](https://github.com/upstash/workflow-py/tree/master/examples/flask) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/hono.mdx
+++ b/workflow/quickstarts/hono.mdx
@@ -48,7 +48,7 @@ Create a `.dev.vars` file in your project root and add your QStash token. This k
 touch .dev.vars
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
 ### Option 1: Local QStash Server
 
@@ -193,7 +193,7 @@ When deploying your Hono app with Upstash Workflow to production, there are a fe
 
 1. **Environment Variables**: Make sure that all necessary environment variables from your `.dev.vars` file are set in your Cloudflare Worker project settings. For example, your `QSTASH_TOKEN`, and any other configuration variables your workflow might need.
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your Hono app to production as you normally would, for example using the Cloudflare CLI:
 
@@ -217,4 +217,4 @@ When deploying your Hono app with Upstash Workflow to production, there are a fe
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/hono) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/nextjs-fastapi.mdx
+++ b/workflow/quickstarts/nextjs-fastapi.mdx
@@ -48,7 +48,7 @@ Create a `.env` file in your project root and add your QStash token. This token 
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
 ### Option 1: Local QStash Server
 
@@ -92,7 +92,7 @@ Using a local tunnel connects your endpoint to the production QStash, enabling y
 
 ## Step 4: Start the Development Server
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), and QStash needs a publicly accessible URL to run your workflows. Here's how to [set up your workflow endpoint for local development](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), and QStash needs a publicly accessible URL to run your workflows. Here's how to [set up your workflow endpoint for local development](/workflow/howto/local-development/development-server).
 
 In a nutshell, in local development, you can either use the QStash development server or use a local tunnel to make your workflow endpoint publicly accessible.
 
@@ -143,4 +143,4 @@ You can observe the logs at [Upstash console under the Worfklow tab](https://con
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/nextjs-fastapi for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/nextjs-flask.mdx
+++ b/workflow/quickstarts/nextjs-flask.mdx
@@ -48,7 +48,7 @@ Create a `.env` file in your project root and add your QStash token. This token 
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
 ### Option 1: Local QStash Server
 
@@ -92,7 +92,7 @@ Using a local tunnel connects your endpoint to the production QStash, enabling y
 
 ## Step 4: Start the Development Server
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), and QStash needs a publicly accessible URL to run your workflows. Here's how to [set up your workflow endpoint for local development](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), and QStash needs a publicly accessible URL to run your workflows. Here's how to [set up your workflow endpoint for local development](/workflow/howto/local-development/development-server).
 
 In a nutshell, in local development, you can either use the QStash development server or use a local tunnel to make your workflow endpoint publicly accessible.
 
@@ -143,4 +143,4 @@ You can observe the logs at [Upstash console under the Worfklow tab](https://con
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/nextjs-flask) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/nuxt.mdx
+++ b/workflow/quickstarts/nuxt.mdx
@@ -49,24 +49,19 @@ Create a `.env.local` file in your project root and add your QStash token. This 
 touch .env.local
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
-### Option 1: Local QStash Server
+### Option 1: Development Server
 
-To start the local QStash server, run:
+Since you are using `@upstash/workflow`, you can set `QSTASH_DEV=true` in your `.env.local` file. The SDK then downloads and connects to the local QStash development server automatically — no tokens or signing keys to copy over:
 
-```bash
-npx @upstash/qstash-cli dev
+```txt .env.local
+QSTASH_DEV=true
 ```
 
-Once the command runs successfully, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env.local` file:
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification. This lets you test workflows locally without affecting your billing.
 
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
-```
-
-This approach allows you to test workflows locally without affecting your billing. However, runs won't be logged in the Upstash Console.
+For ports, the `registerQStashDev()` helper, and other details, see the [Development Server guide](/workflow/howto/local-development/development-server).
 
 ### Option 2: Local Tunnel
 
@@ -150,7 +145,7 @@ When deploying your Nuxt.js application with Upstash Workflow to production, the
 
 1. **Environment Variables**: Make sure that all necessary environment variables are set in your platforms project settings. For example, your `QSTASH_TOKEN` and any other configuration variables your workflow might need.
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your Nuxt application to Vercel, Cloudflare Pages or other platforms as you normally would. These platforms will automatically detect and build your Nuxt application.
 
@@ -170,4 +165,4 @@ When deploying your Nuxt.js application with Upstash Workflow to production, the
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/nuxt) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/solidjs.mdx
+++ b/workflow/quickstarts/solidjs.mdx
@@ -45,24 +45,19 @@ Create a `.env` file in your project root and add your QStash token. This key is
 touch .env
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
-### Option 1: Local QStash Server
+### Option 1: Development Server
 
-To start the local QStash server, run:
+Since you are using `@upstash/workflow`, you can set `QSTASH_DEV=true` in your `.env` file. The SDK then downloads and connects to the local QStash development server automatically — no tokens or signing keys to copy over:
 
-```bash
-npx @upstash/qstash-cli dev
+```txt .env
+QSTASH_DEV=true
 ```
 
-Once the command runs successfully, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env` file:
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification. This lets you test workflows locally without affecting your billing.
 
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
-```
-
-This approach allows you to test workflows locally without affecting your billing. However, runs won't be logged in the Upstash Console.
+For ports, the `registerQStashDev()` helper, and other details, see the [Development Server guide](/workflow/howto/local-development/development-server).
 
 ### Option 2: Local Tunnel
 
@@ -142,7 +137,7 @@ When deploying your SolidJS application with Upstash Workflows to production, th
 
 1. **Environment Variables**: Make sure that all necessary environment variables are set in your platforms project settings. For example, your `QSTASH_TOKEN` and any other configuration variables your workflow might need.
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your SolidJS application to Netlify, Vercel or other platforms as you normally would. These platforms will automatically detect and build your SolidJS application.
 
@@ -162,4 +157,4 @@ When deploying your SolidJS application with Upstash Workflows to production, th
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/solidjs) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/svelte.mdx
+++ b/workflow/quickstarts/svelte.mdx
@@ -49,24 +49,19 @@ Create a `.env.local` file in your project root and add your QStash token. This 
 touch .env.local
 ```
 
-Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development).
+Upstash Workflow is powered by [QStash](/qstash/overall/getstarted), which requires access to your endpoint to execute workflows. When your app is deployed, QStash will use the app's URL. However, for local development, you have two main options: [use a local QStash server or set up a local tunnel](/workflow/howto/local-development/development-server).
 
-### Option 1: Local QStash Server
+### Option 1: Development Server
 
-To start the local QStash server, run:
+Since you are using `@upstash/workflow`, you can set `QSTASH_DEV=true` in your `.env.local` file. The SDK then downloads and connects to the local QStash development server automatically — no tokens or signing keys to copy over:
 
-```bash
-npx @upstash/qstash-cli dev
+```txt .env.local
+QSTASH_DEV=true
 ```
 
-Once the command runs successfully, you’ll see `QSTASH_URL` and `QSTASH_TOKEN` values in the console. Add these values to your `.env.local` file:
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification. This lets you test workflows locally without affecting your billing.
 
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="<QSTASH_TOKEN>"
-```
-
-This approach allows you to test workflows locally without affecting your billing. However, runs won't be logged in the Upstash Console.
+For ports, the `registerQStashDev()` helper, and other details, see the [Development Server guide](/workflow/howto/local-development/development-server).
 
 ### Option 2: Local Tunnel
 
@@ -151,7 +146,7 @@ When deploying your SvelteKit application with Upstash Workflow to production, t
 
 1. **Environment Variables**: Make sure that all necessary environment variables are set in your platforms project settings. For example, your `QSTASH_TOKEN` and any other configuration variables your workflow might need.
 
-2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development#local-tunnel-with-ngrok)
+2. **Remove Local Development Settings**: In your production code, you can remove or conditionally exclude any local development settings. For example, if you used [local tunnel for local development](/workflow/howto/local-development/local-tunnel)
 
 3. **Deployment**: Deploy your app to Vercel, Netlify or other platforms as you normally would. These platforms will automatically detect and build your SvelteKit application.
 
@@ -171,4 +166,4 @@ When deploying your SvelteKit application with Upstash Workflow to production, t
 
 2. Explore [the source code](https://github.com/upstash/workflow-js/tree/main/examples/sveltekit) for a detailed, end-to-end example and best practices.
 
-3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development).
+3. For setting up and testing your workflows in a local environment, check out our [local development guide](/workflow/howto/local-development/development-server).

--- a/workflow/quickstarts/tanstack-start.mdx
+++ b/workflow/quickstarts/tanstack-start.mdx
@@ -55,33 +55,22 @@ Run the following command to install the Upstash Workflow SDK in your TanStack S
   </Tab>
 </Tabs>
 
-## Step 3: Run the development server
+## Step 3: Set up the development server
 
 Upstash Workflow is built on top of Upstash QStash.
 
 In a production environment, your application connects to the managed QStash servers hosted by Upstash.
 This ensures that requests are delivered reliably, securely, and at scale without requiring you to run and maintain your own infrastructure.
 
-For local development, you don't need to depend on the managed QStash servers. Instead, you can run a local QStash server directly on your machine.
-This local server behaves just like the production version but does not require external network calls.
+For local development, you don't need to depend on the managed QStash servers. Since you are using `@upstash/workflow`, you can just set `QSTASH_DEV=true`, and the SDK will download, start, and connect to a local QStash development server automatically — no tokens or signing keys to copy over.
 
-Start the local server with:
+In the root of your project, create a `.env` file (or update your existing one):
 
-<Tabs>
-  <Tab title="pnpm">
-  ```bash
-  pnpx @upstash/qstash-cli dev
-  ```
-  </Tab>
-  <Tab title="npm">
-  ```bash
-  npx @upstash/qstash-cli dev
-  ```
-  </Tab>
-</Tabs>
+```txt .env
+QSTASH_DEV=true
+```
 
-When the server starts, it will print the credentials.
-You'll need these values in the next step to connect your TanStack Start app to QStash.
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification, so there's nothing else to configure. The local server behaves just like the production version but does not require external network calls.
 
 You can enable local mode in the Upstash Workflow dashboard to use the UI while developing locally.
 
@@ -89,24 +78,15 @@ You can enable local mode in the Upstash Workflow dashboard to use the UI while 
   <img src="/img/qstash-workflow/local-dev.png" alt="Enable local mode on dashboard" />
 </Frame>
 
-## Step 4: Configure Environment Variables
-
-Next, you need to configure your TanStack Start app to connect with the local QStash server by setting environment variables.
-
-In the root of your project, create a `.env` file (or update your existing one) and add the values printed by the QStash local server:
-
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="eyJVc2VySUQiOiJkZWZhdWx0VXNlciIsIlBhc3N3b3JkIjoiZGVmYXVsdFBhc3N3b3JkIn0="
-QSTASH_CURRENT_SIGNING_KEY="sig_7kYjw48mhY7kAjqNGcy6cr29RJ6r"
-QSTASH_NEXT_SIGNING_KEY="sig_5ZB6DVzB1wjE8S6rZ7eenA8Pdnhs"
-```
-
 <Tip>
-  For production, replace these with your actual credentials from the Upstash Workflow dashboard.
+  Prefer to start the server yourself, or using a runtime other than Node.js? See the [Development Server guide](/workflow/howto/local-development/development-server) for the manual QStash CLI setup, custom ports, and the `registerQStashDev()` helper for edge routes.
 </Tip>
 
-## Step 5: Create a Workflow Endpoint
+<Note>
+  For production, set your actual credentials from the Upstash Workflow dashboard instead of `QSTASH_DEV`.
+</Note>
+
+## Step 4: Create a Workflow Endpoint
 
 With your environment ready, the next step is to define your first workflow endpoint.
 
@@ -145,7 +125,7 @@ export const Route = createFileRoute('/api/workflow')({
 })
 ```
 
-## Step 6: Start your TanStack Start app
+## Step 5: Start your TanStack Start app
 
 Start your TanStack Start development server:
 
@@ -164,7 +144,7 @@ Start your TanStack Start development server:
 
 Your app should now be running on `http://localhost:3000`.
 
-## Step 7: Run the Workflow Endpoint
+## Step 6: Run the Workflow Endpoint
 
 Once your endpoint is defined, the next step is to trigger a workflow run.
 

--- a/workflow/quickstarts/vercel-nextjs.mdx
+++ b/workflow/quickstarts/vercel-nextjs.mdx
@@ -42,33 +42,22 @@ Run the following command to install the Upstash Workflow SDK in your Next.js ap
 </Tabs>
 
 
-## Step 2: Run the development server
+## Step 2: Set up the development server
 
 Upstash Workflow is built on top of Upstash QStash.
 
 In a production environment, your application connects to the managed QStash servers hosted by Upstash.
 This ensures that requests are delivered reliably, securely, and at scale without requiring you to run and maintain your own infrastructure.
 
-For local development, you don't need to depend on the managed QStash servers. Instead, you can run a local QStash server directly on your machine.
-This local server behaves just like the production version but does not require external network calls.
+For local development, you don't need to depend on the managed QStash servers. Since you are using `@upstash/workflow`, you can just set `QSTASH_DEV=true`, and the SDK will download, start, and connect to a local QStash development server automatically — no tokens or signing keys to copy over.
 
-Start the local server with:
+In the root of your project, create a `.env.local` file (or update your existing one):
 
-<Tabs>
-  <Tab title="npm">
-  ```bash
-  npx @upstash/qstash-cli dev
-  ```
-  </Tab>
-  <Tab title="pnpm">
-  ```bash
-  pnpx @upstash/qstash-cli dev
-  ```
-  </Tab>
-</Tabs>
+```txt .env.local
+QSTASH_DEV=true
+```
 
-When the server starts, it will print the credentials.
-You'll need these values in the next step to connect your Next.js app to QStash.
+Both the workflow client and the `serve()` endpoint pick up the dev server automatically, including signature verification, so there's nothing else to configure. The local server behaves just like the production version but does not require external network calls.
 
 You can enable local mode in the Upstash Workflow dashboard to use the UI while developing locally.
 
@@ -76,22 +65,13 @@ You can enable local mode in the Upstash Workflow dashboard to use the UI while 
   <img src="/img/qstash-workflow/local-dev.png" alt="Enable local mode on dashboard" />
 </Frame>
 
-## Step 3: Configure Environment Variables
-
-Next, you need to configure your Next.js app to connect with the local QStash server by setting environment variables.
-
-In the root of your project, create a `.env.local` file (or update your existing one) and add the values printed by the QStash local server:
-
-```txt
-QSTASH_URL="http://127.0.0.1:8080"
-QSTASH_TOKEN="eyJVc2VySUQiOiJkZWZhdWx0VXNlciIsIlBhc3N3b3JkIjoiZGVmYXVsdFBhc3N3b3JkIn0="
-QSTASH_CURRENT_SIGNING_KEY="sig_7kYjw48mhY7kAjqNGcy6cr29RJ6r"
-QSTASH_NEXT_SIGNING_KEY="sig_5ZB6DVzB1wjE8S6rZ7eenA8Pdnhs"
-```
-
 <Tip>
-  For production, replace these with your actual credentials from the Upstash Workflow dashboard.
+  Prefer to start the server yourself, or using a runtime other than Node.js? See the [Development Server guide](/workflow/howto/local-development/development-server) for the manual QStash CLI setup, custom ports, and the `registerQStashDev()` helper for Next.js edge routes.
 </Tip>
+
+<Note>
+  For production, set your actual credentials from the Upstash Workflow dashboard instead of `QSTASH_DEV`.
+</Note>
 
 
 ## Step 3: Create a Workflow Endpoint
@@ -238,7 +218,7 @@ You now have everything you need to deploy your application to production! 🎉
 Before deploying, make sure your configuration no longer relies on local development settings:
 
 - **Workflow URL**: Update the `trigger()` call to use your production domain (see the tip above for using a dynamic `BASE_URL`).
-- **Credentials**: Replace local QStash credentials with your production tokens.
+- **Credentials**: Remove `QSTASH_DEV=true` and set your production `QSTASH_TOKEN` and signing keys from the Upstash dashboard.
 - **Environment Variables**: Verify that all required variables are set correctly in your deployment environment.
 
 ## Next Steps


### PR DESCRIPTION
- Switch JS/Node quickstarts and agents guide to QSTASH_DEV=true automatic dev server
- Keep manual CLI for Cloudflare Workers/Hono (edge runtime) and Python (fastapi/flask) quickstarts
- Fix broken /workflow/howto/local-development group links to development-server/local-tunnel pages