### PR TITLE
docs(redis-search): document SEARCH.LISTINDEXES, index discovery, and $terms count accuracy

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25927,7 +25927,7 @@ Field must be `FAST`.
 |----------|------|----------|-------------|
 | `field` | `string` | Yes | Field to bucket on. |
 | `size` | `number` | No | Max number of buckets returned. |
-| `segmentSize` | `number` | No | Internal candidate size used while collecting top terms. |
+| `segmentSize` | `number` | No | Number of candidate terms collected per index segment before merging. Raising it improves count accuracy at higher cost; lowering it is cheaper but less accurate. See [Count accuracy](#count-accuracy). |
 | `showTermDocCountError` | `boolean` | No | Include `docCountErrorUpperBound` in output. |
 | `minDocCount` | `number` | No | Buckets with fewer docs are excluded. |
 | `order` | `object` | No | One-key order object: `{ "count": "desc" }`, `{ "key": "asc" }`, or `{ "<subAggAlias>": "desc" }`. |
@@ -25982,6 +25982,41 @@ SEARCH.AGGREGATE products '{}' '{"by_category": {"$terms": {"field": "category",
   }
 }
 ```
+
+* `sumOtherDocCount` — the number of matching documents that fell outside the returned buckets.
+
+### Count accuracy
+
+<Warning>
+`$terms` bucket counts are **approximate**. Terms are tallied per index segment and then
+merged, so a term's `docCount` can be slightly off when its documents are spread across many
+segments and the term sits near each segment's candidate cutoff.
+</Warning>
+
+Two fields help you reason about the error:
+
+* `docCountErrorUpperBound` — the maximum possible error on the returned counts. Enable
+  per-bucket reporting with `showTermDocCountError: true`.
+* `sumOtherDocCount` — the number of matching documents not included in the returned buckets.
+
+To improve accuracy, increase `segmentSize`: more candidate terms are collected per segment
+before merging, which shrinks the error at the cost of more work per query. As `segmentSize`
+grows, the same query converges toward exact counts and `docCountErrorUpperBound` approaches `0`:
+
+| `segmentSize` | A bucket's `docCount` | `docCountErrorUpperBound` |
+|---------------|-----------------------|---------------------------|
+| `10` | 23,829 | 17,988 |
+| default | 25,548 | 8,130 |
+| `200000` | 25,864 | 1 |
+
+If you need an exact count for one specific term, query or filter for it directly with
+[`SEARCH.COUNT`](/docs/redis/search/command-reference#searchcount) instead of reading it from a
+`$terms` bucket.
+
+<Note>
+This matches the behavior of Tantivy's Elasticsearch-compatible terms aggregation, which backs
+Upstash Redis Search.
+</Note>
 
 # $avg
 Source: https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/avg
@@ -27112,6 +27147,13 @@ SEARCH.LISTALIASES
 
 </Tabs>
 
+<Note>
+`SEARCH.LISTALIASES` only returns indexes that have an alias, and it returns an empty array
+when no aliases exist — even if the database has indexes. It is not a way to enumerate all of
+your indexes. To list every index in the database, use `SEARCH.LISTINDEXES` instead (see
+[Indices](/docs/redis/search/index-management#listing-indexes)).
+</Note>
+
 # Command Reference
 Source: https://upstash.com/docs/redis/search/command-reference
 
@@ -27196,6 +27238,56 @@ Do not call `SEARCH.WAITINDEXING` after every write. Batch updates are necessary
 optimal indexing performance. Use this command only when you need to ensure queries
 reflect recent changes, such as in tests or CI pipelines.
 </Warning>
+
+***
+
+### SEARCH.LISTINDEXES
+
+Lists all search indexes in the database.
+
+```bash
+SEARCH.LISTINDEXES [MATCH <pattern>] [LIMIT <count>] [OFFSET <offset>]
+```
+
+**Parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `MATCH` | Filter index names by a glob-style pattern (e.g. `h*`). | All indexes |
+| `LIMIT` | Maximum number of indexes to return. | All indexes |
+| `OFFSET` | Number of indexes to skip (for pagination). | 0 |
+
+**Returns:** One entry per index, each a map of `name` and the backing `type` (`HASH` or `JSON`).
+
+**Response format (Redis CLI):**
+
+```
+[
+  ["name", "productIdx", "type", "HASH"],
+  ["name", "blogIdx", "type", "JSON"]
+]
+```
+
+<Tabs>
+<Tab title="Redis CLI">
+```bash
+SEARCH.LISTINDEXES MATCH 'product*' LIMIT 10 OFFSET 0
+```
+</Tab>
+<Tab title="curl">
+```bash
+curl -X POST https://YOUR_ENDPOINT.upstash.io \
+  -H "Authorization: Bearer $UPSTASH_REDIS_REST_TOKEN" \
+  -d '["SEARCH.LISTINDEXES", "MATCH", "product*", "LIMIT", "10", "OFFSET", "0"]'
+```
+</Tab>
+</Tabs>
+
+<Note>
+To enumerate the indexes in your database, use `SEARCH.LISTINDEXES`. `SEARCH.LISTALIASES`
+only returns indexes that have an alias — it returns an empty array when no aliases exist,
+even if the database has indexes, so it is not a way to discover all of your indexes.
+</Note>
 
 ***
 
@@ -27361,7 +27453,9 @@ Returns all aliases and the indices they point to.
 SEARCH.LISTALIASES
 ```
 
