### PR TITLE
docs: correct team member invitation instructions

### DIFF
--- a/common/account/teams.mdx
+++ b/common/account/teams.mdx
@@ -43,7 +43,9 @@ there.
 
 ## Add/Remove Team Member
 
-After switching to a team, if you are the Owner or an Admin of the team, you can add team members by navigating to `Account > Teams`. Simply enter their email addresses.It's not an issue if the email addresses are not yet registered with Upstash. Once the user registers with that email, they will gain access to the team. We do not send invitations; when you add a member, they become a member directly. You can also remove members from the same page.
+After switching to a team, if you are the Owner or an Admin of the team, you can add team members by navigating to `Account > Teams`. Enter their email address and select a role, and we will send an invitation email to that address. The user joins the team by clicking the acceptance link in the email. It's not an issue if the email address is not yet registered with Upstash — they can accept the invitation after registering with that email.
+
+Until the invitation is accepted, the user appears as a **pending member** and does not have access to the team yet. You can revoke a pending invitation (**Revoke Invite**) or remove an existing member from the same page.
 
 > Only Admins or the Owner can add/remove users.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4938,7 +4938,9 @@ there.
 
 ## Add/Remove Team Member
 
-After switching to a team, if you are the Owner or an Admin of the team, you can add team members by navigating to `Account > Teams`. Simply enter their email addresses.It's not an issue if the email addresses are not yet registered with Upstash. Once the user registers with that email, they will gain access to the team. We do not send invitations; when you add a member, they become a member directly. You can also remove members from the same page.
+After switching to a team, if you are the Owner or an Admin of the team, you can add team members by navigating to `Account > Teams`. Enter their email address and select a role, and we will send an invitation email to that address. The user joins the team by clicking the acceptance link in the email. It's not an issue if the email address is not yet registered with Upstash — they can accept the invitation after registering with that email.
+
+Until the invitation is accepted, the user appears as a **pending member** and does not have access to the team yet. You can revoke a pending invitation (**Revoke Invite**) or remove an existing member from the same page.
 
 > Only Admins or the Owner can add/remove users.
 


### PR DESCRIPTION
Fixes the **Teams and Users** page (`common/account/teams.mdx`, "Add/Remove Team Member" section), which incorrectly stated that adding a team member does **not** send an invitation and that members become members directly.
