### PR TITLE
DX-2663: add indexable Pricing & Billing page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -75,6 +75,7 @@
                 "pages": [
                   "redis/overall/getstarted",
                   "redis/overall/pricing",
+                  "redis/overall/billing",
                   "redis/overall/compatibility",
                   "redis/overall/changelog",
                   "redis/overall/usecases",

--- a/docs.json
+++ b/docs.json
@@ -75,7 +75,6 @@
                 "pages": [
                   "redis/overall/getstarted",
                   "redis/overall/pricing",
-                  "redis/overall/billing",
                   "redis/overall/compatibility",
                   "redis/overall/changelog",
                   "redis/overall/usecases",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18724,6 +18724,98 @@ end
 ## Billing Optimization
 Sidekiq accesses Redis regularly, even when there is no queue activity. This can incur extra costs because Upstash charges per request on the Pay-As-You-Go plan. With the introduction of [our Fixed plans](/docs/redis/overall/pricing#all-plans-and-limits), **we recommend switching to a Fixed plan to avoid increased command count and high costs in Sidekiq use cases.**
 
+# Pricing & Billing
+Source: https://upstash.com/docs/redis/overall/billing
+
+Upstash Redis has a free tier and two paid plans: **Pay-As-You-Go** (billed per
+request) and **Fixed** (a flat monthly price). The numbers below reflect current
+pricing — see the [pricing page](https://upstash.com/pricing/redis) for the most
+up-to-date information.
+
+## Free tier
+
+Every account starts with a free database. No credit card required.
+
+| Limit              | Free            |
+| ------------------ | --------------- |
+| Price              | **$0 / month**  |
+| Data size          | 256 MB          |
+| Monthly commands   | 500K            |
+| Monthly bandwidth  | 10 GB           |
+| Max commands / sec | 10,000          |
+| Max request size   | 10 MB           |
+| Max record size    | 100 MB          |
+| Databases          | 1               |
+
+## Pay-As-You-Go (PAYG)
+
+Billed per request, so you only pay for what you use. Best for variable or
+low-volume workloads where command volume is unpredictable — caching in
+serverless functions, edge workloads, and apps that scale to zero.
+
+| Item               | Price                                          |
+| ------------------ | ---------------------------------------------- |
+| Commands           | **$0.20 per 100K commands**                    |
+| Storage            | $0.25 / GB per month (first 1 GB free)         |
+| Bandwidth          | Free up to 200 GB / month, then $0.03 / GB     |
+| Max data size      | 100 GB                                         |
+| Max commands / sec | 10,000                                         |
+| Databases          | Up to 100 ($0.50 per additional database)      |
+
+To avoid surprise charges, set a **monthly budget** on a PAYG database. When the
+budget is reached the database is rate-limited rather than continuing to bill.
+
+## Fixed plans
+
+A flat monthly price with a cap on throughput and data size. Usually cheaper than
+PAYG for sustained, high-throughput workloads where command count is consistently
+high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and
+cron jobs are a common fit because they hit Redis continuously even when idle.
+
+You can start on PAYG and switch to a Fixed plan later, or vice versa.
+
+## All plans and limits
+
+| Plan   | Price / month | Data size | Bandwidth | Commands / sec | Max request | Max record |
+| ------ | ------------- | --------- | --------- | -------------- | ----------- | ---------- |
+| Free   | $0            | 256 MB    | 10 GB     | 10,000         | 10 MB       | 100 MB     |
+| PAYG   | Per request   | 100 GB    | 200 GB*   | 10,000         | 10 MB       | 100 MB     |
+| 250 MB | $10           | 250 MB    | 50 GB     | 10,000         | 10 MB       | 100 MB     |
+| 1 GB   | $20           | 1 GB      | 100 GB    | 10,000         | 10 MB       | 200 MB     |
+| 5 GB   | $100          | 5 GB      | 500 GB    | 10,000         | 20 MB       | 300 MB     |
+| 10 GB  | $200          | 10 GB     | 1 TB      | 10,000         | 30 MB       | 400 MB     |
+| 50 GB  | $400          | 50 GB     | 5 TB      | 10,000         | 50 MB       | 500 MB     |
+| 100 GB | $800          | 100 GB    | 10 TB     | 16,000         | 75 MB       | 1 GB       |
+| 500 GB | $1,500        | 500 GB    | 20 TB     | 16,000         | 100 MB      | 5 GB       |
+
+<sub>*PAYG bandwidth is free up to 200 GB/month, then $0.03/GB. Enterprise plans
+support larger data sizes and custom limits — [contact us](/docs/common/help/support).</sub>
+
+## How billing works
+
+* **What counts as a command.** Pricing is based on the number of commands (requests)
+  executed. This applies equally to the [REST API](/docs/redis/features/restapi) and to
+  commands made over the Redis protocol — one command is one billable request in both
+  cases.
+* **Global databases.** With [Global replication](/docs/redis/features/globaldatabases),
+  each write is replicated to every read region, and each replicated write counts as a
+  command for billing. Adding read regions to a Fixed plan costs 50% of the base tier
+  price per region.
+* **Storage.** On PAYG, storage is billed at $0.25/GB per month with the first 1 GB free.
+  Fixed plans include storage up to the plan's data-size cap.
+* **Prod Pack.** Production features (high availability, encryption, SOC-2, advanced
+  monitoring) are available as an add-on for $200/month per database. See
+  [Prod Pack & Enterprise](/docs/redis/overall/enterprise).
+
+## Optimizing cost
+
+* On PAYG, a high baseline of background commands (for example, [Sidekiq](/docs/redis/integrations/sidekiq)
+  polling) can drive up command count even when there is no real workload — switching to
+  a Fixed plan caps that cost.
+* Prefer pipelines and `MULTI`/`EXEC` to reduce round trips; note that each command inside
+  a pipeline or transaction is still billed individually.
+* Set a monthly budget on PAYG databases to bound spend.
+
 # Changelog
 Source: https://upstash.com/docs/redis/overall/changelog
 
@@ -19495,18 +19587,6 @@ Source: https://upstash.com/docs/redis/overall/llms-txt
 
 # Pricing & Limits
 Source: https://upstash.com/docs/redis/overall/pricing
-
-Please check our [pricing page](https://upstash.com/pricing/redis) for the most up-to-date information on pricing and limits.
-
-## Choosing a plan
-
-Upstash Redis has two paid plans:
-
-* **Pay-As-You-Go (PAYG).** Billed per request. Best for variable or low-volume workloads where command volume is unpredictable, such as caching in serverless functions, edge workloads, and apps that scale to zero. To help prevent unexpected charges, it's possible to set a monthly budget on pay-as-you-go plans.
-
-* **Fixed plans.** A flat monthly price with a cap on throughput and data size. Usually cheaper than PAYG for sustained, high-throughput workloads where command count is consistently high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and cron jobs are a common fit.
-
-You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](https://upstash.com/pricing) for the full breakdown.
 
 # Pricing & Limits
 Source: https://upstash.com/docs/redis/overall/pricingold

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18727,6 +18727,11 @@ Sidekiq accesses Redis regularly, even when there is no queue activity. This can
 # Pricing & Billing
 Source: https://upstash.com/docs/redis/overall/billing
 
+<Info>
+  The most up-to-date pricing is always available at
+  [upstash.com/pricing/redis](https://upstash.com/pricing/redis).
+</Info>
+
 Upstash Redis has a free tier and two paid plans: **Pay-As-You-Go** (billed per
 request) and **Fixed** (a flat monthly price). The numbers below reflect current
 pricing — see the [pricing page](https://upstash.com/pricing/redis) for the most
@@ -18760,7 +18765,7 @@ serverless functions, edge workloads, and apps that scale to zero.
 | Bandwidth          | Free up to 200 GB / month, then $0.03 / GB     |
 | Max data size      | 100 GB                                         |
 | Max commands / sec | 10,000                                         |
-| Databases          | Up to 100 ($0.50 per additional database)      |
+| Databases          | First 10 free, then $0.50 each (up to 100)      |
 
 To avoid surprise charges, set a **monthly budget** on a PAYG database. When the
 budget is reached the database is rate-limited rather than continuing to bill.
@@ -18797,7 +18802,7 @@ support larger data sizes and custom limits — [contact us](/docs/common/help/s
   executed. This applies equally to the [REST API](/docs/redis/features/restapi) and to
   commands made over the Redis protocol — one command is one billable request in both
   cases.
-* **Global databases.** With [Global replication](/docs/redis/features/globaldatabases),
+* **Global databases.** With [Global replication](/docs/redis/features/globaldatabase),
   each write is replicated to every read region, and each replicated write counts as a
   command for billing. Adding read regions to a Fixed plan costs 50% of the base tier
   price per region.
@@ -19581,6 +19586,7 @@ Manage Upstash Redis databases from Claude and other AI tools by using our [MCP 
 * [Use cases](/docs/redis/overall/usecases): caching, rate limiting, queues, pub/sub, AI workloads, and more.
 * [Upstash Redis Search](/docs/redis/search/introduction): full-text search built into Upstash Redis.
 * [REST API](/docs/redis/features/restapi): connect from edge and serverless runtimes where TCP is restricted.
+* [Pricing & Billing](/docs/redis/overall/billing): free tier, Pay-As-You-Go, and Fixed plan limits, plus how billing works.
 
 # llms.txt
 Source: https://upstash.com/docs/redis/overall/llms-txt

--- a/llms.txt
+++ b/llms.txt
@@ -314,6 +314,7 @@
 - [Upstash Ratelimit Strapi Integration](https://upstash.com/docs/redis/integrations/ratelimit/strapi/getting-started.md)
 - [Replit Templates](https://upstash.com/docs/redis/integrations/replit-templates.md)
 - [Sidekiq with Upstash Redis](https://upstash.com/docs/redis/integrations/sidekiq.md)
+- [Pricing & Billing](https://upstash.com/docs/redis/overall/billing.md): How Upstash Redis pricing works — free tier, Pay-As-You-Go, and Fixed plans, with current limits and billing details.
 - [Changelog](https://upstash.com/docs/redis/overall/changelog.md)
 - [Compare](https://upstash.com/docs/redis/overall/compare.md)
 - [Redis® API Compatibility: supported commands, modules, and protocols](https://upstash.com/docs/redis/overall/compatibility.md)

--- a/redis/overall/billing.mdx
+++ b/redis/overall/billing.mdx
@@ -1,0 +1,93 @@
+---
+title: Pricing & Billing
+description: How Upstash Redis pricing works — free tier, Pay-As-You-Go, and Fixed plans, with current limits and billing details.
+---
+
+Upstash Redis has a free tier and two paid plans: **Pay-As-You-Go** (billed per
+request) and **Fixed** (a flat monthly price). The numbers below reflect current
+pricing — see the [pricing page](https://upstash.com/pricing/redis) for the most
+up-to-date information.
+
+## Free tier
+
+Every account starts with a free database. No credit card required.
+
+| Limit              | Free            |
+| ------------------ | --------------- |
+| Price              | **$0 / month**  |
+| Data size          | 256 MB          |
+| Monthly commands   | 500K            |
+| Monthly bandwidth  | 10 GB           |
+| Max commands / sec | 10,000          |
+| Max request size   | 10 MB           |
+| Max record size    | 100 MB          |
+| Databases          | 1               |
+
+## Pay-As-You-Go (PAYG)
+
+Billed per request, so you only pay for what you use. Best for variable or
+low-volume workloads where command volume is unpredictable — caching in
+serverless functions, edge workloads, and apps that scale to zero.
+
+| Item               | Price                                          |
+| ------------------ | ---------------------------------------------- |
+| Commands           | **$0.20 per 100K commands**                    |
+| Storage            | $0.25 / GB per month (first 1 GB free)         |
+| Bandwidth          | Free up to 200 GB / month, then $0.03 / GB     |
+| Max data size      | 100 GB                                         |
+| Max commands / sec | 10,000                                         |
+| Databases          | Up to 100 ($0.50 per additional database)      |
+
+To avoid surprise charges, set a **monthly budget** on a PAYG database. When the
+budget is reached the database is rate-limited rather than continuing to bill.
+
+## Fixed plans
+
+A flat monthly price with a cap on throughput and data size. Usually cheaper than
+PAYG for sustained, high-throughput workloads where command count is consistently
+high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and
+cron jobs are a common fit because they hit Redis continuously even when idle.
+
+You can start on PAYG and switch to a Fixed plan later, or vice versa.
+
+## All plans and limits
+
+| Plan   | Price / month | Data size | Bandwidth | Commands / sec | Max request | Max record |
+| ------ | ------------- | --------- | --------- | -------------- | ----------- | ---------- |
+| Free   | $0            | 256 MB    | 10 GB     | 10,000         | 10 MB       | 100 MB     |
+| PAYG   | Per request   | 100 GB    | 200 GB*   | 10,000         | 10 MB       | 100 MB     |
+| 250 MB | $10           | 250 MB    | 50 GB     | 10,000         | 10 MB       | 100 MB     |
+| 1 GB   | $20           | 1 GB      | 100 GB    | 10,000         | 10 MB       | 200 MB     |
+| 5 GB   | $100          | 5 GB      | 500 GB    | 10,000         | 20 MB       | 300 MB     |
+| 10 GB  | $200          | 10 GB     | 1 TB      | 10,000         | 30 MB       | 400 MB     |
+| 50 GB  | $400          | 50 GB     | 5 TB      | 10,000         | 50 MB       | 500 MB     |
+| 100 GB | $800          | 100 GB    | 10 TB     | 16,000         | 75 MB       | 1 GB       |
+| 500 GB | $1,500        | 500 GB    | 20 TB     | 16,000         | 100 MB      | 5 GB       |
+
+<sub>*PAYG bandwidth is free up to 200 GB/month, then $0.03/GB. Enterprise plans
+support larger data sizes and custom limits — [contact us](/common/help/support).</sub>
+
+## How billing works
+
+- **What counts as a command.** Pricing is based on the number of commands (requests)
+  executed. This applies equally to the [REST API](/redis/features/restapi) and to
+  commands made over the Redis protocol — one command is one billable request in both
+  cases.
+- **Global databases.** With [Global replication](/redis/features/globaldatabases),
+  each write is replicated to every read region, and each replicated write counts as a
+  command for billing. Adding read regions to a Fixed plan costs 50% of the base tier
+  price per region.
+- **Storage.** On PAYG, storage is billed at $0.25/GB per month with the first 1 GB free.
+  Fixed plans include storage up to the plan's data-size cap.
+- **Prod Pack.** Production features (high availability, encryption, SOC-2, advanced
+  monitoring) are available as an add-on for $200/month per database. See
+  [Prod Pack & Enterprise](/redis/overall/enterprise).
+
+## Optimizing cost
+
+- On PAYG, a high baseline of background commands (for example, [Sidekiq](/redis/integrations/sidekiq)
+  polling) can drive up command count even when there is no real workload — switching to
+  a Fixed plan caps that cost.
+- Prefer pipelines and `MULTI`/`EXEC` to reduce round trips; note that each command inside
+  a pipeline or transaction is still billed individually.
+- Set a monthly budget on PAYG databases to bound spend.

--- a/redis/overall/billing.mdx
+++ b/redis/overall/billing.mdx
@@ -3,6 +3,11 @@ title: Pricing & Billing
 description: How Upstash Redis pricing works — free tier, Pay-As-You-Go, and Fixed plans, with current limits and billing details.
 ---
 
+<Info>
+  The most up-to-date pricing is always available at
+  [upstash.com/pricing/redis](https://upstash.com/pricing/redis).
+</Info>
+
 Upstash Redis has a free tier and two paid plans: **Pay-As-You-Go** (billed per
 request) and **Fixed** (a flat monthly price). The numbers below reflect current
 pricing — see the [pricing page](https://upstash.com/pricing/redis) for the most
@@ -36,7 +41,7 @@ serverless functions, edge workloads, and apps that scale to zero.
 | Bandwidth          | Free up to 200 GB / month, then $0.03 / GB     |
 | Max data size      | 100 GB                                         |
 | Max commands / sec | 10,000                                         |
-| Databases          | Up to 100 ($0.50 per additional database)      |
+| Databases          | First 10 free, then $0.50 each (up to 100)      |
 
 To avoid surprise charges, set a **monthly budget** on a PAYG database. When the
 budget is reached the database is rate-limited rather than continuing to bill.
@@ -73,7 +78,7 @@ support larger data sizes and custom limits — [contact us](/common/help/suppor
   executed. This applies equally to the [REST API](/redis/features/restapi) and to
   commands made over the Redis protocol — one command is one billable request in both
   cases.
-- **Global databases.** With [Global replication](/redis/features/globaldatabases),
+- **Global databases.** With [Global replication](/redis/features/globaldatabase),
   each write is replicated to every read region, and each replicated write counts as a
   command for billing. Adding read regions to a Fixed plan costs 50% of the base tier
   price per region.

--- a/redis/overall/getstarted.mdx
+++ b/redis/overall/getstarted.mdx
@@ -84,3 +84,4 @@ Manage Upstash Redis databases from Claude and other AI tools by using our [MCP 
 - [Use cases](/redis/overall/usecases): caching, rate limiting, queues, pub/sub, AI workloads, and more.
 - [Upstash Redis Search](/redis/search/introduction): full-text search built into Upstash Redis.
 - [REST API](/redis/features/restapi): connect from edge and serverless runtimes where TCP is restricted.
+- [Pricing & Billing](/redis/overall/billing): free tier, Pay-As-You-Go, and Fixed plan limits, plus how billing works.

--- a/redis/overall/pricing.mdx
+++ b/redis/overall/pricing.mdx
@@ -2,15 +2,3 @@
 title: Pricing & Limits
 url: https://upstash.com/pricing/redis
 ---
-
-Please check our [pricing page](https://upstash.com/pricing/redis) for the most up-to-date information on pricing and limits.
-
-## Choosing a plan
-
-Upstash Redis has two paid plans:
-
-- **Pay-As-You-Go (PAYG).** Billed per request. Best for variable or low-volume workloads where command volume is unpredictable, such as caching in serverless functions, edge workloads, and apps that scale to zero. To help prevent unexpected charges, it's possible to set a monthly budget on pay-as-you-go plans.
-
-- **Fixed plans.** A flat monthly price with a cap on throughput and data size. Usually cheaper than PAYG for sustained, high-throughput workloads where command count is consistently high and predictable. Worker-heavy setups such as Sidekiq, BullMQ, Celery, and cron jobs are a common fit.
-
-You can start on PAYG and switch to a Fixed plan later, or vice versa. See [all plans and limits](https://upstash.com/pricing) for the full breakdown.


### PR DESCRIPTION
The redis/overall/pricing page uses a url: frontmatter redirect, so its body is never served and context7 can't index any pricing/billing content. Move that content to a real page (redis/overall/billing) that context7 can parse, with concrete free-tier/PAYG/Fixed plan limits and billing details. Strip the dead body from the redirect page.