-**Returns:** An array of `[alias, index_name]` pairs.
+**Returns:** An array of `[alias, index_name]` pairs. Returns an empty array if no aliases
+exist. This command only reports aliased indexes — to list every index in the database,
+use [`SEARCH.LISTINDEXES`](#searchlistindexes) instead.
 
 ***
 
@@ -28324,6 +28418,32 @@ On response, the following information is returned:
 | `prefixes` | List of tracked key prefixes             |
 | `language` | Stemming language                        |
 | `schema`   | Field definitions with types and options |
+
+### Listing Indexes
+
+The `SEARCH.LISTINDEXES` command enumerates all search indexes in the database. Each entry
+reports the index `name` and its backing `type` (`HASH` or `JSON`). You can optionally filter
+by a glob-style pattern with `MATCH` and paginate with `LIMIT` and `OFFSET`.
+
+<Tabs>
+
+<Tab title="Redis CLI">
+```bash
+SEARCH.LISTINDEXES
+# → [["name", "productIdx", "type", "HASH"], ["name", "blogIdx", "type", "JSON"]]
+
+# Filter index names by a glob pattern and paginate
+SEARCH.LISTINDEXES MATCH 'product*' LIMIT 10 OFFSET 0
+```
+</Tab>
+
+</Tabs>
+
+<Note>
+`SEARCH.LISTINDEXES` is the way to discover your indexes. Do not use `SEARCH.LISTALIASES`
+for this — it only returns indexes that have an alias and returns an empty array when no
+aliases exist, even if the database has indexes. See [Aliases](/docs/redis/search/aliases) for details.
+</Note>
 
 ### Dropping an Index
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25983,40 +25983,15 @@ SEARCH.AGGREGATE products '{}' '{"by_category": {"$terms": {"field": "category",
 }
 ```
 
-* `sumOtherDocCount` — the number of matching documents that fell outside the returned buckets.
+* `sumOtherDocCount` is the number of matching documents that fell outside the returned buckets.
 
 ### Count accuracy
 
 <Warning>
-`$terms` bucket counts are **approximate**. Terms are tallied per index segment and then
-merged, so a term's `docCount` can be slightly off when its documents are spread across many
-segments and the term sits near each segment's candidate cutoff.
+`$terms` bucket counts are **approximate**. Terms are tallied per index segment and then merged, so a term's `docCount` can be slightly off, especially for terms near the `size` cutoff.
 </Warning>
 
-Two fields help you reason about the error:
-
-* `docCountErrorUpperBound` — the maximum possible error on the returned counts. Enable
-  per-bucket reporting with `showTermDocCountError: true`.
-* `sumOtherDocCount` — the number of matching documents not included in the returned buckets.
-
-To improve accuracy, increase `segmentSize`: more candidate terms are collected per segment
-before merging, which shrinks the error at the cost of more work per query. As `segmentSize`
-grows, the same query converges toward exact counts and `docCountErrorUpperBound` approaches `0`:
-
-| `segmentSize` | A bucket's `docCount` | `docCountErrorUpperBound` |
-|---------------|-----------------------|---------------------------|
-| `10` | 23,829 | 17,988 |
-| default | 25,548 | 8,130 |
-| `200000` | 25,864 | 1 |
-
-If you need an exact count for one specific term, query or filter for it directly with
-[`SEARCH.COUNT`](/docs/redis/search/command-reference#searchcount) instead of reading it from a
-`$terms` bucket.
-
-<Note>
-This matches the behavior of Tantivy's Elasticsearch-compatible terms aggregation, which backs
-Upstash Redis Search.
-</Note>
+`docCountErrorUpperBound` reports the maximum possible error on the returned counts (set `showTermDocCountError: true` for per-bucket values), and `sumOtherDocCount` is the number of matching documents not included in the returned buckets. Raising `segmentSize` reduces the error at the cost of more work per query. For an exact count of a specific term, use [`SEARCH.COUNT`](/docs/redis/search/command-reference#searchcount) instead of reading it from a bucket.
 
 # $avg
 Source: https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/avg
@@ -27147,13 +27122,6 @@ SEARCH.LISTALIASES
 
 </Tabs>
 
-<Note>
-`SEARCH.LISTALIASES` only returns indexes that have an alias, and it returns an empty array
-when no aliases exist — even if the database has indexes. It is not a way to enumerate all of
-your indexes. To list every index in the database, use `SEARCH.LISTINDEXES` instead (see
-[Indices](/docs/redis/search/index-management#listing-indexes)).
-</Note>
-
 # Command Reference
 Source: https://upstash.com/docs/redis/search/command-reference
 
@@ -27282,12 +27250,6 @@ curl -X POST https://YOUR_ENDPOINT.upstash.io \
 ```
 </Tab>
 </Tabs>
