### PR TITLE
docs(redis): clarify compatibility scope

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18695,6 +18695,9 @@ Source: https://upstash.com/docs/redis/overall/compatibility
 
 Upstash supports Redis client protocol up to version `8.2`. We are also gradually adding changes introduced in later versions.
 
+This page lists Redis command support at the Upstash Redis API level. SDK command references may cover a smaller set of typed helpers.
+For example, see the [TypeScript SDK command reference](/docs/redis/sdks/ts/commands/overview) for the commands documented in `@upstash/redis`.
+
 Most of the unsupported items are in our roadmap. If you need a feature that we do not support, please drop a note to [support@upstash.com](mailto:support@upstash.com).
 So we can inform you when we are planning to support it.
 
@@ -22161,7 +22164,8 @@ It is the only connectionless (HTTP based) Redis client and designed for:
 
 See
 [the list of APIs](/docs/redis/features/restapi#rest-redis-api-compatibility)
-supported.
+supported by the Upstash REST API. For typed `@upstash/redis` command helpers,
+see the [TypeScript SDK command reference](/docs/redis/sdks/ts/commands/overview).
 
 # Auto-Pipelining
 Source: https://upstash.com/docs/redis/sdks/ts/pipelining/auto-pipeline

--- a/redis/overall/compatibility.mdx
+++ b/redis/overall/compatibility.mdx
@@ -9,6 +9,9 @@ sidebarTitle: "Compatibility"
 
 Upstash supports Redis client protocol up to version `8.2`. We are also gradually adding changes introduced in later versions.
 
+This page lists Redis command support at the Upstash Redis API level. SDK command references may cover a smaller set of typed helpers.
+For example, see the [TypeScript SDK command reference](/redis/sdks/ts/commands/overview) for the commands documented in `@upstash/redis`.
+
 Most of the unsupported items are in our roadmap. If you need a feature that we do not support, please drop a note to [support@upstash.com](mailto:support@upstash.com).
 So we can inform you when we are planning to support it.
 

--- a/redis/sdks/ts/overview.mdx
+++ b/redis/sdks/ts/overview.mdx
@@ -24,4 +24,5 @@ It is the only connectionless (HTTP based) Redis client and designed for:
 
 See
 [the list of APIs](/redis/features/restapi#rest-redis-api-compatibility)
-supported.
+supported by the Upstash REST API. For typed `@upstash/redis` command helpers,
+see the [TypeScript SDK command reference](/redis/sdks/ts/commands/overview).


### PR DESCRIPTION
Closes #632

## Summary

Clarifies that the Redis compatibility page describes Upstash Redis API-level command support, not complete TypeScript SDK helper coverage.

## What changed

- Added a note to the compatibility page explaining the distinction between Redis API support and SDK command references
- Updated the TypeScript SDK overview to point users to the SDK command reference for typed `@upstash/redis` helpers

## Why

`ZRANGESTORE` is listed on the Redis compatibility page, but there is no corresponding TypeScript SDK command doc. The compatibility page links to Redis command docs and appears to describe service/API compatibility, so clarifying the scope is safer than adding a command page for an SDK method that may not exist.