### PR TITLE
Fix stale QStash log retention note

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10920,7 +10920,7 @@ Source: https://upstash.com/docs/qstash/howto/debug-logs
 To debug the logs, first you need to understand the different states a message can
 be in.
 
-Only the last 10.000 logs are kept and older logs are removed automatically.
+Older logs are removed automatically. See our [pricing page](https://upstash.com/pricing/qstash) for log retention limits.
 
 ## Lifecycle of a Message
 

--- a/qstash/howto/debug-logs.mdx
+++ b/qstash/howto/debug-logs.mdx
@@ -5,7 +5,7 @@ title: "Debug Logs"
 To debug the logs, first you need to understand the different states a message can
 be in.
 
-Only the last 10.000 logs are kept and older logs are removed automatically.
+Older logs are removed automatically. See our [pricing page](https://upstash.com/pricing/qstash) for log retention limits.
 
 ## Lifecycle of a Message
 


### PR DESCRIPTION
The QStash debug-logs page claimed only the last 10,000 logs are kept, which no longer matches the backend. Replaced it with a pointer to the pricing page for retention limits.