### PR TITLE
DX-2698: add label usage examples to qstash and workflow docs

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -46072,6 +46072,7 @@ const { workflowRunId } = await client.trigger({
     parallelism: 5,
     period: "10m"
   },
+  label: ["team-a", "high-priority"], // optional label(s); single string or array
 })
 ```
 
@@ -47606,7 +47607,9 @@ This way, you can invoke a workflow simply by passing the object to `context.inv
         {
           // 👇 Pass the workflow object as argument
           workflow: workflowOne,
-          body: "user-1"
+          body: "user-1",
+          // 👇 optionally label the invoked run; single string or array
+          label: ["team-a", "high-priority"],
         }
       ),
     });

--- a/qstash/sdks/ts/examples/publish.mdx
+++ b/qstash/sdks/ts/examples/publish.mdx
@@ -115,3 +115,31 @@ const res = await client.publishJSON({
   timeout: "30s" // 30 seconds timeout
 });
 ```
+
+#### Publish a message with labels
+
+Labels let you tag a message so you can later identify and filter it in the
+[logs](/qstash/sdks/ts/examples/logs) or when [cancelling messages](/qstash/sdks/ts/examples/messages#cancel-messages-with-filters).
+
+```typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+
+// attach a single label
+await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  label: "my-label",
+});
+
+// attach multiple labels to the same message
+await client.publishJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  label: ["team-a", "high-priority"],
+});
+```
+
+Labels are also available when [batching](/qstash/features/batch) and when
+[enqueuing to a queue](/qstash/sdks/ts/examples/queues#enqueue-a-message-with-labels).

--- a/qstash/sdks/ts/examples/queues.mdx
+++ b/qstash/sdks/ts/examples/queues.mdx
@@ -14,6 +14,24 @@ await client.queue({ queueName }).upsert({ parallelism: 2 });
 const queueDetails = await client.queue({ queueName }).get();
 ```
 
+#### Enqueue a message with labels
+
+`enqueue` and `enqueueJSON` accept the same options as `publish`, including
+`label`. Labels let you tag the message so you can later filter it in the
+[logs](/qstash/sdks/ts/examples/logs).
+
+```typescript
+import { Client } from "@upstash/qstash";
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+
+const queue = client.queue({ queueName: "upstash-queue" });
+await queue.enqueueJSON({
+  url: "https://my-api...",
+  body: { hello: "world" },
+  label: ["team-a", "high-priority"], // single string or array
+});
+```
+
 #### Delete Queue
 
 ```typescript

--- a/qstash/sdks/ts/examples/schedules.mdx
+++ b/qstash/sdks/ts/examples/schedules.mdx
@@ -101,19 +101,28 @@ await client.schedules.create({
 });
 ```
 
-#### Create a schedule with a label
+#### Create a schedule with labels
 
-A label tags the schedule so you can later identify and filter the messages it
+Labels tag the schedule so you can later identify and filter the messages it
 produces in the [logs](/qstash/sdks/ts/examples/logs).
 
 ```typescript
 import { Client } from "@upstash/qstash";
 
 const client = new Client({ token: "<QSTASH_TOKEN>" });
+
+// attach a single label
 await client.schedules.create({
   destination: "https://my-api...",
   cron: "* * * * *",
   label: "my-label",
+});
+
+// attach multiple labels to the same schedule
+await client.schedules.create({
+  destination: "https://my-api...",
+  cron: "* * * * *",
+  label: ["team-a", "high-priority"],
 });
 ```
 

--- a/qstash/sdks/ts/examples/schedules.mdx
+++ b/qstash/sdks/ts/examples/schedules.mdx
@@ -101,6 +101,22 @@ await client.schedules.create({
 });
 ```
 
+#### Create a schedule with a label
+
+A label tags the schedule so you can later identify and filter the messages it
+produces in the [logs](/qstash/sdks/ts/examples/logs).
+
+```typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ token: "<QSTASH_TOKEN>" });
+await client.schedules.create({
+  destination: "https://my-api...",
+  cron: "* * * * *",
+  label: "my-label",
+});
+```
+
 #### Pause/Resume a schedule
 
 ```typescript

--- a/workflow/basics/client/trigger.mdx
+++ b/workflow/basics/client/trigger.mdx
@@ -114,6 +114,7 @@ const { workflowRunId } = await client.trigger({
     parallelism: 5,
     period: "10m"
   },
+  label: ["team-a", "high-priority"], // optional label(s); single string or array
 })
 ```
 

--- a/workflow/features/invoke/serveMany.mdx
+++ b/workflow/features/invoke/serveMany.mdx
@@ -76,7 +76,9 @@ This way, you can invoke a workflow simply by passing the object to `context.inv
         {
           // 👇 Pass the workflow object as argument
           workflow: workflowOne,
-          body: "user-1"
+          body: "user-1",
+          // 👇 optionally label the invoked run; single string or array
+          label: ["team-a", "high-priority"],
         }
       ),
     });


### PR DESCRIPTION
## Summary

Adds runnable example snippets showing how to **attach** labels when publishing,
enqueuing, scheduling, and triggering/invoking — covering the multi-label
(`string | string[]`) support shipped in qstash-js (https://github.com/upstash/qstash-js/pull/266) and workflow-js (https://github.com/upstash/workflow-js/pull/197)
under DX-2698.

## Changes

- **QStash (TS examples):**
  - `publish.mdx` — "Publish a message with labels" (single + array)
  - `queues.mdx` — "Enqueue a message with labels"
  - `schedules.mdx` — "Create a schedule with a label" (single string)
- **Workflow:**
  - `basics/client/trigger.mdx` — added `label` to the `client.trigger` usage example
  - `features/invoke/serveMany.mdx` — added `label` to the `context.invoke` example

## Relationship to the previous PR on this ticket

A prior PR for DX-2698 — branch `origin/DX-2698`, commit 7d723ce0
"document multi-label support in workflow docs" — was **never merged as-is**.
It updated the **workflow reference docs only**: `ParamField` types to
`string | string[]`, `context.labels`, the log `labels[]` response field, a
"filter by multiple labels" example, and a changelog entry. Those workflow
reference updates have since already landed on `main` (trigger/logs/changelog
are now identical to that branch).

### What was missing there (and what this PR adds)

1. **No QStash docs at all.** The previous PR only touched workflow pages, even
   though qstash-js also shipped multi-label support. The QStash example pages
   had **zero** label content. This PR documents publishing, enqueuing, and
   scheduling with labels.
2. **No "how to attach a label" code examples.** The previous PR documented
   *filtering* by labels and updated type descriptions, but never showed a
   runnable snippet that actually sets `label` on a publish/trigger/invoke call.
   This PR adds those usage snippets on both the QStash and Workflow sides.

## Testing

Docs-only change. Verified MDX edits and internal cross-reference links
(`/qstash/features/batch`,`/qstash/sdks/ts/examples/queues#enqueue-a-message-with-labels`,
`/qstash/sdks/ts/examples/l