-
-<Note>
-To enumerate the indexes in your database, use `SEARCH.LISTINDEXES`. `SEARCH.LISTALIASES`
-only returns indexes that have an alias — it returns an empty array when no aliases exist,
-even if the database has indexes, so it is not a way to discover all of your indexes.
-</Note>
 
 ***
 
@@ -27453,9 +27415,7 @@ Returns all aliases and the indices they point to.
 SEARCH.LISTALIASES
 ```
 
-**Returns:** An array of `[alias, index_name]` pairs. Returns an empty array if no aliases
-exist. This command only reports aliased indexes — to list every index in the database,
-use [`SEARCH.LISTINDEXES`](#searchlistindexes) instead.
+**Returns:** An array of `[alias, index_name]` pairs, or an empty array if no aliases exist. To list every index in the database, use [`SEARCH.LISTINDEXES`](#searchlistindexes).
 
 ***
 
@@ -28421,29 +28381,20 @@ On response, the following information is returned:
 
 ### Listing Indexes
 
-The `SEARCH.LISTINDEXES` command enumerates all search indexes in the database. Each entry
-reports the index `name` and its backing `type` (`HASH` or `JSON`). You can optionally filter
-by a glob-style pattern with `MATCH` and paginate with `LIMIT` and `OFFSET`.
+`SEARCH.LISTINDEXES` lists all search indexes in the database, reporting each index's `name` and backing `type` (`HASH` or `JSON`). Optionally filter names with `MATCH` and paginate with `LIMIT` and `OFFSET`.
 
 <Tabs>
 
 <Tab title="Redis CLI">
 ```bash
 SEARCH.LISTINDEXES
-# → [["name", "productIdx", "type", "HASH"], ["name", "blogIdx", "type", "JSON"]]
+# Returns: [["name", "productIdx", "type", "HASH"], ["name", "blogIdx", "type", "JSON"]]
 
-# Filter index names by a glob pattern and paginate
 SEARCH.LISTINDEXES MATCH 'product*' LIMIT 10 OFFSET 0
 ```
 </Tab>
 
 </Tabs>
-
-<Note>
-`SEARCH.LISTINDEXES` is the way to discover your indexes. Do not use `SEARCH.LISTALIASES`
-for this — it only returns indexes that have an alias and returns an empty array when no
-aliases exist, even if the database has indexes. See [Aliases](/docs/redis/search/aliases) for details.
-</Note>
 
 ### Dropping an Index
 

--- a/redis/search/aggregation-operators/bucket-aggregations/terms.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/terms.mdx
@@ -81,37 +81,12 @@ SEARCH.AGGREGATE products '{}' '{"by_category": {"$terms": {"field": "category",
 }
 ```
 
-- `sumOtherDocCount` — the number of matching documents that fell outside the returned buckets.
+- `sumOtherDocCount` is the number of matching documents that fell outside the returned buckets.
 
 ### Count accuracy
 
 <Warning>
-`$terms` bucket counts are **approximate**. Terms are tallied per index segment and then
-merged, so a term's `docCount` can be slightly off when its documents are spread across many
-segments and the term sits near each segment's candidate cutoff.
+`$terms` bucket counts are **approximate**. Terms are tallied per index segment and then merged, so a term's `docCount` can be slightly off, especially for terms near the `size` cutoff.
 </Warning>
 
-Two fields help you reason about the error:
-
-- `docCountErrorUpperBound` — the maximum possible error on the returned counts. Enable
-  per-bucket reporting with `showTermDocCountError: true`.
-- `sumOtherDocCount` — the number of matching documents not included in the returned buckets.
-
-To improve accuracy, increase `segmentSize`: more candidate terms are collected per segment
-before merging, which shrinks the error at the cost of more work per query. As `segmentSize`
-grows, the same query converges toward exact counts and `docCountErrorUpperBound` approaches `0`:
-
-| `segmentSize` | A bucket's `docCount` | `docCountErrorUpperBound` |
-|---------------|-----------------------|---------------------------|
-| `10` | 23,829 | 17,988 |
-| default | 25,548 | 8,130 |
-| `200000` | 25,864 | 1 |
-
-If you need an exact count for one specific term, query or filter for it directly with
-[`SEARCH.COUNT`](/redis/search/command-reference#searchcount) instead of reading it from a
-`$terms` bucket.
-
-<Note>
-This matches the behavior of Tantivy's Elasticsearch-compatible terms aggregation, which backs
-Upstash Redis Search.
-</Note>
+`docCountErrorUpperBound` reports the maximum possible error on the returned counts (set `showTermDocCountError: true` for per-bucket values), and `sumOtherDocCount` is the number of matching documents not included in the returned buckets. Raising `segmentSize` reduces the error at the cost of more work per query. For an exact count of a specific term, use [`SEARCH.COUNT`](/redis/search/command-reference#searchcount) instead of reading it from a bucket.

--- a/redis/search/aggregation-operators/bucket-aggregations/terms.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/terms.mdx
@@ -25,7 +25,7 @@ Field must be `FAST`.
 |----------|------|----------|-------------|
 | `field` | `string` | Yes | Field to bucket on. |
 | `size` | `number` | No | Max number of buckets returned. |
-| `segmentSize` | `number` | No | Internal candidate size used while collecting top terms. |
+| `segmentSize` | `number` | No | Number of candidate terms collected per index segment before merging. Raising it improves count accuracy at higher cost; lowering it is cheaper but less accurate. See [Count accuracy](#count-accuracy). |
 | `showTermDocCountError` | `boolean` | No | Include `docCountErrorUpperBound` in output. |
 | `minDocCount` | `number` | No | Buckets with fewer docs are excluded. |
 | `order` | `object` | No | One-key order object: `{ "count": "desc" }`, `{ "key": "asc" }`, or `{ "<subAggAlias>": "desc" }`. |
@@ -80,3 +80,38 @@ SEARCH.AGGREGATE products '{}' '{"by_category": {"$terms": {"field": "category",
   }
 }
 ```
+
+- `sumOtherDocCount` — the number of matching documents that fell outside the returned buckets.
+
+### Count accuracy
+
+<Warning>
+`$terms` bucket counts are **approximate**. Terms are tallied per index segment and then
+merged, so a term's `docCount` can be slightly off when its documents are spread across many
+segments and the term sits near each segment's candidate cutoff.
+</Warning>
+
+Two fields help you reason about the error:
+
+- `docCountErrorUpperBound` — the maximum possible error on the returned counts. Enable
+  per-bucket reporting with `showTermDocCountError: true`.
+- `sumOtherDocCount` — the number of matching documents not included in the returned buckets.
+
+To improve accuracy, increase `segmentSize`: more candidate terms are collected per segment
+before merging, which shrinks the error at the cost of more work per query. As `segmentSize`
+grows, the same query converges toward exact counts and `docCountErrorUpperBound` approaches `0`:
+
+| `segmentSize` | A bucket's `docCount` | `docCountErrorUpperBound` |
+|---------------|-----------------------|---------------------------|
+| `10` | 23,829 | 17,988 |
+| default | 25,548 | 8,130 |
+| `200000` | 25,864 | 1 |
+
+If you need an exact count for one specific term, query or filter for it directly with
+[`SEARCH.COUNT`](/redis/search/command-reference#searchcount) instead of reading it from a
+`$terms` bucket.
+
+<Note>
+This matches the behavior of Tantivy's Elasticsearch-compatible terms aggregation, which backs
+Upstash Redis Search.
+</Note>

--- a/redis/search/aliases.mdx
+++ b/redis/search/aliases.mdx
@@ -175,10 +175,3 @@ SEARCH.LISTALIASES
 </Tab>
 
 </Tabs>
-
-<Note>
-`SEARCH.LISTALIASES` only returns indexes that have an alias, and it returns an empty array
-when no aliases exist — even if the database has indexes. It is not a way to enumerate all of
-your indexes. To list every index in the database, use `SEARCH.LISTINDEXES` instead (see
-[Indices](/redis/search/index-management#listing-indexes)).
-</Note>

--- a/redis/search/aliases.mdx
+++ b/redis/search/aliases.mdx
@@ -175,3 +175,10 @@ SEARCH.LISTALIASES
 </Tab>
 
 </Tabs>
+
+<Note>
+`SEARCH.LISTALIASES` only returns indexes that have an alias, and it returns an empty array
+when no aliases exist — even if the database has indexes. It is not a way to enumerate all of
+your indexes. To list every index in the database, use `SEARCH.LISTINDEXES` instead (see
+[Indices](/redis/search/index-management#listing-indexes)).
+</Note>

--- a/redis/search/command-reference.mdx
+++ b/redis/search/command-reference.mdx
@@ -128,12 +128,6 @@ curl -X POST https://YOUR_ENDPOINT.upstash.io \
 </Tab>
 </Tabs>
 
-<Note>
-To enumerate the indexes in your database, use `SEARCH.LISTINDEXES`. `SEARCH.LISTALIASES`
-only returns indexes that have an alias — it returns an empty array when no aliases exist,
-even if the database has indexes, so it is not a way to discover all of your indexes.
-</Note>
-
 ---
 
 ## Query Commands
@@ -298,9 +292,7 @@ Returns all aliases and the indices they point to.
 SEARCH.LISTALIASES
 ```
 
-**Returns:** An array of `[alias, index_name]` pairs. Returns an empty array if no aliases
-exist. This command only reports aliased indexes — to list every index in the database,
-use [`SEARCH.LISTINDEXES`](#searchlistindexes) instead.
+**Returns:** An array of `[alias, index_name]` pairs, or an empty array if no aliases exist. To list every index in the database, use [`SEARCH.LISTINDEXES`](#searchlistindexes).
 
 ---
 

--- a/redis/search/command-reference.mdx
+++ b/redis/search/command-reference.mdx
@@ -86,6 +86,56 @@ reflect recent changes, such as in tests or CI pipelines.
 
 ---
 
+### SEARCH.LISTINDEXES
+
+Lists all search indexes in the database.
+
+```bash
+SEARCH.LISTINDEXES [MATCH <pattern>] [LIMIT <count>] [OFFSET <offset>]
+```
+
+**Parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `MATCH` | Filter index names by a glob-style pattern (e.g. `h*`). | All indexes |
+| `LIMIT` | Maximum number of indexes to return. | All indexes |
+| `OFFSET` | Number of indexes to skip (for pagination). | 0 |
+
+**Returns:** One entry per index, each a map of `name` and the backing `type` (`HASH` or `JSON`).
+
+**Response format (Redis CLI):**
+
+```
+[
+  ["name", "productIdx", "type", "HASH"],
+  ["name", "blogIdx", "type", "JSON"]
+]
+```
+
+<Tabs>
+<Tab title="Redis CLI">
+```bash
+SEARCH.LISTINDEXES MATCH 'product*' LIMIT 10 OFFSET 0
+```
+</Tab>
+<Tab title="curl">
+```bash
+curl -X POST https://YOUR_ENDPOINT.upstash.io \
+  -H "Authorization: Bearer $UPSTASH_REDIS_REST_TOKEN" \
+  -d '["SEARCH.LISTINDEXES", "MATCH", "product*", "LIMIT", "10", "OFFSET", "0"]'
+```
+</Tab>
+</Tabs>
+
+<Note>
+To enumerate the indexes in your database, use `SEARCH.LISTINDEXES`. `SEARCH.LISTALIASES`
+only returns indexes that have an alias — it returns an empty array when no aliases exist,
+even if the database has indexes, so it is not a way to discover all of your indexes.
+</Note>
+
+---
+
 ## Query Commands
 
 ### SEARCH.QUERY
@@ -248,7 +298,9 @@ Returns all aliases and the indices they point to.
 SEARCH.LISTALIASES
 ```
 
-**Returns:** An array of `[alias, index_name]` pairs.
+**Returns:** An array of `[alias, index_name]` pairs. Returns an empty array if no aliases
+exist. This command only reports aliased indexes — to list every index in the database,
+use [`SEARCH.LISTINDEXES`](#searchlistindexes) instead.
 
 ---
 

--- a/redis/search/index-management.mdx
+++ b/redis/search/index-management.mdx
@@ -460,29 +460,20 @@ On response, the following information is returned:
 
 ### Listing Indexes
 
-The `SEARCH.LISTINDEXES` command enumerates all search indexes in the database. Each entry
-reports the index `name` and its backing `type` (`HASH` or `JSON`). You can optionally filter
-by a glob-style pattern with `MATCH` and paginate with `LIMIT` and `OFFSET`.
+`SEARCH.LISTINDEXES` lists all search indexes in the database, reporting each index's `name` and backing `type` (`HASH` or `JSON`). Optionally filter names with `MATCH` and paginate with `LIMIT` and `OFFSET`.
 
 <Tabs>
 
 <Tab title="Redis CLI">
 ```bash
 SEARCH.LISTINDEXES
-# → [["name", "productIdx", "type", "HASH"], ["name", "blogIdx", "type", "JSON"]]
+# Returns: [["name", "productIdx", "type", "HASH"], ["name", "blogIdx", "type", "JSON"]]
 
-# Filter index names by a glob pattern and paginate
 SEARCH.LISTINDEXES MATCH 'product*' LIMIT 10 OFFSET 0
 ```
 </Tab>
 
 </Tabs>
-
-<Note>
-`SEARCH.LISTINDEXES` is the way to discover your indexes. Do not use `SEARCH.LISTALIASES`
-for this — it only returns indexes that have an alias and returns an empty array when no
-aliases exist, even if the database has indexes. See [Aliases](/redis/search/aliases) for details.
-</Note>
 
 ### Dropping an Index
 

--- a/redis/search/index-management.mdx
+++ b/redis/search/index-management.mdx
@@ -458,6 +458,32 @@ On response, the following information is returned:
 | `language` | Stemming language                        |
 | `schema`   | Field definitions with types and options |
 
+### Listing Indexes
+
+The `SEARCH.LISTINDEXES` command enumerates all search indexes in the database. Each entry
+reports the index `name` and its backing `type` (`HASH` or `JSON`). You can optionally filter
+by a glob-style pattern with `MATCH` and paginate with `LIMIT` and `OFFSET`.
+
+<Tabs>
+
+<Tab title="Redis CLI">
+```bash
+SEARCH.LISTINDEXES
+# → [["name", "productIdx", "type", "HASH"], ["name", "blogIdx", "type", "JSON"]]
+
+# Filter index names by a glob pattern and paginate
+SEARCH.LISTINDEXES MATCH 'product*' LIMIT 10 OFFSET 0
+```
+</Tab>
+
+</Tabs>
+
+<Note>
+`SEARCH.LISTINDEXES` is the way to discover your indexes. Do not use `SEARCH.LISTALIASES`
+for this — it only returns indexes that have an alias and returns an empty array when no
+aliases exist, even if the database has indexes. See [Aliases](/redis/search/aliases) for details.
+</Note>
+
 ### Dropping an Index
 
 The `SEARCH.DROP` command removes an index and stops tracking associated keys.


### PR DESCRIPTION
Documents three validated gaps in the Upstash Redis Search docs (all verified live against Upstash Redis v8.2).

1. **`SEARCH.LISTINDEXES`** was completely undocumented. Added it to the command reference and the Indices page: lists every index (`name` + backing `type`), with optional `MATCH`/`LIMIT`/`OFFSET`.
2. **Index discovery.** Clarified that `SEARCH.LISTINDEXES` is how you enumerate indexes, and that `SEARCH.LISTALIASES` only returns *aliased* indexes (so it is not a discovery mechanism).
3. **`$terms` counts are approximate.** Added a short "Count accuracy" note to the `$terms` page explaining `docCountErrorUpperBound`/`sumOtherDocCount`, that `segmentSize` trades accuracy for cost, and that `SEARCH.COUNT` gives an exact per-term count. Confirmed via a `segmentSize` convergence test (the same query's counts shift and the error bound collapses toward 0 as `segmentSize` grows).

Edits are to existing pages only (no `docs.json` change); `llms-full.txt` was regenerated by the repo's generator.
