### PR TITLE
docs: add SEO meta descriptions to Redis, QStash, Workflow, and Box pages

### DIFF
--- a/box/guides/ai-sdk-code-interpreter.mdx
+++ b/box/guides/ai-sdk-code-interpreter.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Code Interpreter with Vercel AI SDK"
+description: Add a code interpreter tool to a Vercel AI SDK chat app that runs model-written code in a fresh, isolated Upstash Box sandbox.
 ---
 
 In this guide we'll add a **code interpreter** tool to a Vercel AI SDK chat app. When a user asks a question that needs computation — math, data analysis, statistics — the model writes code and sends it to a fresh `EphemeralBox` to run. The sandbox is isolated, disposable, and auto-expires when the session ends.

--- a/box/guides/code-review-agent.mdx
+++ b/box/guides/code-review-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Build a Code Review Agent"
+description: Build an automated code review agent with Upstash Box that clones a repo, analyzes the PR diff, and returns structured findings with severity.
 ---
 
 In this guide, we're building a code review agent (like CodeRabbit or Greptile) with Upstash Box. We clone a repo, inspect the PR diff, and return structured findings with severity and suggested fixes.

--- a/box/guides/crabbox-setup.mdx
+++ b/box/guides/crabbox-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Running Tests with Crabbox"
+description: Run your test suite in a clean cloud environment with Crabbox, a CLI that executes commands inside a remote Upstash Box.
 ---
 
 [Crabbox](https://crabbox.sh) is a CLI tool that runs commands inside a remote box from your local machine. This guide shows how to use it with Upstash Box to run your test suite in a clean cloud environment without touching your local setup.

--- a/box/guides/hermes-setup.mdx
+++ b/box/guides/hermes-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hermes Setup"
+description: Set up the Hermes agent inside an Upstash Box over SSH, install it, and configure an init script for automatic restarts.
 ---
 
 This guide walks you through setting up [Hermes](https://github.com/NousResearch/hermes-agent) inside an Upstash Box.

--- a/box/guides/openclaw-setup.mdx
+++ b/box/guides/openclaw-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OpenClaw Setup"
+description: Set up OpenClaw inside an Upstash Box, forward its dashboard over an SSH tunnel, and keep the gateway running with an init script.
 ---
 
 This guide walks you through setting up [OpenClaw](https://docs.openclaw.ai) inside an Upstash Box.

--- a/box/guides/remote-development.mdx
+++ b/box/guides/remote-development.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Remote Development"
+description: Run any dev server inside an Upstash Box and access it locally over SSH port forwarding, or share it with a public URL.
 ---
 
 Upstash Box supports full remote development workflows. By forwarding ports over SSH, you can run any web server inside a box and access it in your local browser exactly as if it were running on your machine. You can also expose it to the internet with a public URL for sharing or collaboration.

--- a/box/guides/tanstack-ai-file-editor.mdx
+++ b/box/guides/tanstack-ai-file-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AI File Editor with TanStack AI"
+description: Build an AI file editor with TanStack AI that runs model-written code on uploaded files inside a disposable Upstash Box sandbox.
 ---
 
 An `EphemeralBox` gives you exactly two capabilities: **code execution** and **file operations**. That turns out to be all you need to hand an AI agent a real, disposable computer. This guide uses both. The model writes the code, and a single tool moves files in and out of the sandbox to run it against.

--- a/box/guides/web-scraping-playwright.mdx
+++ b/box/guides/web-scraping-playwright.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Scrape Dynamic Websites with Playwright"
+description: Scrape JavaScript-heavy sites by running Playwright and Chromium inside an Upstash Box, then pull the structured results back.
 ---
 
 In this guide, we use Upstash Box to run [Playwright](https://playwright.dev) against a JavaScript-heavy site, scrape structured data from it, and pull the results back to our own server. Because a Box is a real Linux container rather than a restricted serverless runtime, Chromium and its system dependencies install and run exactly like they would on your laptop.

--- a/box/overall/agent.mdx
+++ b/box/overall/agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Agent"
+description: Configure a built-in coding agent like Claude Code, Codex, or OpenCode in an Upstash Box and run or stream tasks with typed output.
 ---
 
 **For every box, you can configure a built-in agent like Claude Code, Codex or OpenCode**. It has access to the filesystem, git, and shell commands and should simulate running an Agent on your own computer.

--- a/box/overall/attach-headers.mdx
+++ b/box/overall/attach-headers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Attach Headers"
+description: Inject secret HTTP headers into a box's outbound HTTPS requests with Upstash Box attach headers, keeping API keys out of the container.
 ---
 
 `attachHeaders` lets you inject HTTP headers into outbound HTTPS requests from a box without the secrets ever entering the container. This is useful for API keys, bearer tokens, and other credentials that should not be readable by code running inside the box.

--- a/box/overall/custom-agent.mdx
+++ b/box/overall/custom-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Add a Custom Agent"
+description: Bring your own agent process to an Upstash Box with a custom harness, streaming output back through the box-sse-v1 protocol.
 ---
 
 Custom agents let you bring your own agent process to an Upstash Box. The box still provides the same sandbox, filesystem, shell, git, logs, streaming, and console experience, but your code decides how to call the model and how to produce output.

--- a/box/overall/ephemeral-box.mdx
+++ b/box/overall/ephemeral-box.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ephemeral Box"
+description: EphemeralBox is a lightweight, short-lived Upstash Box sandbox with instant creation and auto-expiry for quick exec and file tasks.
 ---
 
 `EphemeralBox` is a lightweight, short-lived sandbox that provides only **exec** and **file** operations. It's designed for quick, disposable compute tasks where a full Box (with agent, git, snapshots, etc.) is unnecessary.

--- a/box/overall/files.mdx
+++ b/box/overall/files.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Filesystem"
+description: Upload, write, read, list, and download files inside an Upstash Box using its isolated per-box filesystem API.
 ---
 
 Every box has its own isolated filesystem. Upload, write, read, list, and download files inside the box.

--- a/box/overall/git.mdx
+++ b/box/overall/git.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Git"
+description: Clone repositories, inspect diffs, commit, push branches, and open pull requests from inside an Upstash Box with the git API.
 ---
 
 Clone a repository, inspect changes, commit work, push a branch, or open a pull request from inside a box.

--- a/box/overall/how-it-works.mdx
+++ b/box/overall/how-it-works.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Box Basics"
+description: "How Upstash Box works: durable, isolated containers with agent, git, shell, and filesystem, plus lifecycle, sizes, and billing."
 ---
 
 Every Upstash Box is a **durable execution environment** for AI workloads. Each box is an isolated container with its own filesystem, shell, network stack, and optional coding agent. You send prompts or commands, the box executes them, and you get back structured results without managing infrastructure.

--- a/box/overall/keep-alive.mdx
+++ b/box/overall/keep-alive.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Keep Alive"
+description: Keep an Upstash Box always on between sessions with keepAlive for servers and long-running agents, plus startup init commands.
 ---
 
 When `keepAlive` is enabled, the box stays on between sessions instead of auto-pausing when idle. Use it when you need a box to remain continuously available, for example to host a server, keep a long-running agent ready, or preserve an always-on development environment.

--- a/box/overall/network-policy.mdx
+++ b/box/overall/network-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Policy"
+description: "Control a box's outbound network access with Upstash Box network policies: allow-all, deny-all, or custom domain and CIDR rules."
 ---
 
 Network policies control outbound network access from a box.

--- a/box/overall/preview.mdx
+++ b/box/overall/preview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Public URLs"
+description: Expose ports from an Upstash Box with public URLs, optionally protected by bearer token or basic authentication.
 ---
 
 Expose ports from a box with public URLs. Each public URL maps to a specific port and can optionally require authentication.

--- a/box/overall/quickstart.mdx
+++ b/box/overall/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quickstart"
+description: "Get started with Upstash Box: install the SDK, create an isolated cloud container, configure an AI agent, and run your first task."
 ---
 
 **Upstash Box lets you give your AI agents a computer.**

--- a/box/overall/schedules.mdx
+++ b/box/overall/schedules.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedules"
+description: Schedule recurring shell commands or agent prompts inside an Upstash Box with cron expressions, webhooks, and schedule management.
 ---
 
 Create recurring tasks that run on a cron schedule inside a box. You can schedule shell commands or agent prompts. Available on both `box.schedule` and `ephemeralBox.schedule`.

--- a/box/overall/security.mdx
+++ b/box/overall/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Security & Secrets"
+description: How Upstash Box isolates containers and handles secrets, including environment variables, attach headers, and blocked variables.
 ---
 
 ## Isolation

--- a/box/overall/shell.mdx
+++ b/box/overall/shell.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Shell"
+description: Run shell commands and code snippets in an Upstash Box's full Linux shell through the SDK or an interactive SSH connection.
 ---
 
 Every box has a full Linux shell and runs on Debian by default.

--- a/box/overall/snapshots.mdx
+++ b/box/overall/snapshots.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Snapshots"
+description: Capture and restore Upstash Box state with snapshots to checkpoint workspaces, reuse prepared environments, and fan out boxes.
 ---
 
 Snapshots let you capture and duplicate box state. Use **snapshots** to save a point-in-time checkpoint you can restore later.

--- a/box/overall/use-cases.mdx
+++ b/box/overall/use-cases.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Use Cases"
+description: "Upstash Box use cases: durable agent servers, multi-agent orchestration, and parallel model testing with isolated cloud sandboxes."
 ---
 
 The idea behind Upstash Box is simple: **give AI its own computer**. Your agent gets a full, isolated cloud environment it can control. Run commands, write files, or execute code independent of any user device. Freeze a box anytime, and continue days or even weeks later with perfect resumability.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13961,25 +13961,25 @@ Publish delayed messages whenever a new user signs up in your app. After a
 certain delay (e.g. 10 minutes), QStash will send a request to your API,
 allowing you to email the user a welcome message.
 
-- [AWS Lambda (Node)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/nodejs.md)
-- [AWS Lambda (Python)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/python.md)
-- [Cloudflare Workers](https://upstash.com/docs/qstash/quickstarts/cloudflare-workers.md)
-- [Deno Deploy](https://upstash.com/docs/qstash/quickstarts/deno-deploy.md)
-- [Golang](https://upstash.com/docs/qstash/quickstarts/fly-io/go.md)
-- [Python on Vercel](https://upstash.com/docs/qstash/quickstarts/python-vercel.md)
-- [Next.js](https://upstash.com/docs/qstash/quickstarts/vercel-nextjs.md)
-- [Periodic Data Updates](https://upstash.com/docs/qstash/recipes/periodic-data-updates.md)
-- [DLQ](https://upstash.com/docs/qstash/sdks/py/examples/dlq.md)
-- [Events](https://upstash.com/docs/qstash/sdks/py/examples/events.md)
-- [Flow Control](https://upstash.com/docs/qstash/sdks/py/examples/flow-control.md)
-- [Keys](https://upstash.com/docs/qstash/sdks/py/examples/keys.md)
-- [Messages](https://upstash.com/docs/qstash/sdks/py/examples/messages.md)
-- [Overview](https://upstash.com/docs/qstash/sdks/py/examples/overview.md)
-- [Publish](https://upstash.com/docs/qstash/sdks/py/examples/publish.md)
-- [Queues](https://upstash.com/docs/qstash/sdks/py/examples/queues.md)
-- [Receiver](https://upstash.com/docs/qstash/sdks/py/examples/receiver.md)
-- [Schedules](https://upstash.com/docs/qstash/sdks/py/examples/schedules.md)
-- [URL Groups](https://upstash.com/docs/qstash/sdks/py/examples/url-groups.md)
+- [AWS Lambda (Node)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/nodejs.md): Receive and verify QStash webhooks in a Node.js AWS Lambda function, deploying with the AWS CDK or manually using signature verification.
+- [AWS Lambda (Python)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/python.md): Receive and verify QStash webhooks in a Python AWS Lambda function using PyJWT, then deploy and test the function on AWS.
+- [Cloudflare Workers](https://upstash.com/docs/qstash/quickstarts/cloudflare-workers.md): Receive and verify QStash webhooks in a Cloudflare Worker using the Upstash QStash SDK, with Worker-level and account-level secret setup.
+- [Deno Deploy](https://upstash.com/docs/qstash/quickstarts/deno-deploy.md): Receive and verify QStash webhooks in a Deno Deploy project using the Upstash QStash Receiver and your signing keys.
+- [Golang](https://upstash.com/docs/qstash/quickstarts/fly-io/go.md): Receive and verify QStash webhooks in a Go application deployed on Fly.io, using JWT signature verification with golang-jwt.
+- [Python on Vercel](https://upstash.com/docs/qstash/quickstarts/python-vercel.md): Use Upstash QStash to schedule a daily Python job on Vercel that cleans up your Redis database on a cron schedule.
+- [Next.js](https://upstash.com/docs/qstash/quickstarts/vercel-nextjs.md): Use Upstash QStash in Next.js to run reliable background jobs with automatic retries, publishing messages and verifying signatures on Vercel.
+- [Periodic Data Updates](https://upstash.com/docs/qstash/recipes/periodic-data-updates.md): Use QStash as a cron trigger for a Next.js API route that periodically fetches Bitcoin prices from an API and stores them in Redis.
+- [DLQ](https://upstash.com/docs/qstash/sdks/py/examples/dlq.md): Manage the QStash dead letter queue with the Python SDK by listing messages with cursor pagination, retrieving, and deleting DLQ messages.
+- [Events](https://upstash.com/docs/qstash/sdks/py/examples/events.md): List QStash events with cursor-based pagination using the Python SDK to track your published messages.
+- [Flow Control](https://upstash.com/docs/qstash/sdks/py/examples/flow-control.md): Manage QStash flow control keys with the Python SDK to inspect rate and parallelism, pause, resume, pin, unpin, and reset limits.
+- [Keys](https://upstash.com/docs/qstash/sdks/py/examples/keys.md): Retrieve and rotate your QStash signing keys with the Python SDK to verify incoming message signatures.
+- [Messages](https://upstash.com/docs/qstash/sdks/py/examples/messages.md): Retrieve, cancel, and bulk cancel in-flight QStash messages with the Python SDK.
+- [Overview](https://upstash.com/docs/qstash/sdks/py/examples/overview.md): Example usages of each method in the QStash Python SDK for publishing, scheduling, and managing messages.
+- [Publish](https://upstash.com/docs/qstash/sdks/py/examples/publish.md): Publish QStash messages with the Python SDK, adding delays, headers, callbacks, retries, deduplication, timeouts, and URL groups.
+- [Queues](https://upstash.com/docs/qstash/sdks/py/examples/queues.md): Create, configure, pause, resume, and delete QStash queues with parallelism using the Python SDK.
+- [Receiver](https://upstash.com/docs/qstash/sdks/py/examples/receiver.md): Verify QStash message signatures in your request handler using the Receiver helper in the Python SDK.
+- [Schedules](https://upstash.com/docs/qstash/sdks/py/examples/schedules.md): Create, list, get, pause, resume, and delete QStash cron schedules with the Python SDK, including callbacks and timeouts.
+- [URL Groups](https://upstash.com/docs/qstash/sdks/py/examples/url-groups.md): Create, list, and manage QStash URL groups and their endpoints for fan-out delivery using the Python SDK.
 
 # Getting Started
 Source: https://upstash.com/docs/qstash/sdks/py/gettingstarted
@@ -14061,16 +14061,16 @@ Using `qstash` you can:
 
 You can find the Github Repository [here](https://github.com/upstash/qstash-py).
 
-- [DLQ](https://upstash.com/docs/qstash/sdks/ts/examples/dlq.md)
-- [Flow Control](https://upstash.com/docs/qstash/sdks/ts/examples/flow-control.md)
-- [Logs](https://upstash.com/docs/qstash/sdks/ts/examples/logs.md)
-- [Messages](https://upstash.com/docs/qstash/sdks/ts/examples/messages.md)
-- [Overview](https://upstash.com/docs/qstash/sdks/ts/examples/overview.md)
-- [Publish](https://upstash.com/docs/qstash/sdks/ts/examples/publish.md)
-- [Queues](https://upstash.com/docs/qstash/sdks/ts/examples/queues.md)
-- [Receiver](https://upstash.com/docs/qstash/sdks/ts/examples/receiver.md)
-- [Schedules](https://upstash.com/docs/qstash/sdks/ts/examples/schedules.md)
-- [URL Groups](https://upstash.com/docs/qstash/sdks/ts/examples/url-groups.md)
+- [DLQ](https://upstash.com/docs/qstash/sdks/ts/examples/dlq.md): Manage the QStash dead letter queue with the TypeScript SDK by listing, filtering, deleting, and retrying DLQ messages.
+- [Flow Control](https://upstash.com/docs/qstash/sdks/ts/examples/flow-control.md): Manage QStash flow control keys with the TypeScript SDK to inspect rate and parallelism, pause, resume, pin, unpin, and reset limits.
+- [Logs](https://upstash.com/docs/qstash/sdks/ts/examples/logs.md): Retrieve QStash logs with the TypeScript SDK using cursor pagination, state filters, and message ID lookups.
+- [Messages](https://upstash.com/docs/qstash/sdks/ts/examples/messages.md): Retrieve, cancel, and bulk cancel in-flight QStash messages with filters using the TypeScript SDK.
+- [Overview](https://upstash.com/docs/qstash/sdks/ts/examples/overview.md): Example usages of each method in the QStash TypeScript SDK for publishing, scheduling, and managing messages.
+- [Publish](https://upstash.com/docs/qstash/sdks/ts/examples/publish.md): Publish QStash messages with the TypeScript SDK, adding delays, headers, callbacks, retries, deduplication, timeouts, and URL groups.
+- [Queues](https://upstash.com/docs/qstash/sdks/ts/examples/queues.md): Create, configure, pause, resume, and delete QStash queues with parallelism using the TypeScript SDK.
+- [Receiver](https://upstash.com/docs/qstash/sdks/ts/examples/receiver.md): Verify QStash message signatures in your request handler using the Receiver helper in the TypeScript SDK.
+- [Schedules](https://upstash.com/docs/qstash/sdks/ts/examples/schedules.md): Create, list, get, pause, resume, and delete QStash cron schedules with the TypeScript SDK, including callbacks and timeouts.
+- [URL Groups](https://upstash.com/docs/qstash/sdks/ts/examples/url-groups.md): Create, list, and manage QStash URL groups and their endpoints for fan-out delivery using the TypeScript SDK.
 
 # Getting Started
 Source: https://upstash.com/docs/qstash/sdks/ts/gettingstarted
@@ -20974,30 +20974,30 @@ We believe that Upstash is the best storage for your Lambda Functions because:
   </Card>
 </CardGroup>
 
-- [AWS Lambda](https://upstash.com/docs/redis/quickstarts/aws-lambda.md)
-- [Azure Functions](https://upstash.com/docs/redis/quickstarts/azure-functions.md)
-- [Cloudflare Workers](https://upstash.com/docs/redis/quickstarts/cloudflareworkers.md)
-- [Deno Deploy](https://upstash.com/docs/redis/quickstarts/deno-deploy.md)
-- [DigitalOcean](https://upstash.com/docs/redis/quickstarts/digitalocean.md)
-- [Django](https://upstash.com/docs/redis/quickstarts/django.md)
+- [AWS Lambda](https://upstash.com/docs/redis/quickstarts/aws-lambda.md): Connect Upstash Redis to an AWS Lambda function deployed with the AWS CDK in TypeScript.
+- [Azure Functions](https://upstash.com/docs/redis/quickstarts/azure-functions.md): Build a serverless Azure Function that reads and writes data using an Upstash Redis database.
+- [Cloudflare Workers](https://upstash.com/docs/redis/quickstarts/cloudflareworkers.md): Use Upstash Redis from a Cloudflare Workers edge function for low-latency key-value access worldwide.
+- [Deno Deploy](https://upstash.com/docs/redis/quickstarts/deno-deploy.md): Build a page view counter on Deno Deploy backed by an Upstash Redis database.
+- [DigitalOcean](https://upstash.com/docs/redis/quickstarts/digitalocean.md): Connect Upstash Redis to your DigitalOcean apps and migrate off the deprecated DigitalOcean integration.
+- [Django](https://upstash.com/docs/redis/quickstarts/django.md): Build a Django web app in Python that increments an Upstash Redis counter on every homepage visit.
 - [Elixir](https://upstash.com/docs/redis/quickstarts/elixir.md): Tutorial on Using Upstash Redis In Your Phoenix App and Deploying it on Fly.
-- [FastAPI](https://upstash.com/docs/redis/quickstarts/fastapi.md)
-- [Fastly](https://upstash.com/docs/redis/quickstarts/fastlycompute.md)
-- [Flask](https://upstash.com/docs/redis/quickstarts/flask.md)
-- [Fly.io](https://upstash.com/docs/redis/quickstarts/fly.md)
-- [Google Cloud Functions](https://upstash.com/docs/redis/quickstarts/google-cloud-functions.md)
-- [Ion](https://upstash.com/docs/redis/quickstarts/ion.md)
-- [ioredis note](https://upstash.com/docs/redis/quickstarts/ioredisnote.md)
-- [Koyeb](https://upstash.com/docs/redis/quickstarts/koyeb.md)
-- [Laravel](https://upstash.com/docs/redis/quickstarts/laravel.md)
-- [App Router](https://upstash.com/docs/redis/quickstarts/nextjs-app-router.md)
-- [Pages Router](https://upstash.com/docs/redis/quickstarts/nextjs-pages-router.md)
-- [ AWS Lambda](https://upstash.com/docs/redis/quickstarts/python-aws-lambda.md)
-- [SST v2](https://upstash.com/docs/redis/quickstarts/sst-v2.md)
-- [Supabase Functions](https://upstash.com/docs/redis/quickstarts/supabase.md)
-- [App Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-app-router.md)
-- [Pages Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-pages-router.md)
-- [Vercel Python Runtime](https://upstash.com/docs/redis/quickstarts/vercel-python-runtime.md)
+- [FastAPI](https://upstash.com/docs/redis/quickstarts/fastapi.md): Build a FastAPI application in Python that stores and retrieves data using Upstash Redis.
+- [Fastly](https://upstash.com/docs/redis/quickstarts/fastlycompute.md): Use Upstash Redis from a Fastly Compute edge application for fast, global key-value storage.
+- [Flask](https://upstash.com/docs/redis/quickstarts/flask.md): Build a Flask web app in Python that increments an Upstash Redis counter on each homepage visit.
+- [Fly.io](https://upstash.com/docs/redis/quickstarts/fly.md): Connect Upstash Redis to applications running on the Fly.io platform for global key-value storage.
+- [Google Cloud Functions](https://upstash.com/docs/redis/quickstarts/google-cloud-functions.md): Build a serverless Google Cloud Function that reads and writes data using Upstash Redis.
+- [Ion](https://upstash.com/docs/redis/quickstarts/ion.md): Provision and use Upstash Redis in an SST Ion app deployed to AWS with TypeScript.
+- [ioredis note](https://upstash.com/docs/redis/quickstarts/ioredisnote.md): Connect to Upstash Redis with ioredis using the connection string from the Node tab in the console.
+- [Koyeb](https://upstash.com/docs/redis/quickstarts/koyeb.md): Connect an Upstash Redis database as a cache to a Node.js application deployed on Koyeb.
+- [Laravel](https://upstash.com/docs/redis/quickstarts/laravel.md): Use Upstash Redis as the cache and data store for a PHP Laravel application.
+- [App Router](https://upstash.com/docs/redis/quickstarts/nextjs-app-router.md): Add Upstash Redis to a Next.js 15 App Router project with the @upstash/redis client.
+- [Pages Router](https://upstash.com/docs/redis/quickstarts/nextjs-pages-router.md): Add Upstash Redis to a Next.js Pages Router project with the @upstash/redis client.
+- [ AWS Lambda](https://upstash.com/docs/redis/quickstarts/python-aws-lambda.md): Connect Upstash Redis to a Python AWS Lambda function deployed with the AWS CDK.
+- [SST v2](https://upstash.com/docs/redis/quickstarts/sst-v2.md): Provision and use Upstash Redis in an SST v2 app deployed to AWS with TypeScript.
+- [Supabase Functions](https://upstash.com/docs/redis/quickstarts/supabase.md): Use Upstash Redis in a Supabase Edge Function to track invocation counts per region with a Redis hash.
+- [App Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-app-router.md): Use Upstash Redis in Vercel Functions with a Next.js App Router app and the @upstash/redis client.
+- [Pages Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-pages-router.md): Use Upstash Redis in Vercel Serverless Functions with a Next.js Pages Router app.
+- [Vercel Python Runtime](https://upstash.com/docs/redis/quickstarts/vercel-python-runtime.md): Use Upstash Redis with the Vercel Python runtime in a Django app, adaptable to Flask or FastAPI.
 
 # Agent Analytics
 Source: https://upstash.com/docs/redis/sdks/agent-analytics
@@ -22154,7 +22154,7 @@ with a chat UI that renders tool calls inline) lives in
   </Card>
 </CardGroup>
 
-- [ECHO](https://upstash.com/docs/redis/sdks/py/commands/auth/echo.md)
+- [ECHO](https://upstash.com/docs/redis/sdks/py/commands/auth/echo.md): Echo a message back from the server with the ECHO command in the Upstash Redis Python SDK, useful for debugging your connection.
 - [PING](https://upstash.com/docs/redis/sdks/py/commands/auth/ping.md): Send a ping to the server and get a response if the server is alive.
 - [BITCOUNT](https://upstash.com/docs/redis/sdks/py/commands/bitmap/bitcount.md): Count the number of set bits.
 - [BITFIELD](https://upstash.com/docs/redis/sdks/py/commands/bitmap/bitfield.md): Sets or gets parts of a bitfield
@@ -22256,8 +22256,8 @@ with a chat UI that renders tool calls inline) lives in
 - [SCRIPT FLUSH](https://upstash.com/docs/redis/sdks/py/commands/scripts/script_flush.md): Removes all scripts from the script cache.
 - [SCRIPT LOAD](https://upstash.com/docs/redis/sdks/py/commands/scripts/script_load.md): Load the specified Lua script into the script cache.
 - [DBSIZE](https://upstash.com/docs/redis/sdks/py/commands/server/dbsize.md): Count the number of keys in the database.
-- [FLUSHALL](https://upstash.com/docs/redis/sdks/py/commands/server/flushall.md)
-- [FLUSHDB](https://upstash.com/docs/redis/sdks/py/commands/server/flushdb.md)
+- [FLUSHALL](https://upstash.com/docs/redis/sdks/py/commands/server/flushall.md): Delete all keys across every database with the FLUSHALL command in the Upstash Redis Python SDK, using sync or async execution.
+- [FLUSHDB](https://upstash.com/docs/redis/sdks/py/commands/server/flushdb.md): Delete all keys in the selected database with the FLUSHDB command in the Upstash Redis Python SDK, using sync or async execution.
 - [SADD](https://upstash.com/docs/redis/sdks/py/commands/set/sadd.md): Adds one or more members to a set.
 - [SCARD](https://upstash.com/docs/redis/sdks/py/commands/set/scard.md): Return how many members are in a set
 - [SDIFF](https://upstash.com/docs/redis/sdks/py/commands/set/sdiff.md): Return the difference between sets
@@ -24449,7 +24449,7 @@ const redis = new Redis({
 });
 ```
 
-- [ECHO](https://upstash.com/docs/redis/sdks/ts/commands/auth/echo.md)
+- [ECHO](https://upstash.com/docs/redis/sdks/ts/commands/auth/echo.md): Echo a message back from the server with the ECHO command in the Upstash Redis TypeScript SDK, useful for debugging your connection.
 - [PING](https://upstash.com/docs/redis/sdks/ts/commands/auth/ping.md): Send a ping to the server and get a response if the server is alive.
 - [BITCOUNT](https://upstash.com/docs/redis/sdks/ts/commands/bitmap/bitcount.md): Count the number of set bits.
 - [BITOP](https://upstash.com/docs/redis/sdks/ts/commands/bitmap/bitop.md): Perform bitwise operations between strings.
@@ -24557,8 +24557,8 @@ const redis = new Redis({
 - [SCRIPT FLUSH](https://upstash.com/docs/redis/sdks/ts/commands/scripts/script_flush.md): Removes all scripts from the script cache.
 - [SCRIPT LOAD](https://upstash.com/docs/redis/sdks/ts/commands/scripts/script_load.md): Load the specified Lua script into the script cache.
 - [DBSIZE](https://upstash.com/docs/redis/sdks/ts/commands/server/dbsize.md): Count the number of keys in the database.
-- [FLUSHALL](https://upstash.com/docs/redis/sdks/ts/commands/server/flushall.md)
-- [FLUSHDB](https://upstash.com/docs/redis/sdks/ts/commands/server/flushdb.md)
+- [FLUSHALL](https://upstash.com/docs/redis/sdks/ts/commands/server/flushall.md): Delete all keys across every database with the FLUSHALL command in the Upstash Redis TypeScript SDK, using sync or async execution.
+- [FLUSHDB](https://upstash.com/docs/redis/sdks/ts/commands/server/flushdb.md): Delete all keys in the selected database with the FLUSHDB command in the Upstash Redis TypeScript SDK, using sync or async execution.
 - [SADD](https://upstash.com/docs/redis/sdks/ts/commands/set/sadd.md): Adds one or more members to a set.
 - [SCARD](https://upstash.com/docs/redis/sdks/ts/commands/set/scard.md): Return how many members are in a set
 - [SDIFF](https://upstash.com/docs/redis/sdks/ts/commands/set/sdiff.md): Return the difference between sets
@@ -24591,7 +24591,7 @@ const redis = new Redis({
 - [XREADGROUP](https://upstash.com/docs/redis/sdks/ts/commands/stream/xreadgroup.md): Reads data from a stream as part of a consumer group.
 - [XREVRANGE](https://upstash.com/docs/redis/sdks/ts/commands/stream/xrevrange.md): Returns stream entries matching a given range of IDs in reverse order.
 - [XTRIM](https://upstash.com/docs/redis/sdks/ts/commands/stream/xtrim.md): Trims the stream by removing entries to keep it at a reasonable size.
-- [String Commands](https://upstash.com/docs/redis/sdks/ts/commands/string.md)
+- [String Commands](https://upstash.com/docs/redis/sdks/ts/commands/string.md): Work with Redis string commands like MGET, MSET, SET, and SETEX in the Upstash Redis TypeScript SDK.
 - [APPEND](https://upstash.com/docs/redis/sdks/ts/commands/string/append.md): Append a value to a string stored at key.
 - [DECR](https://upstash.com/docs/redis/sdks/ts/commands/string/decr.md): Decrement the integer value of a key by one
 - [DECRBY](https://upstash.com/docs/redis/sdks/ts/commands/string/decrby.md): Decrement the integer value of a key by a given number.
@@ -30586,10 +30586,10 @@ use the **alias name** (not the actual document field name) when specifying fiel
 The highlighting feature works with indexed field names, which are the aliases.
 </Note>
 
-- [Blog Search](https://upstash.com/docs/redis/search/recipes/blog-search.md)
-- [E-commerce Search](https://upstash.com/docs/redis/search/recipes/e-commerce-search.md)
-- [Overview](https://upstash.com/docs/redis/search/recipes/overview.md)
-- [User Directory](https://upstash.com/docs/redis/search/recipes/user-directory.md)
+- [Blog Search](https://upstash.com/docs/redis/search/recipes/blog-search.md): Build full-text blog search with highlighted snippets, phrase matching, and date filtering using Upstash Redis Search.
+- [E-commerce Search](https://upstash.com/docs/redis/search/recipes/e-commerce-search.md): Build a product catalog search with filtering, sorting, typo tolerance, and relevance boosting using Upstash Redis Search.
+- [Overview](https://upstash.com/docs/redis/search/recipes/overview.md): Real-world Upstash Redis Search recipes for e-commerce, blog, and user directory search, each with schema design, sample data, and query patterns.
+- [User Directory](https://upstash.com/docs/redis/search/recipes/user-directory.md): Build a searchable employee directory with autocomplete, fuzzy name matching, and department filtering using Upstash Redis Search.
 
 # Schemas
 Source: https://upstash.com/docs/redis/search/schema-definition
@@ -31705,38 +31705,38 @@ Acknowledge the consumed messages via [XACK](https://redis.io/commands/xack/)
 from the list of the associated group and consumer.
 
 - [Agent Memory with Redis Search](https://upstash.com/docs/redis/tutorials/agent_memory.md): Build short-term and long-term memory for AI agents on Upstash Redis. Store working memory with TTLs and recall long-term memories with Redis Search full-text queries.
-- [Deploy a Serverless API with AWS CDK and AWS Lambda](https://upstash.com/docs/redis/tutorials/api_with_cdk.md)
-- [Autocomplete API with Serverless Redis](https://upstash.com/docs/redis/tutorials/auto_complete_with_serverless_redis.md)
+- [Deploy a Serverless API with AWS CDK and AWS Lambda](https://upstash.com/docs/redis/tutorials/api_with_cdk.md): Build and deploy a serverless view-counter API on AWS Lambda with the AWS CDK in TypeScript, using Upstash Redis for state.
+- [Autocomplete API with Serverless Redis](https://upstash.com/docs/redis/tutorials/auto_complete_with_serverless_redis.md): Build an autocomplete API using Upstash Redis sorted sets and ZRANK to return term suggestions from prefixes.
 - [Build Stateful Applications with AWS App Runner and Serverless Redis](https://upstash.com/docs/redis/tutorials/aws_app_runner_with_redis.md): This tutorial shows how to create a serverless and stateful application using AWS App Runner and Redis
 - [Session Management on Google Cloud Run with Serverless Redis](https://upstash.com/docs/redis/tutorials/cloud_run_sessions.md): This tutorial shows how to manage user sessions on Google Cloud Run using Serverless Redis.
 - [Cloudflare Workers with Websockets and Redis](https://upstash.com/docs/redis/tutorials/cloudflare_websockets_redis.md)
-- [Use Redis in Cloudflare Workers](https://upstash.com/docs/redis/tutorials/cloudflare_workers_with_redis.md)
-- [Backendless Coin Price List with GraphQL API, Serverless Redis and Next.JS](https://upstash.com/docs/redis/tutorials/coin_price_list.md)
+- [Use Redis in Cloudflare Workers](https://upstash.com/docs/redis/tutorials/cloudflare_workers_with_redis.md): Use Upstash Redis via REST API in a Cloudflare Workers edge function to serve location-based greetings.
+- [Backendless Coin Price List with GraphQL API, Serverless Redis and Next.JS](https://upstash.com/docs/redis/tutorials/coin_price_list.md): Build a backendless coin price list with Next.js and the Upstash GraphQL API, reading Redis directly from the client.
 - [Build a Leaderboard API At Edge using Cloudflare Workers and Redis](https://upstash.com/docs/redis/tutorials/edge_leaderboard.md): This tutorial shows how to build a Leaderboard API At Edge using Cloudflare Workers and Redis.
 - [Express Session with Serverless Redis](https://upstash.com/docs/redis/tutorials/express_session.md): This tutorial shows how to use Upstash as the session storage of your Express application.
-- [Serverless Golang API with Redis](https://upstash.com/docs/redis/tutorials/goapi.md)
+- [Serverless Golang API with Redis](https://upstash.com/docs/redis/tutorials/goapi.md): Build a serverless Golang page-view counter API on AWS Lambda with Upstash Redis, deployed using AWS SAM.
 - [Build a Serverless Histogram API with Redis](https://upstash.com/docs/redis/tutorials/histogram.md): This tutorial shows how to build a histogram API with Redis.
 - [Job Processing and Event Queue with Serverless Redis](https://upstash.com/docs/redis/tutorials/job_processing.md): This tutorial shows how to use Upstash Redis for job/task processing.
-- [Caching in Laravel with Redis](https://upstash.com/docs/redis/tutorials/laravel_caching.md)
-- [Next.js with Redis](https://upstash.com/docs/redis/tutorials/nextjs_with_redis.md)
+- [Caching in Laravel with Redis](https://upstash.com/docs/redis/tutorials/laravel_caching.md): Add caching to a Laravel application with Upstash Redis to speed up database-backed queries.
+- [Next.js with Redis](https://upstash.com/docs/redis/tutorials/nextjs_with_redis.md): Use Upstash Redis as a state store in a Next.js App Router app by building a simple page-view counter.
 - [Building a Serverless Notification API for Your Web Application with Redis](https://upstash.com/docs/redis/tutorials/notification.md): This tutorial shows how to create a Serverless Notification API for Your Web Application with Redis.
 - [Nuxt with Redis](https://upstash.com/docs/redis/tutorials/nuxtjs_with_redis.md): This tutorial shows how to use Upstash inside your Nuxt application.
-- [Redis as a Cache for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_fastapi_caching.md)
-- [Multithreaded Web Scraping with Redis Caching](https://upstash.com/docs/redis/tutorials/python_multithreading.md)
-- [Rate Limiting for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_rate_limiting.md)
-- [Build a Real-Time Chat Application with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_realtime_chat.md)
-- [Manage Sessions in Python with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_session.md)
-- [Building a URL Shortener with Redis](https://upstash.com/docs/redis/tutorials/python_url_shortener.md)
-- [Serverless Python API with Redis](https://upstash.com/docs/redis/tutorials/pythonapi.md)
-- [AWS Lambda Rate Limiting with Serverless Redis](https://upstash.com/docs/redis/tutorials/rate-limiting.md)
+- [Redis as a Cache for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_fastapi_caching.md): Cache FastAPI responses with Upstash Redis to cut database queries and speed up an external weather API app.
+- [Multithreaded Web Scraping with Redis Caching](https://upstash.com/docs/redis/tutorials/python_multithreading.md): Build a multithreaded Python web scraper that caches HTTP responses in Upstash Redis to avoid redundant requests.
+- [Rate Limiting for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_rate_limiting.md): Add rate limiting to a FastAPI app with Upstash Redis using a fixed window limiter to control API usage.
+- [Build a Real-Time Chat Application with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_realtime_chat.md): Build a real-time chat app with Flask, SocketIO, and Upstash Redis Pub/Sub for low-latency message handling.
+- [Manage Sessions in Python with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_session.md): Implement session management in a FastAPI app using cookies and Upstash Redis for fast, expiring session storage.
+- [Building a URL Shortener with Redis](https://upstash.com/docs/redis/tutorials/python_url_shortener.md): Build a URL shortener in Python with Upstash Redis, generating short codes and setting expiration times for links.
+- [Serverless Python API with Redis](https://upstash.com/docs/redis/tutorials/pythonapi.md): Build a serverless Python page-view counter API on AWS Lambda with Upstash Redis, deployed using the AWS CDK.
+- [AWS Lambda Rate Limiting with Serverless Redis](https://upstash.com/docs/redis/tutorials/rate-limiting.md): Rate limit an AWS Lambda function by client IP using @upstash/ratelimit, Upstash Redis, and the Serverless Framework.
 - [Redis Queue: From FIFO Lists to a Job Queue](https://upstash.com/docs/redis/tutorials/redis_queue.md): How to build FIFO, reliable, and blocking queues on Upstash Redis, then a delayed and prioritized job queue with a dead-letter queue.
 - [Serverless Redisson](https://upstash.com/docs/redis/tutorials/redisson.md): This tutorial shows how to use Upstash with Redisson client.
 - [Roadmap Voting App with Serverless Redis](https://upstash.com/docs/redis/tutorials/roadmapvotingapp.md): This is a single page application powered by upstash and next.js.
-- [Serverless API with Java and Redis](https://upstash.com/docs/redis/tutorials/serverless_java_redis.md)
+- [Serverless API with Java and Redis](https://upstash.com/docs/redis/tutorials/serverless_java_redis.md): Build a stateful serverless page-view counter API with Java and Upstash Redis on AWS Lambda.
 - [TanStack AI Chat Persistance](https://upstash.com/docs/redis/tutorials/tanstack_chat_persistence.md): Use Upstash Redis to persist TanStack AI chat histories across reloads, navigation, and devices with a simple adapter.
-- [Using AWS SAM](https://upstash.com/docs/redis/tutorials/using_aws_sam.md)
-- [Serverless Redis on Google Cloud Functions](https://upstash.com/docs/redis/tutorials/using_google_cloud_functions.md)
-- [Using Serverless Framework](https://upstash.com/docs/redis/tutorials/using_serverless_framework.md)
+- [Using AWS SAM](https://upstash.com/docs/redis/tutorials/using_aws_sam.md): Build and deploy a serverless application to AWS Lambda with Upstash Redis using the AWS SAM CLI.
+- [Serverless Redis on Google Cloud Functions](https://upstash.com/docs/redis/tutorials/using_google_cloud_functions.md): Build a serverless view-counter API on Google Cloud Functions using Upstash Redis as the data store.
+- [Using Serverless Framework](https://upstash.com/docs/redis/tutorials/using_serverless_framework.md): Build and deploy a serverless application to AWS Lambda with Upstash Redis using the Serverless Framework.
 
 # Advanced Settings
 Source: https://upstash.com/docs/search/features/advanced-settings
@@ -46956,15 +46956,15 @@ Source: https://upstash.com/docs/workflow/changelog
 * Released [Upstash Workflow](/docs/workflow/getstarted).
 </Update>
 
-- [AI Generation](https://upstash.com/docs/workflow/examples/allInOne.md)
-- [Auth Provider Webhook](https://upstash.com/docs/workflow/examples/authWebhook.md)
-- [Custom Retry Logic](https://upstash.com/docs/workflow/examples/customRetry.md)
-- [Customer Onboarding](https://upstash.com/docs/workflow/examples/customerOnboarding.md)
-- [Dynamic Workflows](https://upstash.com/docs/workflow/examples/dynamicWorkflow.md)
-- [E-commerce Order Fulfillment](https://upstash.com/docs/workflow/examples/eCommerceOrderFulfillment.md)
-- [Image Processing](https://upstash.com/docs/workflow/examples/imageProcessing.md)
-- [Payment Retries](https://upstash.com/docs/workflow/examples/paymentRetry.md)
-- [Waiting for Events](https://upstash.com/docs/workflow/examples/waitForEvent.md)
+- [AI Generation](https://upstash.com/docs/workflow/examples/allInOne.md): Process large datasets with Upstash Workflow by downloading data, processing chunks with OpenAI GPT-4, aggregating results, and generating a report.
+- [Auth Provider Webhook](https://upstash.com/docs/workflow/examples/authWebhook.md): Build an authentication provider webhook with Upstash Workflow to handle user creation, Stripe trials, and automated email reminders.
+- [Custom Retry Logic](https://upstash.com/docs/workflow/examples/customRetry.md): Implement custom retry logic in Upstash Workflow using response status codes and headers to control retries when calling third-party APIs like OpenAI.
+- [Customer Onboarding](https://upstash.com/docs/workflow/examples/customerOnboarding.md): Build a customer onboarding workflow with Upstash Workflow that registers users, sends welcome emails, and reacts to user activity over time.
+- [Dynamic Workflows](https://upstash.com/docs/workflow/examples/dynamicWorkflow.md): Build dynamic, configurable workflows with Upstash Workflow that run runtime-defined steps while safely handling ordering, naming, and versioning.
+- [E-commerce Order Fulfillment](https://upstash.com/docs/workflow/examples/eCommerceOrderFulfillment.md): Automate e-commerce order fulfillment with Upstash Workflow by verifying stock, processing payment, dispatching orders, and notifying customers.
+- [Image Processing](https://upstash.com/docs/workflow/examples/imageProcessing.md): Process images with Upstash Workflow by uploading, resizing into multiple resolutions, applying filters, and storing the processed versions.
+- [Payment Retries](https://upstash.com/docs/workflow/examples/paymentRetry.md): Build a payment retry workflow with Upstash Workflow that retries failed charges, sends invoice emails, and suspends accounts after repeated failures.
+- [Waiting for Events](https://upstash.com/docs/workflow/examples/waitForEvent.md): Pause and resume workflows with Upstash Workflow's wait-for-event feature, letting an external system notify order processing when it is ready.
 
 # Overview
 Source: https://upstash.com/docs/workflow/features/dlq
@@ -52073,20 +52073,20 @@ For detailed pricing information based on different plans, visit our [Workflow p
 * Each step in a [parallel run](/docs/workflow/howto/parallel-runs) costs 1 extra message.
 * If the workflow endpoint or URL in [context.call](/docs/workflow/basics/context#context-call) returns an error or is unreachable, the workflow SDK will retry the call (up to 3 times by default). Each retry counts as a new message.
 
-- [Astro](https://upstash.com/docs/workflow/quickstarts/astro.md)
-- [Cloudflare Workers](https://upstash.com/docs/workflow/quickstarts/cloudflare-workers.md)
-- [Express.js](https://upstash.com/docs/workflow/quickstarts/express.md)
-- [FastAPI](https://upstash.com/docs/workflow/quickstarts/fastapi.md)
-- [Flask](https://upstash.com/docs/workflow/quickstarts/flask.md)
-- [Hono](https://upstash.com/docs/workflow/quickstarts/hono.md)
-- [Next.js & FastAPI](https://upstash.com/docs/workflow/quickstarts/nextjs-fastapi.md)
-- [Next.js & Flask](https://upstash.com/docs/workflow/quickstarts/nextjs-flask.md)
-- [Nuxt](https://upstash.com/docs/workflow/quickstarts/nuxt.md)
-- [Supported Platforms](https://upstash.com/docs/workflow/quickstarts/platforms.md)
-- [SolidJS](https://upstash.com/docs/workflow/quickstarts/solidjs.md)
-- [SvelteKit](https://upstash.com/docs/workflow/quickstarts/svelte.md)
-- [TanStack Start](https://upstash.com/docs/workflow/quickstarts/tanstack-start.md)
-- [Next.js](https://upstash.com/docs/workflow/quickstarts/vercel-nextjs.md)
+- [Astro](https://upstash.com/docs/workflow/quickstarts/astro.md): Use Upstash Workflow with Astro in this step-by-step quickstart, with a complete example project on GitHub.
+- [Cloudflare Workers](https://upstash.com/docs/workflow/quickstarts/cloudflare-workers.md): Deploy Upstash Workflow on Cloudflare Workers with this step-by-step guide, including Hono.js examples and best practices.
+- [Express.js](https://upstash.com/docs/workflow/quickstarts/express.md): Use Upstash Workflow with Express.js in this step-by-step quickstart, with a complete example project on GitHub.
+- [FastAPI](https://upstash.com/docs/workflow/quickstarts/fastapi.md): Use Upstash Workflow with FastAPI in Python through this step-by-step quickstart, with an end-to-end example project on GitHub.
+- [Flask](https://upstash.com/docs/workflow/quickstarts/flask.md): Use Upstash Workflow with Flask in Python through this step-by-step quickstart, with an end-to-end example project on GitHub.
+- [Hono](https://upstash.com/docs/workflow/quickstarts/hono.md): Deploy Upstash Workflow with Hono on Cloudflare Workers in this step-by-step quickstart, with an end-to-end example project.
+- [Next.js & FastAPI](https://upstash.com/docs/workflow/quickstarts/nextjs-fastapi.md): Build durable workflows with Upstash Workflow using a Next.js frontend and FastAPI backend in this step-by-step quickstart.
+- [Next.js & Flask](https://upstash.com/docs/workflow/quickstarts/nextjs-flask.md): Build durable workflows with Upstash Workflow using a Next.js frontend and Flask backend in this step-by-step quickstart.
+- [Nuxt](https://upstash.com/docs/workflow/quickstarts/nuxt.md): Deploy Upstash Workflow with Nuxt in this step-by-step quickstart, featuring a one-click Vercel deploy and example project.
+- [Supported Platforms](https://upstash.com/docs/workflow/quickstarts/platforms.md): Explore the platforms and frameworks natively supported by Upstash Workflow across JavaScript, TypeScript, and Python.
+- [SolidJS](https://upstash.com/docs/workflow/quickstarts/solidjs.md): Use Upstash Workflow with SolidJS in this step-by-step quickstart, with an end-to-end example project on GitHub.
+- [SvelteKit](https://upstash.com/docs/workflow/quickstarts/svelte.md): Deploy Upstash Workflow with SvelteKit in this step-by-step quickstart, featuring a one-click Vercel deploy and example project.
+- [TanStack Start](https://upstash.com/docs/workflow/quickstarts/tanstack-start.md): Use Upstash Workflow with TanStack Start in this step-by-step quickstart, with a complete example project on GitHub.
+- [Next.js](https://upstash.com/docs/workflow/quickstarts/vercel-nextjs.md): Deploy Upstash Workflow with Next.js on Vercel in this step-by-step quickstart, featuring a one-click deploy and example project.
 
 # Roadmap
 Source: https://upstash.com/docs/workflow/roadmap

--- a/llms.txt
+++ b/llms.txt
@@ -32,35 +32,35 @@
 - [Transfer Search Index](https://upstash.com/docs/api-reference/search/transfer-search-index.md): Transfers ownership of a search index to another team. Transferring to a personal account is not supported. However, transferring from a personal account to a team is allowed.
 - [Get Index Stats](https://upstash.com/docs/api-reference/vector/get-index-stats.md): Retrieves statistics and metrics for a specific vector index
 - [Get Vector Stats](https://upstash.com/docs/api-reference/vector/get-vector-stats.md): Get vector statistics for all the vector indices associated with the authenticated user
-- [Code Interpreter with Vercel AI SDK](https://upstash.com/docs/box/guides/ai-sdk-code-interpreter.md)
-- [Build a Code Review Agent](https://upstash.com/docs/box/guides/code-review-agent.md)
-- [Running Tests with Crabbox](https://upstash.com/docs/box/guides/crabbox-setup.md)
-- [Hermes Setup](https://upstash.com/docs/box/guides/hermes-setup.md)
-- [OpenClaw Setup](https://upstash.com/docs/box/guides/openclaw-setup.md)
-- [Remote Development](https://upstash.com/docs/box/guides/remote-development.md)
-- [AI File Editor with TanStack AI](https://upstash.com/docs/box/guides/tanstack-ai-file-editor.md)
-- [Scrape Dynamic Websites with Playwright](https://upstash.com/docs/box/guides/web-scraping-playwright.md)
-- [Agent](https://upstash.com/docs/box/overall/agent.md)
-- [Attach Headers](https://upstash.com/docs/box/overall/attach-headers.md)
-- [How to Add a Custom Agent](https://upstash.com/docs/box/overall/custom-agent.md)
+- [Code Interpreter with Vercel AI SDK](https://upstash.com/docs/box/guides/ai-sdk-code-interpreter.md): Add a code interpreter tool to a Vercel AI SDK chat app that runs model-written code in a fresh, isolated Upstash Box sandbox.
+- [Build a Code Review Agent](https://upstash.com/docs/box/guides/code-review-agent.md): Build an automated code review agent with Upstash Box that clones a repo, analyzes the PR diff, and returns structured findings with severity.
+- [Running Tests with Crabbox](https://upstash.com/docs/box/guides/crabbox-setup.md): Run your test suite in a clean cloud environment with Crabbox, a CLI that executes commands inside a remote Upstash Box.
+- [Hermes Setup](https://upstash.com/docs/box/guides/hermes-setup.md): Set up the Hermes agent inside an Upstash Box over SSH, install it, and configure an init script for automatic restarts.
+- [OpenClaw Setup](https://upstash.com/docs/box/guides/openclaw-setup.md): Set up OpenClaw inside an Upstash Box, forward its dashboard over an SSH tunnel, and keep the gateway running with an init script.
+- [Remote Development](https://upstash.com/docs/box/guides/remote-development.md): Run any dev server inside an Upstash Box and access it locally over SSH port forwarding, or share it with a public URL.
+- [AI File Editor with TanStack AI](https://upstash.com/docs/box/guides/tanstack-ai-file-editor.md): Build an AI file editor with TanStack AI that runs model-written code on uploaded files inside a disposable Upstash Box sandbox.
+- [Scrape Dynamic Websites with Playwright](https://upstash.com/docs/box/guides/web-scraping-playwright.md): Scrape JavaScript-heavy sites by running Playwright and Chromium inside an Upstash Box, then pull the structured results back.
+- [Agent](https://upstash.com/docs/box/overall/agent.md): Configure a built-in coding agent like Claude Code, Codex, or OpenCode in an Upstash Box and run or stream tasks with typed output.
+- [Attach Headers](https://upstash.com/docs/box/overall/attach-headers.md): Inject secret HTTP headers into a box's outbound HTTPS requests with Upstash Box attach headers, keeping API keys out of the container.
+- [How to Add a Custom Agent](https://upstash.com/docs/box/overall/custom-agent.md): Bring your own agent process to an Upstash Box with a custom harness, streaming output back through the box-sse-v1 protocol.
 - [Aider](https://upstash.com/docs/box/overall/custom-harness/aider.md)
 - [Gemini](https://upstash.com/docs/box/overall/custom-harness/gemini.md)
 - [Goose](https://upstash.com/docs/box/overall/custom-harness/goose.md)
 - [Pi](https://upstash.com/docs/box/overall/custom-harness/pi.md)
-- [Ephemeral Box](https://upstash.com/docs/box/overall/ephemeral-box.md)
-- [Filesystem](https://upstash.com/docs/box/overall/files.md)
-- [Git](https://upstash.com/docs/box/overall/git.md)
-- [Box Basics](https://upstash.com/docs/box/overall/how-it-works.md)
-- [Keep Alive](https://upstash.com/docs/box/overall/keep-alive.md)
-- [Network Policy](https://upstash.com/docs/box/overall/network-policy.md)
-- [Public URLs](https://upstash.com/docs/box/overall/preview.md)
+- [Ephemeral Box](https://upstash.com/docs/box/overall/ephemeral-box.md): EphemeralBox is a lightweight, short-lived Upstash Box sandbox with instant creation and auto-expiry for quick exec and file tasks.
+- [Filesystem](https://upstash.com/docs/box/overall/files.md): Upload, write, read, list, and download files inside an Upstash Box using its isolated per-box filesystem API.
+- [Git](https://upstash.com/docs/box/overall/git.md): Clone repositories, inspect diffs, commit, push branches, and open pull requests from inside an Upstash Box with the git API.
+- [Box Basics](https://upstash.com/docs/box/overall/how-it-works.md): How Upstash Box works: durable, isolated containers with agent, git, shell, and filesystem, plus lifecycle, sizes, and billing.
+- [Keep Alive](https://upstash.com/docs/box/overall/keep-alive.md): Keep an Upstash Box always on between sessions with keepAlive for servers and long-running agents, plus startup init commands.
+- [Network Policy](https://upstash.com/docs/box/overall/network-policy.md): Control a box's outbound network access with Upstash Box network policies: allow-all, deny-all, or custom domain and CIDR rules.
+- [Public URLs](https://upstash.com/docs/box/overall/preview.md): Expose ports from an Upstash Box with public URLs, optionally protected by bearer token or basic authentication.
 - [Pricing & Limits](https://upstash.com/docs/box/overall/pricing.md)
-- [Quickstart](https://upstash.com/docs/box/overall/quickstart.md)
-- [Schedules](https://upstash.com/docs/box/overall/schedules.md)
-- [Security & Secrets](https://upstash.com/docs/box/overall/security.md)
-- [Shell](https://upstash.com/docs/box/overall/shell.md)
-- [Snapshots](https://upstash.com/docs/box/overall/snapshots.md)
-- [Use Cases](https://upstash.com/docs/box/overall/use-cases.md)
+- [Quickstart](https://upstash.com/docs/box/overall/quickstart.md): Get started with Upstash Box: install the SDK, create an isolated cloud container, configure an AI agent, and run your first task.
+- [Schedules](https://upstash.com/docs/box/overall/schedules.md): Schedule recurring shell commands or agent prompts inside an Upstash Box with cron expressions, webhooks, and schedule management.
+- [Security & Secrets](https://upstash.com/docs/box/overall/security.md): How Upstash Box isolates containers and handles secrets, including environment variables, attach headers, and blocked variables.
+- [Shell](https://upstash.com/docs/box/overall/shell.md): Run shell commands and code snippets in an Upstash Box's full Linux shell through the SDK or an interactive SSH connection.
+- [Snapshots](https://upstash.com/docs/box/overall/snapshots.md): Capture and restore Upstash Box state with snapshots to checkpoint workspaces, reuse prepared environments, and fan out boxes.
+- [Use Cases](https://upstash.com/docs/box/overall/use-cases.md): Upstash Box use cases: durable agent servers, multi-agent orchestration, and parallel model testing with isolated cloud sandboxes.
 - [Add a Payment Method](https://upstash.com/docs/common/account/add-payment-method.md)
 - [Audit Logs](https://upstash.com/docs/common/account/auditlogs.md)
 - [AWS Marketplace](https://upstash.com/docs/common/account/awsmarketplace.md)
@@ -180,84 +180,84 @@
 - [Upsert URL Group and Endpoint](https://upstash.com/docs/qstash/api-reference/url-groups/upsert-url-group-and-endpoint.md): Add an endpoint to a URL Group
 - [API Rate Limit Response](https://upstash.com/docs/qstash/api/api-ratelimiting.md): This page documents the rate limiting behavior of our API and explains how to handle different types of rate limit errors.
 - [Authentication](https://upstash.com/docs/qstash/api/authentication.md): Authentication for the QStash API
-- [At-Least-Once Delivery](https://upstash.com/docs/qstash/features/at-least-once.md)
-- [Background Jobs](https://upstash.com/docs/qstash/features/background-jobs.md)
-- [Batching](https://upstash.com/docs/qstash/features/batch.md)
-- [Callbacks](https://upstash.com/docs/qstash/features/callbacks.md)
-- [Deduplication](https://upstash.com/docs/qstash/features/deduplication.md)
-- [Delay](https://upstash.com/docs/qstash/features/delay.md)
-- [Dead Letter Queues](https://upstash.com/docs/qstash/features/dlq.md)
-- [Flow Control](https://upstash.com/docs/qstash/features/flowcontrol.md)
-- [Queues](https://upstash.com/docs/qstash/features/queues.md)
-- [Retry](https://upstash.com/docs/qstash/features/retry.md)
-- [Schedules](https://upstash.com/docs/qstash/features/schedules.md)
-- [Security](https://upstash.com/docs/qstash/features/security.md)
-- [URL Groups](https://upstash.com/docs/qstash/features/url-groups.md)
-- [Debug Logs](https://upstash.com/docs/qstash/howto/debug-logs.md)
-- [Delete Schedules](https://upstash.com/docs/qstash/howto/delete-schedule.md)
-- [Handling Failures](https://upstash.com/docs/qstash/howto/handling-failures.md)
-- [Local Development](https://upstash.com/docs/qstash/howto/local-development.md)
-- [Local Tunnel](https://upstash.com/docs/qstash/howto/local-tunnel.md)
-- [Select a Region](https://upstash.com/docs/qstash/howto/multi-region.md)
-- [Publish Messages](https://upstash.com/docs/qstash/howto/publishing.md)
-- [Read-only Token](https://upstash.com/docs/qstash/howto/readonly-token.md)
+- [At-Least-Once Delivery](https://upstash.com/docs/qstash/features/at-least-once.md): QStash guarantees at-least-once message delivery and shows how to handle rare duplicates using idempotency keys and idempotent handlers.
+- [Background Jobs](https://upstash.com/docs/qstash/features/background-jobs.md): Run long-running background jobs from serverless apps with QStash by offloading heavy tasks to a public API endpoint, shown with Next.js.
+- [Batching](https://upstash.com/docs/qstash/features/batch.md): Send multiple QStash messages in a single request with the batch endpoint, targeting destinations, URL Groups, and queues with custom headers and bodies.
+- [Callbacks](https://upstash.com/docs/qstash/features/callbacks.md): Use QStash callbacks and failure callbacks to handle responses from long-running endpoints without waiting, bypassing serverless execution time limits.
+- [Deduplication](https://upstash.com/docs/qstash/features/deduplication.md): Prevent duplicate QStash messages using a deduplication ID or content-based deduplication so retries enqueue each message only once.
+- [Delay](https://upstash.com/docs/qstash/features/delay.md): Delay QStash message delivery with relative Upstash-Delay or absolute Upstash-Not-Before headers, plus how delays apply to scheduled messages.
+- [Dead Letter Queues](https://upstash.com/docs/qstash/features/dlq.md): QStash moves messages that exhaust their retries to a dead letter queue, where you can manually retry or delete them from the console.
+- [Flow Control](https://upstash.com/docs/qstash/features/flowcontrol.md): Limit QStash message delivery to your endpoint with rate and parallelism controls per flow-control key, plus pause, pin, and monitor APIs.
+- [Queues](https://upstash.com/docs/qstash/features/queues.md): Use QStash queues for ordered FIFO message delivery and controlled parallelism, enqueuing messages to your endpoints reliably.
+- [Retry](https://upstash.com/docs/qstash/features/retry.md): QStash automatically retries failed message deliveries with exponential backoff, plus custom retry delays, Retry-After headers, and non-retryable errors.
+- [Schedules](https://upstash.com/docs/qstash/features/schedules.md): Schedule recurring QStash messages using cron expressions with timezone support, delivering to endpoints, URL Groups, or queues.
+- [Security](https://upstash.com/docs/qstash/features/security.md): Authorize QStash API requests with your token and verify incoming messages using the Upstash-Signature JWT header to secure your endpoints.
+- [URL Groups](https://upstash.com/docs/qstash/features/url-groups.md): URL Groups let QStash fan out a single published message to multiple subscribed endpoints, decoupling producers from consumers.
+- [Debug Logs](https://upstash.com/docs/qstash/howto/debug-logs.md): Understand the QStash message lifecycle and states like ACTIVE, DELIVERED, RETRY, and FAILED to debug delivery using the console Logs tab.
+- [Delete Schedules](https://upstash.com/docs/qstash/howto/delete-schedule.md): Delete a QStash schedule by ID with the schedules API using cURL, TypeScript, or Python, and list schedules to find the ID.
+- [Handling Failures](https://upstash.com/docs/qstash/howto/handling-failures.md): Handle failed QStash message deliveries using failure callbacks and the dead letter queue to log, alert, and retry undelivered messages.
+- [Local Development](https://upstash.com/docs/qstash/howto/local-development.md): Run the QStash development server locally with the CLI, npx, or Docker to test messages, schedules, and workflows without deploying a public API.
+- [Local Tunnel](https://upstash.com/docs/qstash/howto/local-tunnel.md): Expose your local API to QStash during development using a public tunnel with localtunnel.me or ngrok so messages reach your machine.
+- [Select a Region](https://upstash.com/docs/qstash/howto/multi-region.md): Choose between QStash EU and US regions, migrate resources between them, and configure the SDK for single-region or multi-region migration mode.
+- [Publish Messages](https://upstash.com/docs/qstash/howto/publishing.md): Publish messages to any HTTP endpoint with QStash, forward custom headers, and fan out to URL Groups using cURL, TypeScript, or Python.
+- [Read-only Token](https://upstash.com/docs/qstash/howto/readonly-token.md): Share a QStash read-only token with teammates or AI agents to view logs, messages, and schedules without allowing publishing or resource changes.
 - [Receiving Messages](https://upstash.com/docs/qstash/howto/receiving.md): What do we send to your API?
 - [Redact Private Data](https://upstash.com/docs/qstash/howto/redact-fields.md): How to redact private data in your messages
-- [Reset Token](https://upstash.com/docs/qstash/howto/reset-token.md)
-- [Roll Your Signing Keys](https://upstash.com/docs/qstash/howto/roll-signing-keys.md)
-- [Verify Signatures](https://upstash.com/docs/qstash/howto/signature.md)
-- [Create URL Groups and Endpoints](https://upstash.com/docs/qstash/howto/url-group-endpoint.md)
-- [Use as Webhook Receiver](https://upstash.com/docs/qstash/howto/webhook.md)
-- [LLM with Anthropic](https://upstash.com/docs/qstash/integrations/anthropic.md)
-- [Datadog - Upstash QStash Integration](https://upstash.com/docs/qstash/integrations/datadog.md)
-- [LLM - OpenAI](https://upstash.com/docs/qstash/integrations/llm.md)
-- [n8n with QStash](https://upstash.com/docs/qstash/integrations/n8n.md)
+- [Reset Token](https://upstash.com/docs/qstash/howto/reset-token.md): Reset your QStash token from the console to invalidate the current one, then update it across your applications to keep publishing messages.
+- [Roll Your Signing Keys](https://upstash.com/docs/qstash/howto/roll-signing-keys.md): Roll your QStash signing keys safely using the current and next key pair to rotate secrets with minimal downtime for request verification.
+- [Verify Signatures](https://upstash.com/docs/qstash/howto/signature.md): Verify the Upstash-Signature JWT on incoming QStash requests using the Receiver in the TypeScript, Python, and Go SDKs or with manual verification.
+- [Create URL Groups and Endpoints](https://upstash.com/docs/qstash/howto/url-group-endpoint.md): Create QStash URL Groups and add endpoints through the Upstash Console or REST API using cURL, TypeScript, or Python.
+- [Use as Webhook Receiver](https://upstash.com/docs/qstash/howto/webhook.md): Route webhook calls through QStash as an intermediary to add retries, delays, timeouts, callbacks, and flow control using publish or URL Groups.
+- [LLM with Anthropic](https://upstash.com/docs/qstash/integrations/anthropic.md): Call Anthropic Claude models through QStash to publish, enqueue, and batch LLM requests with retries, callbacks, and long HTTP timeouts.
+- [Datadog - Upstash QStash Integration](https://upstash.com/docs/qstash/integrations/datadog.md): Connect Datadog with Upstash QStash to monitor message delivery, retries, DLQ, and schedule metrics on Datadog dashboards.
+- [LLM - OpenAI](https://upstash.com/docs/qstash/integrations/llm.md): Call OpenAI and OpenAI-compatible LLM APIs through QStash to publish, enqueue, and batch chat completions with retries, callbacks, and 2-hour timeouts.
+- [n8n with QStash](https://upstash.com/docs/qstash/integrations/n8n.md): Call QStash from an n8n workflow by importing a QStash request as a cURL snippet into an HTTP Request node to publish, enqueue, or schedule.
 - [Pipedream](https://upstash.com/docs/qstash/integrations/pipedream.md): Build and run workflows with 1000s of open source triggers and actions across 900+ apps.
-- [Prometheus - Upstash QStash Integration](https://upstash.com/docs/qstash/integrations/prometheus.md)
-- [Email - Resend](https://upstash.com/docs/qstash/integrations/resend.md)
-- [Development Server License Agreement](https://upstash.com/docs/qstash/misc/license.md)
-- [API Examples](https://upstash.com/docs/qstash/overall/apiexamples.md)
-- [Changelog](https://upstash.com/docs/qstash/overall/changelog.md)
-- [Compare](https://upstash.com/docs/qstash/overall/compare.md)
-- [Prod Pack & Enterprise](https://upstash.com/docs/qstash/overall/enterprise.md)
-- [Getting Started](https://upstash.com/docs/qstash/overall/getstarted.md)
+- [Prometheus - Upstash QStash Integration](https://upstash.com/docs/qstash/integrations/prometheus.md): Scrape Upstash QStash metrics into Prometheus and visualize message throughput, retries, DLQ, and schedules in a Grafana dashboard.
+- [Email - Resend](https://upstash.com/docs/qstash/integrations/resend.md): Send transactional and batch emails through QStash using the Resend provider in the qstash-js SDK with publishJSON.
+- [Development Server License Agreement](https://upstash.com/docs/qstash/misc/license.md): License terms for the QStash development server, restricting its use to local development, testing, and CI rather than production or commercial deployment.
+- [API Examples](https://upstash.com/docs/qstash/overall/apiexamples.md): Get started with QStash through cURL, TypeScript, and Python examples for publishing messages, scheduling, and using URL Groups.
+- [Changelog](https://upstash.com/docs/qstash/overall/changelog.md): Track new QStash features and updates across the server, console, and TypeScript and Python SDKs over time.
+- [Compare](https://upstash.com/docs/qstash/overall/compare.md): Compare QStash with alternatives like BullMQ, Zeplo, and Quirrel to see how its serverless message queue and scheduling differ.
+- [Prod Pack & Enterprise](https://upstash.com/docs/qstash/overall/enterprise.md): Upgrade Upstash QStash to Prod Pack or Enterprise for 99.99% uptime SLA, SOC-2 compliance, encryption at rest, and Prometheus and Datadog monitoring.
+- [Getting Started](https://upstash.com/docs/qstash/overall/getstarted.md): Get started with Upstash QStash, publish your first message to an HTTP endpoint, and explore background jobs, schedules, and delivery guarantees.
 - [llms.txt](https://upstash.com/docs/qstash/overall/llms-txt.md)
 - [Pricing & Limits](https://upstash.com/docs/qstash/overall/pricing.md)
 - [Roadmap](https://upstash.com/docs/qstash/overall/roadmap.md)
-- [Use Cases](https://upstash.com/docs/qstash/overall/usecases.md)
-- [AWS Lambda (Node)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/nodejs.md)
-- [AWS Lambda (Python)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/python.md)
-- [Cloudflare Workers](https://upstash.com/docs/qstash/quickstarts/cloudflare-workers.md)
-- [Deno Deploy](https://upstash.com/docs/qstash/quickstarts/deno-deploy.md)
-- [Golang](https://upstash.com/docs/qstash/quickstarts/fly-io/go.md)
-- [Python on Vercel](https://upstash.com/docs/qstash/quickstarts/python-vercel.md)
-- [Next.js](https://upstash.com/docs/qstash/quickstarts/vercel-nextjs.md)
-- [Periodic Data Updates](https://upstash.com/docs/qstash/recipes/periodic-data-updates.md)
-- [DLQ](https://upstash.com/docs/qstash/sdks/py/examples/dlq.md)
-- [Events](https://upstash.com/docs/qstash/sdks/py/examples/events.md)
-- [Flow Control](https://upstash.com/docs/qstash/sdks/py/examples/flow-control.md)
-- [Keys](https://upstash.com/docs/qstash/sdks/py/examples/keys.md)
-- [Messages](https://upstash.com/docs/qstash/sdks/py/examples/messages.md)
-- [Overview](https://upstash.com/docs/qstash/sdks/py/examples/overview.md)
-- [Publish](https://upstash.com/docs/qstash/sdks/py/examples/publish.md)
-- [Queues](https://upstash.com/docs/qstash/sdks/py/examples/queues.md)
-- [Receiver](https://upstash.com/docs/qstash/sdks/py/examples/receiver.md)
-- [Schedules](https://upstash.com/docs/qstash/sdks/py/examples/schedules.md)
-- [URL Groups](https://upstash.com/docs/qstash/sdks/py/examples/url-groups.md)
-- [Getting Started](https://upstash.com/docs/qstash/sdks/py/gettingstarted.md)
-- [Overview](https://upstash.com/docs/qstash/sdks/py/overview.md)
-- [DLQ](https://upstash.com/docs/qstash/sdks/ts/examples/dlq.md)
-- [Flow Control](https://upstash.com/docs/qstash/sdks/ts/examples/flow-control.md)
-- [Logs](https://upstash.com/docs/qstash/sdks/ts/examples/logs.md)
-- [Messages](https://upstash.com/docs/qstash/sdks/ts/examples/messages.md)
-- [Overview](https://upstash.com/docs/qstash/sdks/ts/examples/overview.md)
-- [Publish](https://upstash.com/docs/qstash/sdks/ts/examples/publish.md)
-- [Queues](https://upstash.com/docs/qstash/sdks/ts/examples/queues.md)
-- [Receiver](https://upstash.com/docs/qstash/sdks/ts/examples/receiver.md)
-- [Schedules](https://upstash.com/docs/qstash/sdks/ts/examples/schedules.md)
-- [URL Groups](https://upstash.com/docs/qstash/sdks/ts/examples/url-groups.md)
-- [Getting Started](https://upstash.com/docs/qstash/sdks/ts/gettingstarted.md)
-- [Overview](https://upstash.com/docs/qstash/sdks/ts/overview.md)
+- [Use Cases](https://upstash.com/docs/qstash/overall/usecases.md): Explore common Upstash QStash use cases like scheduled Next.js jobs, resetting billing cycles, fanning out alerts, and delayed signup messages.
+- [AWS Lambda (Node)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/nodejs.md): Receive and verify QStash webhooks in a Node.js AWS Lambda function, deploying with the AWS CDK or manually using signature verification.
+- [AWS Lambda (Python)](https://upstash.com/docs/qstash/quickstarts/aws-lambda/python.md): Receive and verify QStash webhooks in a Python AWS Lambda function using PyJWT, then deploy and test the function on AWS.
+- [Cloudflare Workers](https://upstash.com/docs/qstash/quickstarts/cloudflare-workers.md): Receive and verify QStash webhooks in a Cloudflare Worker using the Upstash QStash SDK, with Worker-level and account-level secret setup.
+- [Deno Deploy](https://upstash.com/docs/qstash/quickstarts/deno-deploy.md): Receive and verify QStash webhooks in a Deno Deploy project using the Upstash QStash Receiver and your signing keys.
+- [Golang](https://upstash.com/docs/qstash/quickstarts/fly-io/go.md): Receive and verify QStash webhooks in a Go application deployed on Fly.io, using JWT signature verification with golang-jwt.
+- [Python on Vercel](https://upstash.com/docs/qstash/quickstarts/python-vercel.md): Use Upstash QStash to schedule a daily Python job on Vercel that cleans up your Redis database on a cron schedule.
+- [Next.js](https://upstash.com/docs/qstash/quickstarts/vercel-nextjs.md): Use Upstash QStash in Next.js to run reliable background jobs with automatic retries, publishing messages and verifying signatures on Vercel.
+- [Periodic Data Updates](https://upstash.com/docs/qstash/recipes/periodic-data-updates.md): Use QStash as a cron trigger for a Next.js API route that periodically fetches Bitcoin prices from an API and stores them in Redis.
+- [DLQ](https://upstash.com/docs/qstash/sdks/py/examples/dlq.md): Manage the QStash dead letter queue with the Python SDK by listing messages with cursor pagination, retrieving, and deleting DLQ messages.
+- [Events](https://upstash.com/docs/qstash/sdks/py/examples/events.md): List QStash events with cursor-based pagination using the Python SDK to track your published messages.
+- [Flow Control](https://upstash.com/docs/qstash/sdks/py/examples/flow-control.md): Manage QStash flow control keys with the Python SDK to inspect rate and parallelism, pause, resume, pin, unpin, and reset limits.
+- [Keys](https://upstash.com/docs/qstash/sdks/py/examples/keys.md): Retrieve and rotate your QStash signing keys with the Python SDK to verify incoming message signatures.
+- [Messages](https://upstash.com/docs/qstash/sdks/py/examples/messages.md): Retrieve, cancel, and bulk cancel in-flight QStash messages with the Python SDK.
+- [Overview](https://upstash.com/docs/qstash/sdks/py/examples/overview.md): Example usages of each method in the QStash Python SDK for publishing, scheduling, and managing messages.
+- [Publish](https://upstash.com/docs/qstash/sdks/py/examples/publish.md): Publish QStash messages with the Python SDK, adding delays, headers, callbacks, retries, deduplication, timeouts, and URL groups.
+- [Queues](https://upstash.com/docs/qstash/sdks/py/examples/queues.md): Create, configure, pause, resume, and delete QStash queues with parallelism using the Python SDK.
+- [Receiver](https://upstash.com/docs/qstash/sdks/py/examples/receiver.md): Verify QStash message signatures in your request handler using the Receiver helper in the Python SDK.
+- [Schedules](https://upstash.com/docs/qstash/sdks/py/examples/schedules.md): Create, list, get, pause, resume, and delete QStash cron schedules with the Python SDK, including callbacks and timeouts.
+- [URL Groups](https://upstash.com/docs/qstash/sdks/py/examples/url-groups.md): Create, list, and manage QStash URL groups and their endpoints for fan-out delivery using the Python SDK.
+- [Getting Started](https://upstash.com/docs/qstash/sdks/py/gettingstarted.md): Install the QStash Python SDK and start publishing messages with synchronous and asynchronous clients and configurable retries.
+- [Overview](https://upstash.com/docs/qstash/sdks/py/overview.md): The QStash Python SDK for publishing, scheduling, and managing messages, URL groups, DLQ, and signature verification.
+- [DLQ](https://upstash.com/docs/qstash/sdks/ts/examples/dlq.md): Manage the QStash dead letter queue with the TypeScript SDK by listing, filtering, deleting, and retrying DLQ messages.
+- [Flow Control](https://upstash.com/docs/qstash/sdks/ts/examples/flow-control.md): Manage QStash flow control keys with the TypeScript SDK to inspect rate and parallelism, pause, resume, pin, unpin, and reset limits.
+- [Logs](https://upstash.com/docs/qstash/sdks/ts/examples/logs.md): Retrieve QStash logs with the TypeScript SDK using cursor pagination, state filters, and message ID lookups.
+- [Messages](https://upstash.com/docs/qstash/sdks/ts/examples/messages.md): Retrieve, cancel, and bulk cancel in-flight QStash messages with filters using the TypeScript SDK.
+- [Overview](https://upstash.com/docs/qstash/sdks/ts/examples/overview.md): Example usages of each method in the QStash TypeScript SDK for publishing, scheduling, and managing messages.
+- [Publish](https://upstash.com/docs/qstash/sdks/ts/examples/publish.md): Publish QStash messages with the TypeScript SDK, adding delays, headers, callbacks, retries, deduplication, timeouts, and URL groups.
+- [Queues](https://upstash.com/docs/qstash/sdks/ts/examples/queues.md): Create, configure, pause, resume, and delete QStash queues with parallelism using the TypeScript SDK.
+- [Receiver](https://upstash.com/docs/qstash/sdks/ts/examples/receiver.md): Verify QStash message signatures in your request handler using the Receiver helper in the TypeScript SDK.
+- [Schedules](https://upstash.com/docs/qstash/sdks/ts/examples/schedules.md): Create, list, get, pause, resume, and delete QStash cron schedules with the TypeScript SDK, including callbacks and timeouts.
+- [URL Groups](https://upstash.com/docs/qstash/sdks/ts/examples/url-groups.md): Create, list, and manage QStash URL groups and their endpoints for fan-out delivery using the TypeScript SDK.
+- [Getting Started](https://upstash.com/docs/qstash/sdks/ts/gettingstarted.md): Install the QStash TypeScript SDK, configure the client and retries, and run a local dev server for testing.
+- [Overview](https://upstash.com/docs/qstash/sdks/ts/overview.md): The QStash TypeScript SDK for publishing, scheduling, and managing messages, URL groups, DLQ, and signature verification.
 - [Channels](https://upstash.com/docs/realtime/features/channels.md)
 - [Client-Side Usage](https://upstash.com/docs/realtime/features/client-side.md)
 - [History](https://upstash.com/docs/realtime/features/history.md)
@@ -266,59 +266,59 @@
 - [Deployment](https://upstash.com/docs/realtime/features/serverless.md)
 - [Pricing](https://upstash.com/docs/realtime/overall/pricing.md)
 - [Quickstart](https://upstash.com/docs/realtime/overall/quickstart.md)
-- [Auto Upgrade](https://upstash.com/docs/redis/features/auto-upgrade.md)
-- [Backup/Restore](https://upstash.com/docs/redis/features/backup.md)
-- [Consistency](https://upstash.com/docs/redis/features/consistency.md)
-- [Credential Protection](https://upstash.com/docs/redis/features/credential-protection.md)
+- [Auto Upgrade](https://upstash.com/docs/redis/features/auto-upgrade.md): Auto Upgrade automatically moves your Upstash Redis database to a higher plan when you hit bandwidth or storage limits, preventing throttling and downtime.
+- [Backup/Restore](https://upstash.com/docs/redis/features/backup.md): Create immediate or scheduled daily backups of your Upstash Redis database and restore data to any database in your account or team.
+- [Consistency](https://upstash.com/docs/redis/features/consistency.md): How Upstash Redis uses leader-based replication to provide eventual and causal consistency guarantees for reads and writes.
+- [Credential Protection](https://upstash.com/docs/redis/features/credential-protection.md): Credential Protection keeps Upstash Redis database credentials out of Upstash infrastructure, exposing them only once at generation for stronger security.
 - [Durable Storage](https://upstash.com/docs/redis/features/durability.md): This article explains the persistence provided by Upstash databases.
-- [Eviction](https://upstash.com/docs/redis/features/eviction.md)
-- [Global Database](https://upstash.com/docs/redis/features/globaldatabase.md)
+- [Eviction](https://upstash.com/docs/redis/features/eviction.md): Enable eviction on Upstash Redis to automatically remove older data when the maximum size limit is reached, ideal for caching workloads.
+- [Global Database](https://upstash.com/docs/redis/features/globaldatabase.md): Upstash Redis Global Database replicates data across multiple regions with a primary and read regions to deliver low read latency worldwide.
 - [Key-Based Locking](https://upstash.com/docs/redis/features/key-locking.md): Key-based locks for concurrent command execution
-- [Replication](https://upstash.com/docs/redis/features/replication.md)
-- [REST API](https://upstash.com/docs/redis/features/restapi.md)
-- [Security](https://upstash.com/docs/redis/features/security.md)
-- [Compliance](https://upstash.com/docs/redis/help/compliance.md)
-- [Frequently Asked Questions](https://upstash.com/docs/redis/help/faq.md)
-- [Integration with Third Parties & Partnerships](https://upstash.com/docs/redis/help/integration.md)
-- [Legal](https://upstash.com/docs/redis/help/legal.md)
-- [Managing Healthcare Data](https://upstash.com/docs/redis/help/managing-healthcare-data.md)
-- [Production Checklist](https://upstash.com/docs/redis/help/production-checklist.md)
-- [Shared Responsibility Model](https://upstash.com/docs/redis/help/shared-responsibility-model.md)
-- [Support & Contact Us](https://upstash.com/docs/redis/help/support.md)
-- [Uptime Monitor](https://upstash.com/docs/redis/help/uptime.md)
-- [Connect Your Client](https://upstash.com/docs/redis/howto/connect-client.md)
-- [Connect with @upstash/redis](https://upstash.com/docs/redis/howto/connect-with-upstash-redis.md)
-- [Datadog - Upstash Redis Integration](https://upstash.com/docs/redis/howto/datadog.md)
-- [EMQX - Upstash Redis Integration](https://upstash.com/docs/redis/howto/emqxintegration.md)
-- [Get Started with AWS Lambda](https://upstash.com/docs/redis/howto/getstartedawslambda.md)
-- [Get Started with Cloudflare Workers](https://upstash.com/docs/redis/howto/getstartedcloudflareworkers.md)
-- [Get Started with Google Cloud Functions](https://upstash.com/docs/redis/howto/getstartedgooglecloudfunctions.md)
-- [Import/Export Data](https://upstash.com/docs/redis/howto/importexport.md)
-- [ioredis note](https://upstash.com/docs/redis/howto/ioredisnote.md)
-- [Use IP Allowlist](https://upstash.com/docs/redis/howto/ipallowlist.md)
-- [Listen Keyspace Notifications](https://upstash.com/docs/redis/howto/keyspacenotifications.md)
-- [Metrics and Charts](https://upstash.com/docs/redis/howto/metrics-and-charts.md)
-- [Migrate Regional to Global Database](https://upstash.com/docs/redis/howto/migratefromregionaltoglobal.md)
-- [Monitor your usage](https://upstash.com/docs/redis/howto/monitoryourusage.md)
-- [Read Your Writes](https://upstash.com/docs/redis/howto/readyourwrites.md)
-- [Terraform Provider](https://upstash.com/docs/redis/howto/terraformprovider.md)
-- [Upgrade Your Database](https://upstash.com/docs/redis/howto/upgrade-database.md)
-- [Vercel - Upstash Redis Integration](https://upstash.com/docs/redis/howto/vercelintegration.md)
-- [BullMQ with Upstash Redis](https://upstash.com/docs/redis/integrations/bullmq.md)
-- [Celery with Upstash Redis](https://upstash.com/docs/redis/integrations/celery.md)
-- [DrizzleORM with Upstash Redis](https://upstash.com/docs/redis/integrations/drizzle.md)
+- [Replication](https://upstash.com/docs/redis/features/replication.md): How Upstash Redis replication uses primary and read replicas to deliver high availability, better scalability, and multi-zone resilience.
+- [REST API](https://upstash.com/docs/redis/features/restapi.md): Access Upstash Redis over HTTP with the REST API, including commands, pipelining, transactions, pub/sub, auth tokens, and response formats.
+- [Security](https://upstash.com/docs/redis/features/security.md): Secure your Upstash Redis database with TLS, Redis ACL, encryption at rest, IP allowlisting, VPC peering, and AWS Private Link.
+- [Compliance](https://upstash.com/docs/redis/help/compliance.md): Upstash Redis compliance details covering SOC 2, GDPR, HIPAA, and PCI, plus backups, encryption, and legal and security documents.
+- [Frequently Asked Questions](https://upstash.com/docs/redis/help/faq.md): Frequently asked questions about Upstash Redis covering serverless pricing, supported regions and clients, persistence, limits, and data safety.
+- [Integration with Third Parties & Partnerships](https://upstash.com/docs/redis/help/integration.md): Integrate Upstash into your platform with OAuth 2.0 so users can create and manage Redis, Vector, and QStash databases without leaving your app.
+- [Legal](https://upstash.com/docs/redis/help/legal.md): Upstash legal documents including the Terms of Service, Privacy Policy, and list of subcontractors.
+- [Managing Healthcare Data](https://upstash.com/docs/redis/help/managing-healthcare-data.md): Store and process Protected Health Information (PHI) on Upstash Redis with BAAs, HIPAA databases, encryption, MFA, and access controls.
+- [Production Checklist](https://upstash.com/docs/redis/help/production-checklist.md): Essential checklist to secure and optimize your Upstash Redis database for production, covering Prod Pack, backups, ACL, IP allowlist, and monitoring.
+- [Shared Responsibility Model](https://upstash.com/docs/redis/help/shared-responsibility-model.md): Understand the security and operational responsibilities split between Upstash and customers when running Upstash Redis in production.
+- [Support & Contact Us](https://upstash.com/docs/redis/help/support.md): Get help with Upstash Redis through the Discord community, email support, and professional support from the Upstash team.
+- [Uptime Monitor](https://upstash.com/docs/redis/help/uptime.md): Track Upstash Redis uptime and regional latencies using the Upstash status page and latency monitoring page.
+- [Connect Your Client](https://upstash.com/docs/redis/howto/connect-client.md): Connect to Upstash Redis from any language with code examples for @upstash/redis, ioredis, redis-py, Jedis, phpredis, and redigo.
+- [Connect with @upstash/redis](https://upstash.com/docs/redis/howto/connect-with-upstash-redis.md): Connect to Upstash Redis using the HTTP-based @upstash/redis client, ideal for serverless functions, Cloudflare Workers, and edge environments.
+- [Datadog - Upstash Redis Integration](https://upstash.com/docs/redis/howto/datadog.md): Connect your Datadog account to Upstash Redis to monitor Pro and Enterprise database metrics in your Datadog dashboards.
+- [EMQX - Upstash Redis Integration](https://upstash.com/docs/redis/howto/emqxintegration.md): Stream MQTT data from EMQX Cloud into Upstash Redis using data integration rules to store IoT temperature and humidity messages.
+- [Get Started with AWS Lambda](https://upstash.com/docs/redis/howto/getstartedawslambda.md): Connect an AWS Lambda function to Upstash Redis with a step-by-step Node.js tutorial, plus tips on serverless connection handling.
+- [Get Started with Cloudflare Workers](https://upstash.com/docs/redis/howto/getstartedcloudflareworkers.md): Build a Cloudflare Workers edge function that reads from Upstash Redis over REST to serve location-based greetings using @upstash/redis.
+- [Get Started with Google Cloud Functions](https://upstash.com/docs/redis/howto/getstartedgooglecloudfunctions.md): Deploy a Google Cloud Function that connects to Upstash Redis with ioredis to increment and return a page view counter.
+- [Import/Export Data](https://upstash.com/docs/redis/howto/importexport.md): Import data into Upstash Redis from a backup or RDB file, and export your database as an RDB file for backup or migration.
+- [ioredis note](https://upstash.com/docs/redis/howto/ioredisnote.md): Reusable note reminding you to copy the ioredis connection string from the Node tab in the Upstash Console.
+- [Use IP Allowlist](https://upstash.com/docs/redis/howto/ipallowlist.md): Restrict access to your Upstash Redis database by allowing connections only from specified IPv4 addresses or CIDR blocks.
+- [Listen Keyspace Notifications](https://upstash.com/docs/redis/howto/keyspacenotifications.md): Enable and listen for Upstash Redis keyspace and keyevent notifications over pubsub channels using the notify-keyspace-events config.
+- [Metrics and Charts](https://upstash.com/docs/redis/howto/metrics-and-charts.md): Understand the Upstash Console metrics and charts for Redis, including throughput, latency, data size, connections, keyspace, and hit rates.
+- [Migrate Regional to Global Database](https://upstash.com/docs/redis/howto/migratefromregionaltoglobal.md): Migrate your data from a legacy regional Upstash Redis database to a global database using backup and restore in the Upstash Console.
+- [Monitor your usage](https://upstash.com/docs/redis/howto/monitoryourusage.md): Use the Redis MONITOR command with ioredis to watch all requests processed by your Upstash Redis instance in real time.
+- [Read Your Writes](https://upstash.com/docs/redis/howto/readyourwrites.md): Ensure read-your-writes consistency in Upstash Redis using sync tokens, handled automatically by the TypeScript and Python SDKs or via REST headers.
+- [Terraform Provider](https://upstash.com/docs/redis/howto/terraformprovider.md): Use the Upstash Terraform provider to create and manage Redis databases as code and output their connection credentials.
+- [Upgrade Your Database](https://upstash.com/docs/redis/howto/upgrade-database.md): Upgrade your Upstash Redis database from the free tier to the pay-as-you-go plan by adding a payment method to raise usage limits.
+- [Vercel - Upstash Redis Integration](https://upstash.com/docs/redis/howto/vercelintegration.md): Integrate Upstash Redis, Vector, Search, or QStash with your Vercel project and inject connection credentials as environment variables.
+- [BullMQ with Upstash Redis](https://upstash.com/docs/redis/integrations/bullmq.md): Use BullMQ and Bull with Upstash Redis to run Node.js job queues, with install steps, a connection example, and billing optimization tips.
+- [Celery with Upstash Redis](https://upstash.com/docs/redis/integrations/celery.md): Use Celery with Upstash Redis as broker and result backend to build scalable, serverless Python task queues.
+- [DrizzleORM with Upstash Redis](https://upstash.com/docs/redis/integrations/drizzle.md): Cache Drizzle ORM queries with Upstash Redis using the upstashCache helper, with per-query and global caching plus automatic invalidation.
 - [Upstash MCP](https://upstash.com/docs/redis/integrations/mcp.md)
-- [n8n with Upstash Redis](https://upstash.com/docs/redis/integrations/n8n.md)
-- [Prometheus - Upstash Redis Integration](https://upstash.com/docs/redis/integrations/prometheus.md)
-- [Configure Upstash Ratelimit Strapi Plugin](https://upstash.com/docs/redis/integrations/ratelimit/strapi/configurations.md)
-- [Upstash Ratelimit Strapi Integration](https://upstash.com/docs/redis/integrations/ratelimit/strapi/getting-started.md)
-- [Replit Templates](https://upstash.com/docs/redis/integrations/replit-templates.md)
-- [Sidekiq with Upstash Redis](https://upstash.com/docs/redis/integrations/sidekiq.md)
+- [n8n with Upstash Redis](https://upstash.com/docs/redis/integrations/n8n.md): Connect an n8n Redis node to Upstash Redis to store data in automation workflows, with a step-by-step visit counter example.
+- [Prometheus - Upstash Redis Integration](https://upstash.com/docs/redis/integrations/prometheus.md): Monitor your Upstash Redis database with Prometheus and Grafana using the monitoring token, data source setup, and federation.
+- [Configure Upstash Ratelimit Strapi Plugin](https://upstash.com/docs/redis/integrations/ratelimit/strapi/configurations.md): Configure the Upstash Ratelimit Strapi plugin with rate limit algorithms, tokens, windows, identifier sources, and per-route strategies.
+- [Upstash Ratelimit Strapi Integration](https://upstash.com/docs/redis/integrations/ratelimit/strapi/getting-started.md): Protect your Strapi APIs from abuse with the Upstash Ratelimit plugin, powered by HTTP and Redis based rate limiting.
+- [Replit Templates](https://upstash.com/docs/redis/integrations/replit-templates.md): Explore Replit templates showcasing Upstash Redis and Vector for caching, rate limiting, real-time chat, RAG, and vector search.
+- [Sidekiq with Upstash Redis](https://upstash.com/docs/redis/integrations/sidekiq.md): Use Sidekiq with Upstash Redis to run Ruby background job queues, with a worker example and billing optimization tips.
 - [Pricing & Billing](https://upstash.com/docs/redis/overall/billing.md): How Upstash Redis pricing works — free tier, Pay-As-You-Go, and Fixed plans, with current limits and billing details.
-- [Changelog](https://upstash.com/docs/redis/overall/changelog.md)
-- [Compare](https://upstash.com/docs/redis/overall/compare.md)
-- [Redis® API Compatibility: supported commands, modules, and protocols](https://upstash.com/docs/redis/overall/compatibility.md)
-- [Prod Pack & Enterprise](https://upstash.com/docs/redis/overall/enterprise.md)
+- [Changelog](https://upstash.com/docs/redis/overall/changelog.md): Upstash Redis changelog tracking new commands, features, regions, and REST API updates over time.
+- [Compare](https://upstash.com/docs/redis/overall/compare.md): Compare Upstash Redis with ElastiCache, MemoryDB, Redis Labs, DynamoDB, and FaunaDB on serverless pricing, latency, and portability.
+- [Redis® API Compatibility: supported commands, modules, and protocols](https://upstash.com/docs/redis/overall/compatibility.md): Upstash Redis API compatibility reference listing supported Redis commands, modules, and protocols across native TCP and REST.
+- [Prod Pack & Enterprise](https://upstash.com/docs/redis/overall/enterprise.md): Upstash Redis Prod Pack and Enterprise plans add uptime SLA, SOC 2, multi-zone HA, encryption, monitoring, SSO, and custom limits.
 - [Getting Started](https://upstash.com/docs/redis/overall/getstarted.md): Create an Upstash Redis database in seconds
 - [llms.txt](https://upstash.com/docs/redis/overall/llms-txt.md)
 - [Pricing & Limits](https://upstash.com/docs/redis/overall/pricing.md)
@@ -326,37 +326,37 @@
 - [Python SDK](https://upstash.com/docs/redis/overall/pythonredis.md)
 - [Rate Limit SDK](https://upstash.com/docs/redis/overall/ratelimit.md)
 - [Typescript SDK](https://upstash.com/docs/redis/overall/redis.md)
-- [Use Cases](https://upstash.com/docs/redis/overall/usecases.md)
-- [AWS Lambda](https://upstash.com/docs/redis/quickstarts/aws-lambda.md)
-- [Azure Functions](https://upstash.com/docs/redis/quickstarts/azure-functions.md)
-- [Cloudflare Workers](https://upstash.com/docs/redis/quickstarts/cloudflareworkers.md)
-- [Deno Deploy](https://upstash.com/docs/redis/quickstarts/deno-deploy.md)
-- [DigitalOcean](https://upstash.com/docs/redis/quickstarts/digitalocean.md)
-- [Django](https://upstash.com/docs/redis/quickstarts/django.md)
+- [Use Cases](https://upstash.com/docs/redis/overall/usecases.md): Common Upstash Redis use cases including caching, rate limiting, queues, pub/sub, leaderboards, full-text search, and AI agent memory.
+- [AWS Lambda](https://upstash.com/docs/redis/quickstarts/aws-lambda.md): Connect Upstash Redis to an AWS Lambda function deployed with the AWS CDK in TypeScript.
+- [Azure Functions](https://upstash.com/docs/redis/quickstarts/azure-functions.md): Build a serverless Azure Function that reads and writes data using an Upstash Redis database.
+- [Cloudflare Workers](https://upstash.com/docs/redis/quickstarts/cloudflareworkers.md): Use Upstash Redis from a Cloudflare Workers edge function for low-latency key-value access worldwide.
+- [Deno Deploy](https://upstash.com/docs/redis/quickstarts/deno-deploy.md): Build a page view counter on Deno Deploy backed by an Upstash Redis database.
+- [DigitalOcean](https://upstash.com/docs/redis/quickstarts/digitalocean.md): Connect Upstash Redis to your DigitalOcean apps and migrate off the deprecated DigitalOcean integration.
+- [Django](https://upstash.com/docs/redis/quickstarts/django.md): Build a Django web app in Python that increments an Upstash Redis counter on every homepage visit.
 - [Elixir](https://upstash.com/docs/redis/quickstarts/elixir.md): Tutorial on Using Upstash Redis In Your Phoenix App and Deploying it on Fly.
-- [FastAPI](https://upstash.com/docs/redis/quickstarts/fastapi.md)
-- [Fastly](https://upstash.com/docs/redis/quickstarts/fastlycompute.md)
-- [Flask](https://upstash.com/docs/redis/quickstarts/flask.md)
-- [Fly.io](https://upstash.com/docs/redis/quickstarts/fly.md)
-- [Google Cloud Functions](https://upstash.com/docs/redis/quickstarts/google-cloud-functions.md)
-- [Ion](https://upstash.com/docs/redis/quickstarts/ion.md)
-- [ioredis note](https://upstash.com/docs/redis/quickstarts/ioredisnote.md)
-- [Koyeb](https://upstash.com/docs/redis/quickstarts/koyeb.md)
-- [Laravel](https://upstash.com/docs/redis/quickstarts/laravel.md)
-- [App Router](https://upstash.com/docs/redis/quickstarts/nextjs-app-router.md)
-- [Pages Router](https://upstash.com/docs/redis/quickstarts/nextjs-pages-router.md)
-- [ AWS Lambda](https://upstash.com/docs/redis/quickstarts/python-aws-lambda.md)
-- [SST v2](https://upstash.com/docs/redis/quickstarts/sst-v2.md)
-- [Supabase Functions](https://upstash.com/docs/redis/quickstarts/supabase.md)
-- [App Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-app-router.md)
-- [Pages Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-pages-router.md)
-- [Vercel Python Runtime](https://upstash.com/docs/redis/quickstarts/vercel-python-runtime.md)
+- [FastAPI](https://upstash.com/docs/redis/quickstarts/fastapi.md): Build a FastAPI application in Python that stores and retrieves data using Upstash Redis.
+- [Fastly](https://upstash.com/docs/redis/quickstarts/fastlycompute.md): Use Upstash Redis from a Fastly Compute edge application for fast, global key-value storage.
+- [Flask](https://upstash.com/docs/redis/quickstarts/flask.md): Build a Flask web app in Python that increments an Upstash Redis counter on each homepage visit.
+- [Fly.io](https://upstash.com/docs/redis/quickstarts/fly.md): Connect Upstash Redis to applications running on the Fly.io platform for global key-value storage.
+- [Google Cloud Functions](https://upstash.com/docs/redis/quickstarts/google-cloud-functions.md): Build a serverless Google Cloud Function that reads and writes data using Upstash Redis.
+- [Ion](https://upstash.com/docs/redis/quickstarts/ion.md): Provision and use Upstash Redis in an SST Ion app deployed to AWS with TypeScript.
+- [ioredis note](https://upstash.com/docs/redis/quickstarts/ioredisnote.md): Connect to Upstash Redis with ioredis using the connection string from the Node tab in the console.
+- [Koyeb](https://upstash.com/docs/redis/quickstarts/koyeb.md): Connect an Upstash Redis database as a cache to a Node.js application deployed on Koyeb.
+- [Laravel](https://upstash.com/docs/redis/quickstarts/laravel.md): Use Upstash Redis as the cache and data store for a PHP Laravel application.
+- [App Router](https://upstash.com/docs/redis/quickstarts/nextjs-app-router.md): Add Upstash Redis to a Next.js 15 App Router project with the @upstash/redis client.
+- [Pages Router](https://upstash.com/docs/redis/quickstarts/nextjs-pages-router.md): Add Upstash Redis to a Next.js Pages Router project with the @upstash/redis client.
+- [ AWS Lambda](https://upstash.com/docs/redis/quickstarts/python-aws-lambda.md): Connect Upstash Redis to a Python AWS Lambda function deployed with the AWS CDK.
+- [SST v2](https://upstash.com/docs/redis/quickstarts/sst-v2.md): Provision and use Upstash Redis in an SST v2 app deployed to AWS with TypeScript.
+- [Supabase Functions](https://upstash.com/docs/redis/quickstarts/supabase.md): Use Upstash Redis in a Supabase Edge Function to track invocation counts per region with a Redis hash.
+- [App Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-app-router.md): Use Upstash Redis in Vercel Functions with a Next.js App Router app and the @upstash/redis client.
+- [Pages Router](https://upstash.com/docs/redis/quickstarts/vercel-functions-pages-router.md): Use Upstash Redis in Vercel Serverless Functions with a Next.js Pages Router app.
+- [Vercel Python Runtime](https://upstash.com/docs/redis/quickstarts/vercel-python-runtime.md): Use Upstash Redis with the Vercel Python runtime in a Django app, adaptable to Flask or FastAPI.
 - [Agent Analytics](https://upstash.com/docs/redis/sdks/agent-analytics.md)
 - [Vercel AI SDK Memory, RAG & Chat History with Redis](https://upstash.com/docs/redis/sdks/agentkit/ai-sdk.md): Add long-term memory, RAG, and chat history to the Vercel AI SDK with Upstash Redis — drop-in tools for generateText and streamText, no separate vector database.
 - [Vercel AI SDK Memory, RAG & Chat History with Redis](https://upstash.com/docs/redis/sdks/agentkit/ai-sdk.md): Add long-term memory, RAG, and chat history to the Vercel AI SDK with Upstash Redis — drop-in tools for generateText and streamText, no separate vector database.
 - [Memory, RAG, Rate Limiting & Sandboxes for the Vercel Eve Agent Framework](https://upstash.com/docs/redis/sdks/agentkit/eve.md): Add long-term memory, RAG, rate limiting, tool caching, and sandboxes to Vercel's Eve agent framework with Upstash Redis — no separate vector database.
 - [Memory, RAG, Rate Limiting & Sandboxes for the Vercel Eve Agent Framework](https://upstash.com/docs/redis/sdks/agentkit/eve.md): Add long-term memory, RAG, rate limiting, tool caching, and sandboxes to Vercel's Eve agent framework with Upstash Redis — no separate vector database.
-- [ECHO](https://upstash.com/docs/redis/sdks/py/commands/auth/echo.md)
+- [ECHO](https://upstash.com/docs/redis/sdks/py/commands/auth/echo.md): Echo a message back from the server with the ECHO command in the Upstash Redis Python SDK, useful for debugging your connection.
 - [PING](https://upstash.com/docs/redis/sdks/py/commands/auth/ping.md): Send a ping to the server and get a response if the server is alive.
 - [BITCOUNT](https://upstash.com/docs/redis/sdks/py/commands/bitmap/bitcount.md): Count the number of set bits.
 - [BITFIELD](https://upstash.com/docs/redis/sdks/py/commands/bitmap/bitfield.md): Sets or gets parts of a bitfield
@@ -458,8 +458,8 @@
 - [SCRIPT FLUSH](https://upstash.com/docs/redis/sdks/py/commands/scripts/script_flush.md): Removes all scripts from the script cache.
 - [SCRIPT LOAD](https://upstash.com/docs/redis/sdks/py/commands/scripts/script_load.md): Load the specified Lua script into the script cache.
 - [DBSIZE](https://upstash.com/docs/redis/sdks/py/commands/server/dbsize.md): Count the number of keys in the database.
-- [FLUSHALL](https://upstash.com/docs/redis/sdks/py/commands/server/flushall.md)
-- [FLUSHDB](https://upstash.com/docs/redis/sdks/py/commands/server/flushdb.md)
+- [FLUSHALL](https://upstash.com/docs/redis/sdks/py/commands/server/flushall.md): Delete all keys across every database with the FLUSHALL command in the Upstash Redis Python SDK, using sync or async execution.
+- [FLUSHDB](https://upstash.com/docs/redis/sdks/py/commands/server/flushdb.md): Delete all keys in the selected database with the FLUSHDB command in the Upstash Redis Python SDK, using sync or async execution.
 - [SADD](https://upstash.com/docs/redis/sdks/py/commands/set/sadd.md): Adds one or more members to a set.
 - [SCARD](https://upstash.com/docs/redis/sdks/py/commands/set/scard.md): Return how many members are in a set
 - [SDIFF](https://upstash.com/docs/redis/sdks/py/commands/set/sdiff.md): Return the difference between sets
@@ -537,26 +537,26 @@
 - [ZSCORE](https://upstash.com/docs/redis/sdks/py/commands/zset/zscore.md): Returns the scores of a member.
 - [ZINTER](https://upstash.com/docs/redis/sdks/py/commands/zset/zunion.md): Returns the intersection between sets.
 - [ZUNIONSTORE](https://upstash.com/docs/redis/sdks/py/commands/zset/zunionstore.md): Writes the union between sets to a new key.
-- [Features](https://upstash.com/docs/redis/sdks/py/features.md)
-- [Getting Started](https://upstash.com/docs/redis/sdks/py/gettingstarted.md)
-- [Overview](https://upstash.com/docs/redis/sdks/py/overview.md)
-- [Ratelimiting Algorithms](https://upstash.com/docs/redis/sdks/ratelimit-py/algorithms.md)
-- [Features](https://upstash.com/docs/redis/sdks/ratelimit-py/features.md)
-- [Getting Started](https://upstash.com/docs/redis/sdks/ratelimit-py/gettingstarted.md)
-- [Overview](https://upstash.com/docs/redis/sdks/ratelimit-py/overview.md)
-- [Ratelimiting Algorithms](https://upstash.com/docs/redis/sdks/ratelimit-ts/algorithms.md)
-- [Costs](https://upstash.com/docs/redis/sdks/ratelimit-ts/costs.md)
-- [Features](https://upstash.com/docs/redis/sdks/ratelimit-ts/features.md)
-- [Getting Started](https://upstash.com/docs/redis/sdks/ratelimit-ts/gettingstarted.md)
-- [Configure Upstash Ratelimit Strapi Plugin](https://upstash.com/docs/redis/sdks/ratelimit-ts/integrations/strapi/configurations.md)
-- [Upstash Ratelimit Strapi Integration](https://upstash.com/docs/redis/sdks/ratelimit-ts/integrations/strapi/getting-started.md)
-- [Methods](https://upstash.com/docs/redis/sdks/ratelimit-ts/methods.md)
-- [Overview](https://upstash.com/docs/redis/sdks/ratelimit-ts/overview.md)
-- [Traffic Protection](https://upstash.com/docs/redis/sdks/ratelimit-ts/traffic-protection.md)
+- [Features](https://upstash.com/docs/redis/sdks/py/features.md): Explore upstash-redis Python SDK features including BITFIELD, custom commands, REST encoding, retries, pipelines, transactions, and telemetry.
+- [Getting Started](https://upstash.com/docs/redis/sdks/py/gettingstarted.md): Install the upstash-redis Python SDK and connect a sync or async client to your Upstash Redis database to start running commands.
+- [Overview](https://upstash.com/docs/redis/sdks/py/overview.md): upstash-redis is a connectionless, HTTP-based Redis client for Python built for serverless environments like AWS Lambda and Vercel.
+- [Ratelimiting Algorithms](https://upstash.com/docs/redis/sdks/ratelimit-py/algorithms.md): Compare fixed window, sliding window, and token bucket rate limiting algorithms in the Upstash Ratelimit Python SDK.
+- [Features](https://upstash.com/docs/redis/sdks/ratelimit-py/features.md): Use advanced Upstash Ratelimit Python features like block until ready, multiple limits per user tier, and custom token rates.
+- [Getting Started](https://upstash.com/docs/redis/sdks/ratelimit-py/gettingstarted.md): Install upstash-ratelimit for Python and add Redis-backed rate limiting to your serverless app in a few lines of code.
+- [Overview](https://upstash.com/docs/redis/sdks/ratelimit-py/overview.md): upstash-ratelimit is a connectionless rate limiting library for Python built for serverless environments like AWS Lambda and Vercel.
+- [Ratelimiting Algorithms](https://upstash.com/docs/redis/sdks/ratelimit-ts/algorithms.md): Compare fixed window, sliding window, and token bucket rate limiting algorithms in the Upstash Ratelimit TypeScript SDK.
+- [Costs](https://upstash.com/docs/redis/sdks/ratelimit-ts/costs.md): Understand the Redis command cost of each Upstash Ratelimit algorithm, method, deny list, and analytics to optimize latency and spend.
+- [Features](https://upstash.com/docs/redis/sdks/ratelimit-ts/features.md): Configure Upstash Ratelimit features like caching, timeouts, analytics, multi-region, multiple limits, custom rates, and dynamic limits.
+- [Getting Started](https://upstash.com/docs/redis/sdks/ratelimit-ts/gettingstarted.md): Install @upstash/ratelimit and protect your API endpoints with Upstash Redis-backed rate limiting in TypeScript in a few steps.
+- [Configure Upstash Ratelimit Strapi Plugin](https://upstash.com/docs/redis/sdks/ratelimit-ts/integrations/strapi/configurations.md): Configure the Upstash Ratelimit Strapi plugin with per-route algorithms, rates, identifiers, and analytics for your Strapi API.
+- [Upstash Ratelimit Strapi Integration](https://upstash.com/docs/redis/sdks/ratelimit-ts/integrations/strapi/getting-started.md): Install and configure the Upstash Ratelimit Strapi plugin to protect your Strapi CMS APIs from abuse with Redis-backed rate limiting.
+- [Methods](https://upstash.com/docs/redis/sdks/ratelimit-ts/methods.md): Reference for Upstash Ratelimit methods including limit, blockUntilReady, resetUsedTokens, getRemaining, and dynamic limit controls.
+- [Overview](https://upstash.com/docs/redis/sdks/ratelimit-ts/overview.md): @upstash/ratelimit is a connectionless, HTTP-based rate limiting library for serverless, edge, and Cloudflare Workers environments.
+- [Traffic Protection](https://upstash.com/docs/redis/sdks/ratelimit-ts/traffic-protection.md): Block malicious traffic with Upstash Ratelimit deny lists and the auto IP deny list, filtering by IP, country, user agent, or identifier.
 - [Realtime](https://upstash.com/docs/redis/sdks/realtime.md)
 - [Redis Analytics](https://upstash.com/docs/redis/sdks/redis-analytics.md)
-- [Advanced](https://upstash.com/docs/redis/sdks/ts/advanced.md)
-- [ECHO](https://upstash.com/docs/redis/sdks/ts/commands/auth/echo.md)
+- [Advanced](https://upstash.com/docs/redis/sdks/ts/advanced.md): Fine-tune the @upstash/redis TypeScript SDK with serialization, keep-alive connections, request timeouts, and telemetry options.
+- [ECHO](https://upstash.com/docs/redis/sdks/ts/commands/auth/echo.md): Echo a message back from the server with the ECHO command in the Upstash Redis TypeScript SDK, useful for debugging your connection.
 - [PING](https://upstash.com/docs/redis/sdks/ts/commands/auth/ping.md): Send a ping to the server and get a response if the server is alive.
 - [BITCOUNT](https://upstash.com/docs/redis/sdks/ts/commands/bitmap/bitcount.md): Count the number of set bits.
 - [BITOP](https://upstash.com/docs/redis/sdks/ts/commands/bitmap/bitop.md): Perform bitwise operations between strings.
@@ -664,8 +664,8 @@
 - [SCRIPT FLUSH](https://upstash.com/docs/redis/sdks/ts/commands/scripts/script_flush.md): Removes all scripts from the script cache.
 - [SCRIPT LOAD](https://upstash.com/docs/redis/sdks/ts/commands/scripts/script_load.md): Load the specified Lua script into the script cache.
 - [DBSIZE](https://upstash.com/docs/redis/sdks/ts/commands/server/dbsize.md): Count the number of keys in the database.
-- [FLUSHALL](https://upstash.com/docs/redis/sdks/ts/commands/server/flushall.md)
-- [FLUSHDB](https://upstash.com/docs/redis/sdks/ts/commands/server/flushdb.md)
+- [FLUSHALL](https://upstash.com/docs/redis/sdks/ts/commands/server/flushall.md): Delete all keys across every database with the FLUSHALL command in the Upstash Redis TypeScript SDK, using sync or async execution.
+- [FLUSHDB](https://upstash.com/docs/redis/sdks/ts/commands/server/flushdb.md): Delete all keys in the selected database with the FLUSHDB command in the Upstash Redis TypeScript SDK, using sync or async execution.
 - [SADD](https://upstash.com/docs/redis/sdks/ts/commands/set/sadd.md): Adds one or more members to a set.
 - [SCARD](https://upstash.com/docs/redis/sdks/ts/commands/set/scard.md): Return how many members are in a set
 - [SDIFF](https://upstash.com/docs/redis/sdks/ts/commands/set/sdiff.md): Return the difference between sets
@@ -698,7 +698,7 @@
 - [XREADGROUP](https://upstash.com/docs/redis/sdks/ts/commands/stream/xreadgroup.md): Reads data from a stream as part of a consumer group.
 - [XREVRANGE](https://upstash.com/docs/redis/sdks/ts/commands/stream/xrevrange.md): Returns stream entries matching a given range of IDs in reverse order.
 - [XTRIM](https://upstash.com/docs/redis/sdks/ts/commands/stream/xtrim.md): Trims the stream by removing entries to keep it at a reasonable size.
-- [String Commands](https://upstash.com/docs/redis/sdks/ts/commands/string.md)
+- [String Commands](https://upstash.com/docs/redis/sdks/ts/commands/string.md): Work with Redis string commands like MGET, MSET, SET, and SETEX in the Upstash Redis TypeScript SDK.
 - [APPEND](https://upstash.com/docs/redis/sdks/ts/commands/string/append.md): Append a value to a string stored at key.
 - [DECR](https://upstash.com/docs/redis/sdks/ts/commands/string/decr.md): Decrement the integer value of a key by one
 - [DECRBY](https://upstash.com/docs/redis/sdks/ts/commands/string/decrby.md): Decrement the integer value of a key by a given number.
@@ -736,107 +736,107 @@
 - [ZSCAN](https://upstash.com/docs/redis/sdks/ts/commands/zset/zscan.md): Scan a sorted set
 - [ZSCORE](https://upstash.com/docs/redis/sdks/ts/commands/zset/zscore.md): Returns the scores of a member.
 - [ZUNIONSTORE](https://upstash.com/docs/redis/sdks/ts/commands/zset/zunionstore.md): Writes the union between sets to a new key.
-- [Deployment](https://upstash.com/docs/redis/sdks/ts/deployment.md)
-- [Developing or Testing](https://upstash.com/docs/redis/sdks/ts/developing.md)
-- [Get Started](https://upstash.com/docs/redis/sdks/ts/getstarted.md)
-- [Overview](https://upstash.com/docs/redis/sdks/ts/overview.md)
-- [Auto-Pipelining](https://upstash.com/docs/redis/sdks/ts/pipelining/auto-pipeline.md)
-- [Pipeline & Transaction](https://upstash.com/docs/redis/sdks/ts/pipelining/pipeline-transaction.md)
-- [Retries](https://upstash.com/docs/redis/sdks/ts/retries.md)
-- [Troubleshooting](https://upstash.com/docs/redis/sdks/ts/troubleshooting.md)
+- [Deployment](https://upstash.com/docs/redis/sdks/ts/deployment.md): Deploy @upstash/redis on Node.js, Cloudflare Workers, Fastly Compute@Edge, and Deno with the correct imports and environment setup.
+- [Developing or Testing](https://upstash.com/docs/redis/sdks/ts/developing.md): Develop and test @upstash/redis locally with Serverless Redis HTTP (SRH), a Redis HTTP proxy for CI, Docker, and Kubernetes.
+- [Get Started](https://upstash.com/docs/redis/sdks/ts/getstarted.md): Install the @upstash/redis TypeScript SDK and run your first commands on strings, sets, lists, and hashes against Upstash Redis.
+- [Overview](https://upstash.com/docs/redis/sdks/ts/overview.md): @upstash/redis is a connectionless, HTTP/REST-based Redis client for serverless, edge, and Cloudflare Workers environments.
+- [Auto-Pipelining](https://upstash.com/docs/redis/sdks/ts/pipelining/auto-pipeline.md): Batch Redis commands automatically with auto-pipelining in the @upstash/redis TypeScript SDK to reduce HTTP requests and latency.
+- [Pipeline & Transaction](https://upstash.com/docs/redis/sdks/ts/pipelining/pipeline-transaction.md): Send multiple Redis commands in one request using pipelines and atomic transactions with the @upstash/redis TypeScript SDK.
+- [Retries](https://upstash.com/docs/redis/sdks/ts/retries.md): Configure automatic retries and custom backoff for network errors in the @upstash/redis TypeScript SDK constructor.
+- [Troubleshooting](https://upstash.com/docs/redis/sdks/ts/troubleshooting.md): Fix common @upstash/redis issues like missing fetch, base64-hashed responses, and large numbers returned as strings.
 - [ioredis](https://upstash.com/docs/redis/search/adapters/ioredis.md): Use Redis Search with ioredis via the @upstash/search-ioredis adapter
 - [node-redis](https://upstash.com/docs/redis/search/adapters/node-redis.md): Use Redis Search with node-redis via the @upstash/search-redis adapter
-- [$dateHistogram](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/date-histogram.md)
-- [$facet](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/facet.md)
-- [$histogram](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/histogram.md)
-- [Overview](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/overview.md)
-- [$range](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/range.md)
-- [$terms](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/terms.md)
-- [$avg](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/avg.md)
-- [$cardinality](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/cardinality.md)
-- [$count](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/count.md)
-- [$extendedStats](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/extended-stats.md)
-- [$max](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/max.md)
-- [$min](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/min.md)
-- [Overview](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/overview.md)
-- [$percentiles](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/percentiles.md)
-- [$stats](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/stats.md)
-- [$sum](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/sum.md)
-- [Aggregations](https://upstash.com/docs/redis/search/aggregations.md)
-- [Aliases](https://upstash.com/docs/redis/search/aliases.md)
-- [Command Reference](https://upstash.com/docs/redis/search/command-reference.md)
-- [Counting](https://upstash.com/docs/redis/search/counting.md)
-- [Document Updates](https://upstash.com/docs/redis/search/document-updates.md)
-- [Quickstart](https://upstash.com/docs/redis/search/getting-started.md)
-- [Indices](https://upstash.com/docs/redis/search/index-management.md)
-- [Introduction](https://upstash.com/docs/redis/search/introduction.md)
-- [$boost](https://upstash.com/docs/redis/search/query-operators/boolean-operators/boost.md)
-- [$must](https://upstash.com/docs/redis/search/query-operators/boolean-operators/must.md)
-- [$mustNot](https://upstash.com/docs/redis/search/query-operators/boolean-operators/must-not.md)
-- [Overview](https://upstash.com/docs/redis/search/query-operators/boolean-operators/overview.md)
-- [$should](https://upstash.com/docs/redis/search/query-operators/boolean-operators/should.md)
-- [$boost](https://upstash.com/docs/redis/search/query-operators/field-operators/boost.md)
-- [$eq](https://upstash.com/docs/redis/search/query-operators/field-operators/eq.md)
-- [$fuzzy](https://upstash.com/docs/redis/search/query-operators/field-operators/fuzzy.md)
-- [$in](https://upstash.com/docs/redis/search/query-operators/field-operators/in.md)
-- [Overview](https://upstash.com/docs/redis/search/query-operators/field-operators/overview.md)
-- [$phrase](https://upstash.com/docs/redis/search/query-operators/field-operators/phrase.md)
-- [Range Operators](https://upstash.com/docs/redis/search/query-operators/field-operators/range-operators.md)
-- [$regex](https://upstash.com/docs/redis/search/query-operators/field-operators/regex.md)
-- [Smart Matching](https://upstash.com/docs/redis/search/query-operators/field-operators/smart-matching.md)
-- [Queries](https://upstash.com/docs/redis/search/querying.md)
-- [Blog Search](https://upstash.com/docs/redis/search/recipes/blog-search.md)
-- [E-commerce Search](https://upstash.com/docs/redis/search/recipes/e-commerce-search.md)
-- [Overview](https://upstash.com/docs/redis/search/recipes/overview.md)
-- [User Directory](https://upstash.com/docs/redis/search/recipes/user-directory.md)
-- [Schemas](https://upstash.com/docs/redis/search/schema-definition.md)
-- [Troubleshooting](https://upstash.com/docs/redis/search/troubleshooting.md)
-- [Unexpected Increase in Command Count](https://upstash.com/docs/redis/troubleshooting/command_count_increases_unexpectedly.md)
-- [ERR DB capacity quota exceeded](https://upstash.com/docs/redis/troubleshooting/db_capacity_quota_exceeded.md)
-- [Error read ECONNRESET](https://upstash.com/docs/redis/troubleshooting/econn_reset.md)
-- [WRONGPASS invalid or missing auth token](https://upstash.com/docs/redis/troubleshooting/http_unauthorized.md)
-- [ERR max concurrent connections exceeded](https://upstash.com/docs/redis/troubleshooting/max_concurrent_connections.md)
-- [ERR max daily request limit exceeded](https://upstash.com/docs/redis/troubleshooting/max_daily_request_limit.md)
-- [ERR max key size exceeded](https://upstash.com/docs/redis/troubleshooting/max_key_size_exceeded.md)
-- [ERR max single record size exceeded](https://upstash.com/docs/redis/troubleshooting/max_record_size_exceeded.md)
-- [ERR max request size exceeded](https://upstash.com/docs/redis/troubleshooting/max_request_size_exceeded.md)
-- [ERR max requests limit exceeded](https://upstash.com/docs/redis/troubleshooting/max_requests_limit.md)
-- [NOAUTH Authentication Required](https://upstash.com/docs/redis/troubleshooting/no_auth.md)
-- [Connecting with Read-Only Access](https://upstash.com/docs/redis/troubleshooting/readonly_connection.md)
-- [ERR XReadGroup is cancelled](https://upstash.com/docs/redis/troubleshooting/stream_pel_limit.md)
+- [$dateHistogram](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/date-histogram.md): Group DATE fields into fixed time buckets with the $dateHistogram aggregation for time-series analytics in Upstash Redis Search.
+- [$facet](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/facet.md): Build hierarchical bucket trees from FACET field paths with the $facet aggregation for drill-down category navigation in Upstash Redis Search.
+- [$histogram](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/histogram.md): Group numeric values into fixed-width interval buckets with the $histogram aggregation for distribution charts in Upstash Redis Search.
+- [Overview](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/overview.md): Group documents into buckets with $terms, $range, $histogram, $dateHistogram, and $facet aggregations for segmented analytics in Upstash Redis Search.
+- [$range](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/range.md): Group documents into custom from/to range buckets with the $range aggregation for pricing tiers and business-logic ranges in Upstash Redis Search.
+- [$terms](https://upstash.com/docs/redis/search/aggregation-operators/bucket-aggregations/terms.md): Group documents by distinct field values with the $terms aggregation, controlling size, ordering, and count accuracy in Upstash Redis Search.
+- [$avg](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/avg.md): Compute the arithmetic mean of a numeric field across matching documents with the $avg metric aggregation in Upstash Redis Search.
+- [$cardinality](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/cardinality.md): Count the number of distinct values in a field with the $cardinality metric aggregation in Upstash Redis Search.
+- [$count](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/count.md): Count how many documents contribute a value for a field with the $count metric aggregation in Upstash Redis Search.
+- [$extendedStats](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/extended-stats.md): Compute count, sum, min, max, avg plus variance and standard deviation for a field with the $extendedStats aggregation in Upstash Redis Search.
+- [$max](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/max.md): Return the maximum field value across matching documents with the $max metric aggregation in Upstash Redis Search.
+- [$min](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/min.md): Return the minimum field value across matching documents with the $min metric aggregation in Upstash Redis Search.
+- [Overview](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/overview.md): Compute summary metrics like avg, sum, min, max, count, cardinality, stats, and percentiles over matched documents in Upstash Redis Search.
+- [$percentiles](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/percentiles.md): Return percentile cut points for a field to analyze value distribution with the $percentiles metric aggregation in Upstash Redis Search.
+- [$stats](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/stats.md): Compute count, sum, min, max, and avg for a field in a single pass with the $stats metric aggregation in Upstash Redis Search.
+- [$sum](https://upstash.com/docs/redis/search/aggregation-operators/metric-aggregations/sum.md): Compute the total of a numeric field across matching documents with the $sum metric aggregation in Upstash Redis Search.
+- [Aggregations](https://upstash.com/docs/redis/search/aggregations.md): Compute analytics over indexed data with metric and bucket aggregations, from averages and sums to terms, ranges, and histograms in Upstash Redis Search.
+- [Aliases](https://upstash.com/docs/redis/search/aliases.md): Create alternative names for search indices and atomically swap them for zero-downtime reindexing in Upstash Redis Search.
+- [Command Reference](https://upstash.com/docs/redis/search/command-reference.md): Complete reference of all Upstash Redis Search SEARCH.* commands, their syntax, arguments, and return values.
+- [Counting](https://upstash.com/docs/redis/search/counting.md): Count documents matching a query without retrieving them using the SEARCH.COUNT command in Upstash Redis Search.
+- [Document Updates](https://upstash.com/docs/redis/search/document-updates.md): Keep your search index in sync automatically using regular Redis write commands, with no separate update command in Upstash Redis Search.
+- [Quickstart](https://upstash.com/docs/redis/search/getting-started.md): Create an index, add documents, and run your first full-text query with Upstash Redis Search using TypeScript or Python.
+- [Indices](https://upstash.com/docs/redis/search/index-management.md): Create and manage search indices with a name, key prefix, and schema for fast full-text search and filtering in Upstash Redis Search.
+- [Introduction](https://upstash.com/docs/redis/search/introduction.md): Search JSON, Hashes, and Strings in Redis with Upstash Redis Search, a fast full-text and vector search engine built on Rust-based Tantivy.
+- [$boost](https://upstash.com/docs/redis/search/query-operators/boolean-operators/boost.md): Adjust the relevance score contribution of a boolean clause to fine-tune result ranking with the $boost operator in Upstash Redis Search.
+- [$must](https://upstash.com/docs/redis/search/query-operators/boolean-operators/must.md): Require all specified conditions to match with the $must boolean operator, implementing logical AND queries in Upstash Redis Search.
+- [$mustNot](https://upstash.com/docs/redis/search/query-operators/boolean-operators/must-not.md): Exclude documents that match any of the specified conditions with the $mustNot boolean operator in Upstash Redis Search.
+- [Overview](https://upstash.com/docs/redis/search/query-operators/boolean-operators/overview.md): Combine conditions into complex queries with the $must, $should, $mustNot, and $boost boolean operators in Upstash Redis Search.
+- [$should](https://upstash.com/docs/redis/search/query-operators/boolean-operators/should.md): Match at least one condition as a logical OR, or boost scores when combined with $must, using the $should boolean operator in Upstash Redis Search.
+- [$boost](https://upstash.com/docs/redis/search/query-operators/field-operators/boost.md): Adjust the relevance score contribution of a field match to prioritize certain matches in result ranking with the $boost operator in Upstash Redis Search.
+- [$eq](https://upstash.com/docs/redis/search/query-operators/field-operators/eq.md): Perform explicit equality matching on a field with the $eq operator, required when combining with other operators in Upstash Redis Search.
+- [$fuzzy](https://upstash.com/docs/redis/search/query-operators/field-operators/fuzzy.md): Match terms that are similar but not identical using Levenshtein distance to handle typos and misspellings with the $fuzzy operator in Upstash Redis Search.
+- [$in](https://upstash.com/docs/redis/search/query-operators/field-operators/in.md): Match documents where a field equals any value in an array with the $in operator for multi-value filtering in Upstash Redis Search.
+- [Overview](https://upstash.com/docs/redis/search/query-operators/field-operators/overview.md): Control how individual fields match with $smart, $eq, $in, range, $phrase, $fuzzy, $regex, and $boost field operators in Upstash Redis Search.
+- [$phrase](https://upstash.com/docs/redis/search/query-operators/field-operators/phrase.md): Match documents where terms appear in an exact sequence, with optional slop and prefix, using the $phrase operator in Upstash Redis Search.
+- [Range Operators](https://upstash.com/docs/redis/search/query-operators/field-operators/range-operators.md): Filter documents by numeric or date field boundaries with the $gt, $gte, $lt, and $lte range operators in Upstash Redis Search.
+- [$regex](https://upstash.com/docs/redis/search/query-operators/field-operators/regex.md): Match field terms against a regular expression pattern for flexible text matching with the $regex operator in Upstash Redis Search.
+- [Smart Matching](https://upstash.com/docs/redis/search/query-operators/field-operators/smart-matching.md): Understand default smart matching, which applies exact checks on numeric fields and intelligent multi-stage matching on text fields in Upstash Redis Search.
+- [Queries](https://upstash.com/docs/redis/search/querying.md): Search indexed documents with JSON queries, field filters, sorting, and pagination using TypeScript or Python in Upstash Redis Search.
+- [Blog Search](https://upstash.com/docs/redis/search/recipes/blog-search.md): Build full-text blog search with highlighted snippets, phrase matching, and date filtering using Upstash Redis Search.
+- [E-commerce Search](https://upstash.com/docs/redis/search/recipes/e-commerce-search.md): Build a product catalog search with filtering, sorting, typo tolerance, and relevance boosting using Upstash Redis Search.
+- [Overview](https://upstash.com/docs/redis/search/recipes/overview.md): Real-world Upstash Redis Search recipes for e-commerce, blog, and user directory search, each with schema design, sample data, and query patterns.
+- [User Directory](https://upstash.com/docs/redis/search/recipes/user-directory.md): Build a searchable employee directory with autocomplete, fuzzy name matching, and department filtering using Upstash Redis Search.
+- [Schemas](https://upstash.com/docs/redis/search/schema-definition.md): Define type-safe index schemas with the s schema builder, choosing field types like text, numeric, keyword, and FACET in Upstash Redis Search.
+- [Troubleshooting](https://upstash.com/docs/redis/search/troubleshooting.md): Diagnose and fix common Upstash Redis Search errors, from index creation conflicts to schema and query issues.
+- [Unexpected Increase in Command Count](https://upstash.com/docs/redis/troubleshooting/command_count_increases_unexpectedly.md): Understand why your Upstash Redis command count rises with no connected clients, caused by normal Console operations like the Data Browser.
+- [ERR DB capacity quota exceeded](https://upstash.com/docs/redis/troubleshooting/db_capacity_quota_exceeded.md): Fix the Upstash Redis DB capacity quota exceeded error by deleting entries, setting TTLs, enabling eviction, or upgrading your plan.
+- [Error read ECONNRESET](https://upstash.com/docs/redis/troubleshooting/econn_reset.md): Resolve the read ECONNRESET error when connecting to Upstash Redis by enabling TLS and using a rediss:// connection URL.
+- [WRONGPASS invalid or missing auth token](https://upstash.com/docs/redis/troubleshooting/http_unauthorized.md): Fix the Upstash Redis WRONGPASS error over HTTP by setting the correct UPSTASH_REDIS_REST_TOKEN from the console REST section.
+- [ERR max concurrent connections exceeded](https://upstash.com/docs/redis/troubleshooting/max_concurrent_connections.md): Fix the Upstash Redis max concurrent connections exceeded error by managing connections efficiently or using the REST-based client.
+- [ERR max daily request limit exceeded](https://upstash.com/docs/redis/troubleshooting/max_daily_request_limit.md): Fix the Upstash Redis max daily request limit exceeded error by sending fewer commands or upgrading to a paid plan.
+- [ERR max key size exceeded](https://upstash.com/docs/redis/troubleshooting/max_key_size_exceeded.md): Resolve the Upstash Redis max key size exceeded error by reducing your key size below the hardcoded 32Kb limit.
+- [ERR max single record size exceeded](https://upstash.com/docs/redis/troubleshooting/max_record_size_exceeded.md): Fix the Upstash Redis max single record size exceeded error by splitting data into smaller entries or upgrading past the 100Mb limit.
+- [ERR max request size exceeded](https://upstash.com/docs/redis/troubleshooting/max_request_size_exceeded.md): Fix the Upstash Redis max request size exceeded error by splitting commands into smaller chunks below the 10MB per-request limit.
+- [ERR max requests limit exceeded](https://upstash.com/docs/redis/troubleshooting/max_requests_limit.md): Fix the Upstash Redis max requests limit exceeded error by sending fewer monthly commands or upgrading to a paid plan.
+- [NOAUTH Authentication Required](https://upstash.com/docs/redis/troubleshooting/no_auth.md): Fix the Upstash Redis NOAUTH Authentication required error by adding the password to your connection URL with the correct ioredis format.
+- [Connecting with Read-Only Access](https://upstash.com/docs/redis/troubleshooting/readonly_connection.md): Connect to Upstash Redis with a read-only token over TCP using the default_ro user or a custom read-only ACL user to avoid WRONGPASS errors.
+- [ERR XReadGroup is cancelled](https://upstash.com/docs/redis/troubleshooting/stream_pel_limit.md): Fix the Upstash Redis XReadGroup is cancelled error by acknowledging pending stream messages with XACK to free the consumer PEL.
 - [Agent Memory with Redis Search](https://upstash.com/docs/redis/tutorials/agent_memory.md): Build short-term and long-term memory for AI agents on Upstash Redis. Store working memory with TTLs and recall long-term memories with Redis Search full-text queries.
-- [Deploy a Serverless API with AWS CDK and AWS Lambda](https://upstash.com/docs/redis/tutorials/api_with_cdk.md)
-- [Autocomplete API with Serverless Redis](https://upstash.com/docs/redis/tutorials/auto_complete_with_serverless_redis.md)
+- [Deploy a Serverless API with AWS CDK and AWS Lambda](https://upstash.com/docs/redis/tutorials/api_with_cdk.md): Build and deploy a serverless view-counter API on AWS Lambda with the AWS CDK in TypeScript, using Upstash Redis for state.
+- [Autocomplete API with Serverless Redis](https://upstash.com/docs/redis/tutorials/auto_complete_with_serverless_redis.md): Build an autocomplete API using Upstash Redis sorted sets and ZRANK to return term suggestions from prefixes.
 - [Build Stateful Applications with AWS App Runner and Serverless Redis](https://upstash.com/docs/redis/tutorials/aws_app_runner_with_redis.md): This tutorial shows how to create a serverless and stateful application using AWS App Runner and Redis
 - [Session Management on Google Cloud Run with Serverless Redis](https://upstash.com/docs/redis/tutorials/cloud_run_sessions.md): This tutorial shows how to manage user sessions on Google Cloud Run using Serverless Redis.
 - [Cloudflare Workers with Websockets and Redis](https://upstash.com/docs/redis/tutorials/cloudflare_websockets_redis.md)
-- [Use Redis in Cloudflare Workers](https://upstash.com/docs/redis/tutorials/cloudflare_workers_with_redis.md)
-- [Backendless Coin Price List with GraphQL API, Serverless Redis and Next.JS](https://upstash.com/docs/redis/tutorials/coin_price_list.md)
+- [Use Redis in Cloudflare Workers](https://upstash.com/docs/redis/tutorials/cloudflare_workers_with_redis.md): Use Upstash Redis via REST API in a Cloudflare Workers edge function to serve location-based greetings.
+- [Backendless Coin Price List with GraphQL API, Serverless Redis and Next.JS](https://upstash.com/docs/redis/tutorials/coin_price_list.md): Build a backendless coin price list with Next.js and the Upstash GraphQL API, reading Redis directly from the client.
 - [Build a Leaderboard API At Edge using Cloudflare Workers and Redis](https://upstash.com/docs/redis/tutorials/edge_leaderboard.md): This tutorial shows how to build a Leaderboard API At Edge using Cloudflare Workers and Redis.
 - [Express Session with Serverless Redis](https://upstash.com/docs/redis/tutorials/express_session.md): This tutorial shows how to use Upstash as the session storage of your Express application.
-- [Serverless Golang API with Redis](https://upstash.com/docs/redis/tutorials/goapi.md)
+- [Serverless Golang API with Redis](https://upstash.com/docs/redis/tutorials/goapi.md): Build a serverless Golang page-view counter API on AWS Lambda with Upstash Redis, deployed using AWS SAM.
 - [Build a Serverless Histogram API with Redis](https://upstash.com/docs/redis/tutorials/histogram.md): This tutorial shows how to build a histogram API with Redis.
 - [Job Processing and Event Queue with Serverless Redis](https://upstash.com/docs/redis/tutorials/job_processing.md): This tutorial shows how to use Upstash Redis for job/task processing.
-- [Caching in Laravel with Redis](https://upstash.com/docs/redis/tutorials/laravel_caching.md)
-- [Next.js with Redis](https://upstash.com/docs/redis/tutorials/nextjs_with_redis.md)
+- [Caching in Laravel with Redis](https://upstash.com/docs/redis/tutorials/laravel_caching.md): Add caching to a Laravel application with Upstash Redis to speed up database-backed queries.
+- [Next.js with Redis](https://upstash.com/docs/redis/tutorials/nextjs_with_redis.md): Use Upstash Redis as a state store in a Next.js App Router app by building a simple page-view counter.
 - [Building a Serverless Notification API for Your Web Application with Redis](https://upstash.com/docs/redis/tutorials/notification.md): This tutorial shows how to create a Serverless Notification API for Your Web Application with Redis.
 - [Nuxt with Redis](https://upstash.com/docs/redis/tutorials/nuxtjs_with_redis.md): This tutorial shows how to use Upstash inside your Nuxt application.
-- [Redis as a Cache for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_fastapi_caching.md)
-- [Multithreaded Web Scraping with Redis Caching](https://upstash.com/docs/redis/tutorials/python_multithreading.md)
-- [Rate Limiting for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_rate_limiting.md)
-- [Build a Real-Time Chat Application with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_realtime_chat.md)
-- [Manage Sessions in Python with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_session.md)
-- [Building a URL Shortener with Redis](https://upstash.com/docs/redis/tutorials/python_url_shortener.md)
-- [Serverless Python API with Redis](https://upstash.com/docs/redis/tutorials/pythonapi.md)
-- [AWS Lambda Rate Limiting with Serverless Redis](https://upstash.com/docs/redis/tutorials/rate-limiting.md)
+- [Redis as a Cache for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_fastapi_caching.md): Cache FastAPI responses with Upstash Redis to cut database queries and speed up an external weather API app.
+- [Multithreaded Web Scraping with Redis Caching](https://upstash.com/docs/redis/tutorials/python_multithreading.md): Build a multithreaded Python web scraper that caches HTTP responses in Upstash Redis to avoid redundant requests.
+- [Rate Limiting for Your FastAPI App](https://upstash.com/docs/redis/tutorials/python_rate_limiting.md): Add rate limiting to a FastAPI app with Upstash Redis using a fixed window limiter to control API usage.
+- [Build a Real-Time Chat Application with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_realtime_chat.md): Build a real-time chat app with Flask, SocketIO, and Upstash Redis Pub/Sub for low-latency message handling.
+- [Manage Sessions in Python with Serverless Redis](https://upstash.com/docs/redis/tutorials/python_session.md): Implement session management in a FastAPI app using cookies and Upstash Redis for fast, expiring session storage.
+- [Building a URL Shortener with Redis](https://upstash.com/docs/redis/tutorials/python_url_shortener.md): Build a URL shortener in Python with Upstash Redis, generating short codes and setting expiration times for links.
+- [Serverless Python API with Redis](https://upstash.com/docs/redis/tutorials/pythonapi.md): Build a serverless Python page-view counter API on AWS Lambda with Upstash Redis, deployed using the AWS CDK.
+- [AWS Lambda Rate Limiting with Serverless Redis](https://upstash.com/docs/redis/tutorials/rate-limiting.md): Rate limit an AWS Lambda function by client IP using @upstash/ratelimit, Upstash Redis, and the Serverless Framework.
 - [Redis Queue: From FIFO Lists to a Job Queue](https://upstash.com/docs/redis/tutorials/redis_queue.md): How to build FIFO, reliable, and blocking queues on Upstash Redis, then a delayed and prioritized job queue with a dead-letter queue.
 - [Serverless Redisson](https://upstash.com/docs/redis/tutorials/redisson.md): This tutorial shows how to use Upstash with Redisson client.
 - [Roadmap Voting App with Serverless Redis](https://upstash.com/docs/redis/tutorials/roadmapvotingapp.md): This is a single page application powered by upstash and next.js.
-- [Serverless API with Java and Redis](https://upstash.com/docs/redis/tutorials/serverless_java_redis.md)
+- [Serverless API with Java and Redis](https://upstash.com/docs/redis/tutorials/serverless_java_redis.md): Build a stateful serverless page-view counter API with Java and Upstash Redis on AWS Lambda.
 - [TanStack AI Chat Persistance](https://upstash.com/docs/redis/tutorials/tanstack_chat_persistence.md): Use Upstash Redis to persist TanStack AI chat histories across reloads, navigation, and devices with a simple adapter.
-- [Using AWS SAM](https://upstash.com/docs/redis/tutorials/using_aws_sam.md)
-- [Serverless Redis on Google Cloud Functions](https://upstash.com/docs/redis/tutorials/using_google_cloud_functions.md)
-- [Using Serverless Framework](https://upstash.com/docs/redis/tutorials/using_serverless_framework.md)
+- [Using AWS SAM](https://upstash.com/docs/redis/tutorials/using_aws_sam.md): Build and deploy a serverless application to AWS Lambda with Upstash Redis using the AWS SAM CLI.
+- [Serverless Redis on Google Cloud Functions](https://upstash.com/docs/redis/tutorials/using_google_cloud_functions.md): Build a serverless view-counter API on Google Cloud Functions using Upstash Redis as the data store.
+- [Using Serverless Framework](https://upstash.com/docs/redis/tutorials/using_serverless_framework.md): Build and deploy a serverless application to AWS Lambda with Upstash Redis using the Serverless Framework.
 - [Advanced Settings](https://upstash.com/docs/search/features/advanced-settings.md)
 - [Algorithm](https://upstash.com/docs/search/features/algorithm.md)
 - [Content and Metadata](https://upstash.com/docs/search/features/content-and-metadata.md): How to use content and metadata fields in your documents
@@ -952,14 +952,14 @@
 - [RAG with LlamaIndex](https://upstash.com/docs/vector/tutorials/llamaindex.md)
 - [Parsing and Querying Documents with LlamaParse](https://upstash.com/docs/vector/tutorials/llamaparse.md)
 - [Simple Semantic Search](https://upstash.com/docs/vector/tutorials/semantic_search.md)
-- [Examples](https://upstash.com/docs/workflow/agents/examples.md)
-- [Features](https://upstash.com/docs/workflow/agents/features.md)
-- [Getting Started](https://upstash.com/docs/workflow/agents/getting-started.md)
-- [Overview](https://upstash.com/docs/workflow/agents/overview.md)
-- [Evaluator-Optimizer](https://upstash.com/docs/workflow/agents/patterns/evaluator-optimizer.md)
-- [Orchestrator-Workers](https://upstash.com/docs/workflow/agents/patterns/orchestrator-workers.md)
-- [Parallelization](https://upstash.com/docs/workflow/agents/patterns/parallelization.md)
-- [Prompt Chaining](https://upstash.com/docs/workflow/agents/patterns/prompt-chaining.md)
+- [Examples](https://upstash.com/docs/workflow/agents/examples.md): Explore examples of building agent systems with the Upstash Workflow Agents API, from architectural patterns to real-world implementations.
+- [Features](https://upstash.com/docs/workflow/agents/features.md): Explore the features of the Upstash Workflow Agents API, including models, tools from AI SDK and LangChain, and multi-agent orchestration.
+- [Getting Started](https://upstash.com/docs/workflow/agents/getting-started.md): Build your first AI agent endpoint with Upstash Workflow and Next.js, from installation to defining reliable, tool-using agents.
+- [Overview](https://upstash.com/docs/workflow/agents/overview.md): Run single or multi-agent AI systems with Upstash Workflow, integrating AI SDK or LangChain tools with reliable, timeout-free execution.
+- [Evaluator-Optimizer](https://upstash.com/docs/workflow/agents/patterns/evaluator-optimizer.md): Build an evaluator-optimizer agent pattern with Upstash Workflow, where a generator refines its output from evaluator feedback until it passes.
+- [Orchestrator-Workers](https://upstash.com/docs/workflow/agents/patterns/orchestrator-workers.md): Build an orchestrator-workers agent pattern with Upstash Workflow, directing multiple worker agents on subtasks and synthesizing their outputs.
+- [Parallelization](https://upstash.com/docs/workflow/agents/patterns/parallelization.md): Build a parallelization agent pattern with Upstash Workflow, calling multiple agents simultaneously and aggregating their results.
+- [Prompt Chaining](https://upstash.com/docs/workflow/agents/patterns/prompt-chaining.md): Build a prompt chaining agent pattern with Upstash Workflow, where each agent's output feeds the next in a sequence of LLM calls.
 - [Bulk Delete Failed Workflow Runs](https://upstash.com/docs/workflow/api-reference/dlq/bulk-delete-failed-workflow-runs.md): Delete multiple failed workflow runs from the DLQ.
 - [Bulk Restart Workflows from DLQ](https://upstash.com/docs/workflow/api-reference/dlq/bulk-restart-workflows-from-dlq.md): Restart multiple failed workflow runs from the DLQ. Each workflow will start from the beginning.
 - [Bulk Resume Workflows from DLQ](https://upstash.com/docs/workflow/api-reference/dlq/bulk-resume-workflows-from-dlq.md): When a workflow run fails, it's automatically moved to the DLQ (Dead Letter Queue) where it can be analyzed and resumed.    The resume feature allows you to continue a failed workflow run from exactly where it failed, without re-executing successfully completed steps.
@@ -989,112 +989,112 @@
 - [Trigger Workflow Run](https://upstash.com/docs/workflow/api-reference/runs/trigger-workflow-run.md): Start a new workflow run.
 - [Get Signing Keys](https://upstash.com/docs/workflow/api-reference/signing-keys/get-signing-keys.md): Retrieve your current and next signing keys
 - [Rotate Signing Keys](https://upstash.com/docs/workflow/api-reference/signing-keys/rotate-signing-keys.md): Rotate your signing keys
-- [Caveats](https://upstash.com/docs/workflow/basics/caveats.md)
-- [Overview](https://upstash.com/docs/workflow/basics/client.md)
-- [client.cancel](https://upstash.com/docs/workflow/basics/client/cancel.md)
-- [client.dlq.retryFailureFunction](https://upstash.com/docs/workflow/basics/client/dlq/callback.md)
-- [client.dlq.delete](https://upstash.com/docs/workflow/basics/client/dlq/delete.md)
-- [client.dlq.list](https://upstash.com/docs/workflow/basics/client/dlq/list.md)
-- [client.dlq.restart](https://upstash.com/docs/workflow/basics/client/dlq/restart.md)
-- [client.dlq.resume](https://upstash.com/docs/workflow/basics/client/dlq/resume.md)
-- [client.logs](https://upstash.com/docs/workflow/basics/client/logs.md)
-- [client.notify](https://upstash.com/docs/workflow/basics/client/notify.md)
-- [client.trigger](https://upstash.com/docs/workflow/basics/client/trigger.md)
-- [client.getWaiters](https://upstash.com/docs/workflow/basics/client/waiters.md)
-- [How Workflow Works](https://upstash.com/docs/workflow/basics/how.md)
-- [Overview](https://upstash.com/docs/workflow/basics/serve.md)
-- [Advanced Options](https://upstash.com/docs/workflow/basics/serve/advanced.md)
-- [Changelog](https://upstash.com/docs/workflow/changelog.md)
-- [AI Generation](https://upstash.com/docs/workflow/examples/allInOne.md)
-- [Auth Provider Webhook](https://upstash.com/docs/workflow/examples/authWebhook.md)
-- [Custom Retry Logic](https://upstash.com/docs/workflow/examples/customRetry.md)
-- [Customer Onboarding](https://upstash.com/docs/workflow/examples/customerOnboarding.md)
-- [Dynamic Workflows](https://upstash.com/docs/workflow/examples/dynamicWorkflow.md)
-- [E-commerce Order Fulfillment](https://upstash.com/docs/workflow/examples/eCommerceOrderFulfillment.md)
-- [Image Processing](https://upstash.com/docs/workflow/examples/imageProcessing.md)
-- [Payment Retries](https://upstash.com/docs/workflow/examples/paymentRetry.md)
-- [Waiting for Events](https://upstash.com/docs/workflow/examples/waitForEvent.md)
-- [Overview](https://upstash.com/docs/workflow/features/dlq.md)
-- [Rerun Failure Function](https://upstash.com/docs/workflow/features/dlq/callback.md)
-- [Delete](https://upstash.com/docs/workflow/features/dlq/delete.md)
-- [Restart](https://upstash.com/docs/workflow/features/dlq/restart.md)
-- [Resume](https://upstash.com/docs/workflow/features/dlq/resume.md)
-- [Overview](https://upstash.com/docs/workflow/features/failure-callback.md)
-- [Advanced failureUrl Option](https://upstash.com/docs/workflow/features/failureFunction/advanced.md)
-- [Reliability of Failure Function](https://upstash.com/docs/workflow/features/failureFunction/reliability.md)
-- [Overview](https://upstash.com/docs/workflow/features/flow-control.md)
-- [Monitor & Manage](https://upstash.com/docs/workflow/features/flow-control/monitor.md)
-- [Parallelism](https://upstash.com/docs/workflow/features/flow-control/parallelism.md)
-- [Rate and Period](https://upstash.com/docs/workflow/features/flow-control/rate-period.md)
-- [Overview](https://upstash.com/docs/workflow/features/invoke.md)
-- [Using Serve Many](https://upstash.com/docs/workflow/features/invoke/serveMany.md)
-- [Notify](https://upstash.com/docs/workflow/features/notify.md)
-- [Parallel Steps](https://upstash.com/docs/workflow/features/parallel-steps.md)
-- [Overview](https://upstash.com/docs/workflow/features/retries.md)
-- [Prevent Retries](https://upstash.com/docs/workflow/features/retries/prevent-retries.md)
-- [Sleep](https://upstash.com/docs/workflow/features/sleep.md)
-- [Wait](https://upstash.com/docs/workflow/features/wait.md)
-- [Overview](https://upstash.com/docs/workflow/features/wait-for-event.md)
-- [Webhooks](https://upstash.com/docs/workflow/features/webhooks.md)
-- [Overview](https://upstash.com/docs/workflow/getstarted.md)
-- [Cancel a Run](https://upstash.com/docs/workflow/howto/cancel.md)
-- [Update a Workflow](https://upstash.com/docs/workflow/howto/changes.md)
-- [Configure a Run](https://upstash.com/docs/workflow/howto/configure.md)
-- [Handle Failed Runs](https://upstash.com/docs/workflow/howto/failures.md)
+- [Caveats](https://upstash.com/docs/workflow/basics/caveats.md): Best practices and caveats for Upstash Workflow, including running business logic inside context.run and avoiding common pitfalls.
+- [Overview](https://upstash.com/docs/workflow/basics/client.md): Use the Upstash Workflow Client to programmatically interact with your workflow runs from your own app or any external service.
+- [client.cancel](https://upstash.com/docs/workflow/basics/client/cancel.md): Cancel one or more Upstash Workflow runs by ID, using filters, or all at once with the client.cancel method.
+- [client.dlq.retryFailureFunction](https://upstash.com/docs/workflow/basics/client/dlq/callback.md): Retry a failed failureFunction or failureUrl request in Upstash Workflow using the client.dlq.retryFailureFunction method.
+- [client.dlq.delete](https://upstash.com/docs/workflow/basics/client/dlq/delete.md): Delete one or more workflow runs from the Upstash Workflow Dead Letter Queue by ID, array of IDs, or filters with client.dlq.delete.
+- [client.dlq.list](https://upstash.com/docs/workflow/basics/client/dlq/list.md): List failed workflow and QStash messages in the Upstash Workflow Dead Letter Queue with pagination using the client.dlq.list method.
+- [client.dlq.restart](https://upstash.com/docs/workflow/basics/client/dlq/restart.md): Restart failed workflow runs from the Upstash Workflow Dead Letter Queue from the beginning using the client.dlq.restart method.
+- [client.dlq.resume](https://upstash.com/docs/workflow/basics/client/dlq/resume.md): Resume failed workflow runs from the Upstash Workflow Dead Letter Queue at the failed step using the client.dlq.resume method.
+- [client.logs](https://upstash.com/docs/workflow/basics/client/logs.md): Retrieve Upstash Workflow run logs with pagination and filtering using the client.logs method.
+- [client.notify](https://upstash.com/docs/workflow/basics/client/notify.md): Notify Upstash Workflow runs waiting at a waitForEvent step and resume them with event data using the client.notify method.
+- [client.trigger](https://upstash.com/docs/workflow/basics/client/trigger.md): Start one or more Upstash Workflow runs and get their workflowRunId using the client.trigger method.
+- [client.getWaiters](https://upstash.com/docs/workflow/basics/client/waiters.md): Retrieve all workflow runs currently paused at a waitForEvent step for a given event using the client.getWaiters method.
+- [How Workflow Works](https://upstash.com/docs/workflow/basics/how.md): Understand how Upstash Workflow orchestrates durable, scalable, and cost-efficient multi-step workflows built on top of Upstash QStash.
+- [Overview](https://upstash.com/docs/workflow/basics/serve.md): Define a workflow endpoint with the Upstash Workflow serve() function, passing a route function of steps and configuration options.
+- [Advanced Options](https://upstash.com/docs/workflow/basics/serve/advanced.md): Advanced serve() options for Upstash Workflow, including failureFunction, retries, and settings for edge cases and testing pipelines.
+- [Changelog](https://upstash.com/docs/workflow/changelog.md): Changelog for Upstash Workflow, tracking new features and updates to the TypeScript (workflow-js) and Python (workflow-py) SDKs.
+- [AI Generation](https://upstash.com/docs/workflow/examples/allInOne.md): Process large datasets with Upstash Workflow by downloading data, processing chunks with OpenAI GPT-4, aggregating results, and generating a report.
+- [Auth Provider Webhook](https://upstash.com/docs/workflow/examples/authWebhook.md): Build an authentication provider webhook with Upstash Workflow to handle user creation, Stripe trials, and automated email reminders.
+- [Custom Retry Logic](https://upstash.com/docs/workflow/examples/customRetry.md): Implement custom retry logic in Upstash Workflow using response status codes and headers to control retries when calling third-party APIs like OpenAI.
+- [Customer Onboarding](https://upstash.com/docs/workflow/examples/customerOnboarding.md): Build a customer onboarding workflow with Upstash Workflow that registers users, sends welcome emails, and reacts to user activity over time.
+- [Dynamic Workflows](https://upstash.com/docs/workflow/examples/dynamicWorkflow.md): Build dynamic, configurable workflows with Upstash Workflow that run runtime-defined steps while safely handling ordering, naming, and versioning.
+- [E-commerce Order Fulfillment](https://upstash.com/docs/workflow/examples/eCommerceOrderFulfillment.md): Automate e-commerce order fulfillment with Upstash Workflow by verifying stock, processing payment, dispatching orders, and notifying customers.
+- [Image Processing](https://upstash.com/docs/workflow/examples/imageProcessing.md): Process images with Upstash Workflow by uploading, resizing into multiple resolutions, applying filters, and storing the processed versions.
+- [Payment Retries](https://upstash.com/docs/workflow/examples/paymentRetry.md): Build a payment retry workflow with Upstash Workflow that retries failed charges, sends invoice emails, and suspends accounts after repeated failures.
+- [Waiting for Events](https://upstash.com/docs/workflow/examples/waitForEvent.md): Pause and resume workflows with Upstash Workflow's wait-for-event feature, letting an external system notify order processing when it is ready.
+- [Overview](https://upstash.com/docs/workflow/features/dlq.md): The Dead Letter Queue automatically captures failed Upstash Workflow runs after all retries, preserving execution context for restart, resume, or delete.
+- [Rerun Failure Function](https://upstash.com/docs/workflow/features/dlq/callback.md): Rerun a workflow's failure function from the DLQ to complete cleanup, logging, or alerting tasks that failed after an Upstash Workflow run failed.
+- [Delete](https://upstash.com/docs/workflow/features/dlq/delete.md): Delete failed Upstash Workflow runs from the Dead Letter Queue individually, in bulk by ID, or by filters like label, URL, or date range.
+- [Restart](https://upstash.com/docs/workflow/features/dlq/restart.md): Restart a failed Upstash Workflow run from the beginning, discarding previous step results and executing from scratch with the original payload.
+- [Resume](https://upstash.com/docs/workflow/features/dlq/resume.md): Resume a failed Upstash Workflow run from the exact point of failure, preserving all successfully completed steps and their results.
+- [Overview](https://upstash.com/docs/workflow/features/failure-callback.md): Attach a failure function to your Upstash Workflow to run custom cleanup, logging, or alerting when a run fails after exhausting all retries.
+- [Advanced failureUrl Option](https://upstash.com/docs/workflow/features/failureFunction/advanced.md): Use the failureUrl option to send Upstash Workflow failure callbacks to a separate endpoint, handling failures on infrastructure independent of your workflow.
+- [Reliability of Failure Function](https://upstash.com/docs/workflow/features/failureFunction/reliability.md): Understand how Upstash Workflow retries a failing failure function and how to inspect and rerun failed executions from the DLQ dashboard.
+- [Overview](https://upstash.com/docs/workflow/features/flow-control.md): Flow Control limits how many Upstash Workflow steps run by queuing and delaying delivery to respect rate, period, and parallelism constraints.
+- [Monitor & Manage](https://upstash.com/docs/workflow/features/flow-control/monitor.md): Monitor and manage Upstash Workflow flow control keys from the console or REST API, including pausing delivery, pinning configs, and resetting rate counts.
+- [Parallelism](https://upstash.com/docs/workflow/features/flow-control/parallelism.md): Limit how many Upstash Workflow steps run concurrently with a token-based parallelism control that queues excess requests in a waitlist.
+- [Rate and Period](https://upstash.com/docs/workflow/features/flow-control/rate-period.md): Control how many Upstash Workflow steps start within a time window using rate and period limits, queuing excess steps for the next window.
+- [Overview](https://upstash.com/docs/workflow/features/invoke.md): Use context.invoke to start another Upstash Workflow from within a workflow and await its result, orchestrating multiple workflows together.
+- [Using Serve Many](https://upstash.com/docs/workflow/features/invoke/serveMany.md): Expose multiple Upstash Workflows under one route with serveMany and invoke them by object with full type safety, no URLs required.
+- [Notify](https://upstash.com/docs/workflow/features/notify.md): Notify Upstash Workflow runs waiting on an event ID from inside a workflow or an external system, with lookback to prevent race conditions.
+- [Parallel Steps](https://upstash.com/docs/workflow/features/parallel-steps.md): Run multiple Upstash Workflow steps concurrently with Promise.all to execute independent operations in parallel with no extra configuration.
+- [Overview](https://upstash.com/docs/workflow/features/retries.md): Upstash Workflow automatically retries failed steps with configurable attempt counts and exponential backoff to handle transient errors reliably.
+- [Prevent Retries](https://upstash.com/docs/workflow/features/retries/prevent-retries.md): Stop Upstash Workflow execution without retries using WorkflowNonRetryableError, context.cancel, or conditional guards to exit early gracefully.
+- [Sleep](https://upstash.com/docs/workflow/features/sleep.md): Pause Upstash Workflow execution with context.sleep and sleepUntil to build time-based delays without consuming compute or serverless timeouts.
+- [Wait](https://upstash.com/docs/workflow/features/wait.md): Pause an Upstash Workflow run with waitForEvent until a matching event is published, using configurable timeouts to handle waits gracefully.
+- [Overview](https://upstash.com/docs/workflow/features/wait-for-event.md): Pause an Upstash Workflow with waitForEvent until an external event arrives, with timeouts and lookback strategies to avoid notify race conditions.
+- [Webhooks](https://upstash.com/docs/workflow/features/webhooks.md): Pause an Upstash Workflow and wait for a callback URL with createWebhook and waitForWebhook, integrating third-party APIs with built-in lookback.
+- [Overview](https://upstash.com/docs/workflow/getstarted.md): Upstash Workflow lets you write durable, reliable serverless functions with delivery guarantees, automatic retries, and scheduling, with no infrastructure to manage.
+- [Cancel a Run](https://upstash.com/docs/workflow/howto/cancel.md): Cancel a running Upstash Workflow from the console, the client.cancel method, or the REST API using the workflow run ID.
+- [Update a Workflow](https://upstash.com/docs/workflow/howto/changes.md): Update Upstash Workflow code safely by understanding step-order constraints and strategies for handling in-progress runs during deployments.
+- [Configure a Run](https://upstash.com/docs/workflow/howto/configure.md): Configure an Upstash Workflow run with retries, retry delay, and flow control options when triggering it with the client.
+- [Handle Failed Runs](https://upstash.com/docs/workflow/howto/failures.md): Gracefully handle failed Upstash Workflow runs with failure functions, failureUrl callbacks, retries, and DLQ recovery for debugging and resuming.
 - [Flow control](https://upstash.com/docs/workflow/howto/flow-control.md)
-- [Development Server](https://upstash.com/docs/workflow/howto/local-development/development-server.md)
-- [Local Tunnel](https://upstash.com/docs/workflow/howto/local-development/local-tunnel.md)
-- [Middlewares](https://upstash.com/docs/workflow/howto/middlewares.md)
-- [Migration Guide](https://upstash.com/docs/workflow/howto/migrations.md)
-- [Select a Region](https://upstash.com/docs/workflow/howto/multi-region.md)
-- [Parallel Runs](https://upstash.com/docs/workflow/howto/parallel-runs.md)
-- [Read-only Token](https://upstash.com/docs/workflow/howto/readonly-token.md)
-- [Realtime Quickstart](https://upstash.com/docs/workflow/howto/realtime/basic.md)
-- [Human-in-the-Loop](https://upstash.com/docs/workflow/howto/realtime/human-in-the-loop.md)
+- [Development Server](https://upstash.com/docs/workflow/howto/local-development/development-server.md): Run Upstash Workflow locally with the QStash development server, using QSTASH_DEV for automatic setup or manual configuration with the CLI.
+- [Local Tunnel](https://upstash.com/docs/workflow/howto/local-development/local-tunnel.md): Expose your local Upstash Workflow endpoint publicly with an ngrok tunnel so managed QStash servers can reach it during development.
+- [Middlewares](https://upstash.com/docs/workflow/howto/middlewares.md): Hook into Upstash Workflow lifecycle and debug events with built-in or custom middleware for logging, monitoring, and error tracking.
+- [Migration Guide](https://upstash.com/docs/workflow/howto/migrations.md): Migrate between Upstash Workflow versions, including the 1.0.0 TypeScript release breaking changes and moving from @upstash/qstash.
+- [Select a Region](https://upstash.com/docs/workflow/howto/multi-region.md): Choose between Upstash Workflow's EU and US regions and migrate resources between them using single-region or migration mode configuration.
+- [Parallel Runs](https://upstash.com/docs/workflow/howto/parallel-runs.md): Run multiple Upstash Workflow steps at the same time with Promise.all, executing independent steps concurrently within a single run.
+- [Read-only Token](https://upstash.com/docs/workflow/howto/readonly-token.md): Share a read-only Upstash Workflow token that accesses logs, messages, and schedules but cannot publish messages or modify resources.
+- [Realtime Quickstart](https://upstash.com/docs/workflow/howto/realtime/basic.md): Integrate Upstash Workflow with Upstash Realtime to emit step events and stream live workflow progress to your frontend over Server-Sent Events.
+- [Human-in-the-Loop](https://upstash.com/docs/workflow/howto/realtime/human-in-the-loop.md): Build human-in-the-loop Upstash Workflows that pause for user approval with waitForEvent and stream real-time status updates using Upstash Realtime.
 - [Redact Private Data](https://upstash.com/docs/workflow/howto/redact-fields.md): How to redact private data in your workflow runs
-- [Schedule a Workflow](https://upstash.com/docs/workflow/howto/schedule.md)
-- [Secure a Workflow](https://upstash.com/docs/workflow/howto/security.md)
-- [Start a Run](https://upstash.com/docs/workflow/howto/start.md)
-- [Webhooks](https://upstash.com/docs/workflow/howto/use-webhooks.md)
-- [Vercel AI SDK](https://upstash.com/docs/workflow/integrations/aisdk.md)
-- [Anthropic](https://upstash.com/docs/workflow/integrations/anthropic.md)
-- [Datadog - Upstash QStash Integration](https://upstash.com/docs/workflow/integrations/datadog.md)
-- [OpenAI](https://upstash.com/docs/workflow/integrations/openai.md)
-- [Prometheus - Upstash QStash Integration](https://upstash.com/docs/workflow/integrations/prometheus.md)
-- [Resend](https://upstash.com/docs/workflow/integrations/resend.md)
+- [Schedule a Workflow](https://upstash.com/docs/workflow/howto/schedule.md): Schedule Upstash Workflows to run periodically with QStash cron schedules, from the dashboard or programmatically with per-user schedule IDs.
+- [Secure a Workflow](https://upstash.com/docs/workflow/howto/security.md): Secure your Upstash Workflow endpoint with built-in Upstash-Signature request verification or a custom authorization method.
+- [Start a Run](https://upstash.com/docs/workflow/howto/start.md): Start an Upstash Workflow run with the recommended client.trigger method or a direct HTTP request, passing body, headers, retries, and more.
+- [Webhooks](https://upstash.com/docs/workflow/howto/use-webhooks.md): Handle incoming webhooks in Upstash Workflow by setting up endpoints, validating requests, and processing events as trackable steps.
+- [Vercel AI SDK](https://upstash.com/docs/workflow/integrations/aisdk.md): Integrate Upstash Workflow with the Vercel AI SDK to build durable AI applications with automatic retries, workflow steps, and tool calling.
+- [Anthropic](https://upstash.com/docs/workflow/integrations/anthropic.md): Call the Anthropic messages API from Upstash Workflow using the type-safe context.api.anthropic.call method for durable text generation.
+- [Datadog - Upstash QStash Integration](https://upstash.com/docs/workflow/integrations/datadog.md): Connect Datadog with Upstash QStash to monitor message delivery, retries, DLQ, and schedules with dashboards and analytics.
+- [OpenAI](https://upstash.com/docs/workflow/integrations/openai.md): Call the OpenAI chat completions API from Upstash Workflow using the type-safe context.api.openai.call method for durable text generation.
+- [Prometheus - Upstash QStash Integration](https://upstash.com/docs/workflow/integrations/prometheus.md): Scrape Upstash QStash metrics into Prometheus and visualize them in Grafana to monitor message delivery and performance.
+- [Resend](https://upstash.com/docs/workflow/integrations/resend.md): Send emails from Upstash Workflow using the type-safe context.api.resend.call method for durable single and batch email delivery.
 - [llms.txt](https://upstash.com/docs/workflow/llms-txt.md)
-- [Pricing](https://upstash.com/docs/workflow/pricing.md)
-- [Astro](https://upstash.com/docs/workflow/quickstarts/astro.md)
-- [Cloudflare Workers](https://upstash.com/docs/workflow/quickstarts/cloudflare-workers.md)
-- [Express.js](https://upstash.com/docs/workflow/quickstarts/express.md)
-- [FastAPI](https://upstash.com/docs/workflow/quickstarts/fastapi.md)
-- [Flask](https://upstash.com/docs/workflow/quickstarts/flask.md)
-- [Hono](https://upstash.com/docs/workflow/quickstarts/hono.md)
-- [Next.js & FastAPI](https://upstash.com/docs/workflow/quickstarts/nextjs-fastapi.md)
-- [Next.js & Flask](https://upstash.com/docs/workflow/quickstarts/nextjs-flask.md)
-- [Nuxt](https://upstash.com/docs/workflow/quickstarts/nuxt.md)
-- [Supported Platforms](https://upstash.com/docs/workflow/quickstarts/platforms.md)
-- [SolidJS](https://upstash.com/docs/workflow/quickstarts/solidjs.md)
-- [SvelteKit](https://upstash.com/docs/workflow/quickstarts/svelte.md)
-- [TanStack Start](https://upstash.com/docs/workflow/quickstarts/tanstack-start.md)
-- [Next.js](https://upstash.com/docs/workflow/quickstarts/vercel-nextjs.md)
+- [Pricing](https://upstash.com/docs/workflow/pricing.md): Understand Upstash Workflow's pay-as-you-go pricing, based on QStash messages per workflow run, and how each step contributes to cost.
+- [Astro](https://upstash.com/docs/workflow/quickstarts/astro.md): Use Upstash Workflow with Astro in this step-by-step quickstart, with a complete example project on GitHub.
+- [Cloudflare Workers](https://upstash.com/docs/workflow/quickstarts/cloudflare-workers.md): Deploy Upstash Workflow on Cloudflare Workers with this step-by-step guide, including Hono.js examples and best practices.
+- [Express.js](https://upstash.com/docs/workflow/quickstarts/express.md): Use Upstash Workflow with Express.js in this step-by-step quickstart, with a complete example project on GitHub.
+- [FastAPI](https://upstash.com/docs/workflow/quickstarts/fastapi.md): Use Upstash Workflow with FastAPI in Python through this step-by-step quickstart, with an end-to-end example project on GitHub.
+- [Flask](https://upstash.com/docs/workflow/quickstarts/flask.md): Use Upstash Workflow with Flask in Python through this step-by-step quickstart, with an end-to-end example project on GitHub.
+- [Hono](https://upstash.com/docs/workflow/quickstarts/hono.md): Deploy Upstash Workflow with Hono on Cloudflare Workers in this step-by-step quickstart, with an end-to-end example project.
+- [Next.js & FastAPI](https://upstash.com/docs/workflow/quickstarts/nextjs-fastapi.md): Build durable workflows with Upstash Workflow using a Next.js frontend and FastAPI backend in this step-by-step quickstart.
+- [Next.js & Flask](https://upstash.com/docs/workflow/quickstarts/nextjs-flask.md): Build durable workflows with Upstash Workflow using a Next.js frontend and Flask backend in this step-by-step quickstart.
+- [Nuxt](https://upstash.com/docs/workflow/quickstarts/nuxt.md): Deploy Upstash Workflow with Nuxt in this step-by-step quickstart, featuring a one-click Vercel deploy and example project.
+- [Supported Platforms](https://upstash.com/docs/workflow/quickstarts/platforms.md): Explore the platforms and frameworks natively supported by Upstash Workflow across JavaScript, TypeScript, and Python.
+- [SolidJS](https://upstash.com/docs/workflow/quickstarts/solidjs.md): Use Upstash Workflow with SolidJS in this step-by-step quickstart, with an end-to-end example project on GitHub.
+- [SvelteKit](https://upstash.com/docs/workflow/quickstarts/svelte.md): Deploy Upstash Workflow with SvelteKit in this step-by-step quickstart, featuring a one-click Vercel deploy and example project.
+- [TanStack Start](https://upstash.com/docs/workflow/quickstarts/tanstack-start.md): Use Upstash Workflow with TanStack Start in this step-by-step quickstart, with a complete example project on GitHub.
+- [Next.js](https://upstash.com/docs/workflow/quickstarts/vercel-nextjs.md): Deploy Upstash Workflow with Next.js on Vercel in this step-by-step quickstart, featuring a one-click deploy and example project.
 - [Roadmap](https://upstash.com/docs/workflow/roadmap.md)
 - [JavaScript SDK](https://upstash.com/docs/workflow/sdk/workflow-js.md)
 - [Python SDK](https://upstash.com/docs/workflow/sdk/workflow-py.md)
-- [Overview](https://upstash.com/docs/workflow/steps.md)
-- [context.api](https://upstash.com/docs/workflow/steps/api.md)
-- [context.call](https://upstash.com/docs/workflow/steps/call.md)
-- [context.cancel](https://upstash.com/docs/workflow/steps/cancel.md)
-- [context.createWebhook](https://upstash.com/docs/workflow/steps/createWebhook.md)
-- [context.invoke](https://upstash.com/docs/workflow/steps/invoke.md)
-- [context.notify](https://upstash.com/docs/workflow/steps/notify.md)
-- [context.run](https://upstash.com/docs/workflow/steps/run.md)
-- [context.sleep](https://upstash.com/docs/workflow/steps/sleep.md)
-- [context.sleepUntil](https://upstash.com/docs/workflow/steps/sleepUntil.md)
-- [context.waitForEvent](https://upstash.com/docs/workflow/steps/waitForEvent.md)
-- [context.waitForWebhook](https://upstash.com/docs/workflow/steps/waitForWebhook.md)
-- [General](https://upstash.com/docs/workflow/troubleshooting/general.md)
-- [Vercel](https://upstash.com/docs/workflow/troubleshooting/vercel.md)
+- [Overview](https://upstash.com/docs/workflow/steps.md): Explore the Upstash Workflow context object that exposes step APIs plus run properties like the request payload, headers, and metadata.
+- [context.api](https://upstash.com/docs/workflow/steps/api.md): Make type-safe third-party API requests to OpenAI, Anthropic, and Resend as workflow steps with the context.api namespace.
+- [context.call](https://upstash.com/docs/workflow/steps/call.md): Perform HTTP requests as a workflow step with context.call, supporting response times up to 12 hours without consuming compute.
+- [context.cancel](https://upstash.com/docs/workflow/steps/cancel.md): Explicitly cancel the current workflow run from within your code using the Upstash Workflow context.cancel method.
+- [context.createWebhook](https://upstash.com/docs/workflow/steps/createWebhook.md): Create a unique webhook URL that external services can call to resume workflow execution with the context.createWebhook method.
+- [context.invoke](https://upstash.com/docs/workflow/steps/invoke.md): Trigger another workflow and pause until it finishes with context.invoke, resuming when it succeeds, fails, or is canceled.
+- [context.notify](https://upstash.com/docs/workflow/steps/notify.md): Notify workflows waiting at a waitForEvent step and pass an optional payload using the Upstash Workflow context.notify method.
+- [context.run](https://upstash.com/docs/workflow/steps/run.md): Execute custom business logic as a workflow step with context.run, running steps sequentially or in parallel in Upstash Workflow.
+- [context.sleep](https://upstash.com/docs/workflow/steps/sleep.md): Pause workflow execution for a set duration with context.sleep, consuming no compute resources while the workflow sleeps.
+- [context.sleepUntil](https://upstash.com/docs/workflow/steps/sleepUntil.md): Pause workflow execution until a specific timestamp with context.sleepUntil, consuming no compute resources while sleeping.
+- [context.waitForEvent](https://upstash.com/docs/workflow/steps/waitForEvent.md): Pause workflow execution until an event occurs or a timeout is reached with the Upstash Workflow context.waitForEvent step.
+- [context.waitForWebhook](https://upstash.com/docs/workflow/steps/waitForWebhook.md): Pause workflow execution until a created webhook is called or a timeout is reached with the context.waitForWebhook step.
+- [General](https://upstash.com/docs/workflow/troubleshooting/general.md): Troubleshoot common Upstash Workflow issues, including the WorkflowAbort error from running steps inside try/catch blocks.
+- [Vercel](https://upstash.com/docs/workflow/troubleshooting/vercel.md): Troubleshoot Upstash Workflow on Vercel, including bypassing preview deployment protection with a bypass secret.
 
 ## OpenAPI Specs
 

--- a/qstash/features/at-least-once.mdx
+++ b/qstash/features/at-least-once.mdx
@@ -1,5 +1,6 @@
 ---
 title: "At-Least-Once Delivery"
+description: QStash guarantees at-least-once message delivery and shows how to handle rare duplicates using idempotency keys and idempotent handlers.
 ---
 
 QStash provides at-least-once delivery for all messages. This guarantees that no messages will be lost, even in the face of server crashes, or other unexpected problems.

--- a/qstash/features/background-jobs.mdx
+++ b/qstash/features/background-jobs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Background Jobs"
+description: Run long-running background jobs from serverless apps with QStash by offloading heavy tasks to a public API endpoint, shown with Next.js.
 ---
 
 ## When do you need background jobs

--- a/qstash/features/batch.mdx
+++ b/qstash/features/batch.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Batching"
+description: Send multiple QStash messages in a single request with the batch endpoint, targeting destinations, URL Groups, and queues with custom headers and bodies.
 ---
 
 [Publishing](/qstash/howto/publishing) is great for sending one message

--- a/qstash/features/callbacks.mdx
+++ b/qstash/features/callbacks.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Callbacks"
+description: Use QStash callbacks and failure callbacks to handle responses from long-running endpoints without waiting, bypassing serverless execution time limits.
 ---
 
 All serverless function providers have a maximum execution time for each

--- a/qstash/features/deduplication.mdx
+++ b/qstash/features/deduplication.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deduplication"
+description: Prevent duplicate QStash messages using a deduplication ID or content-based deduplication so retries enqueue each message only once.
 ---
 
 Messages can be deduplicated to prevent duplicate messages from being sent. When

--- a/qstash/features/delay.mdx
+++ b/qstash/features/delay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delay"
+description: Delay QStash message delivery with relative Upstash-Delay or absolute Upstash-Not-Before headers, plus how delays apply to scheduled messages.
 ---
 
 When publishing a message, you can delay it for a certain amount of time before

--- a/qstash/features/dlq.mdx
+++ b/qstash/features/dlq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Dead Letter Queues"
+description: QStash moves messages that exhaust their retries to a dead letter queue, where you can manually retry or delete them from the console.
 ---
 
 At times, your API may fail to process a request. This could be due to a bug in your code, a temporary issue with a third-party service, or even network issues.

--- a/qstash/features/flowcontrol.mdx
+++ b/qstash/features/flowcontrol.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Flow Control"
+description: Limit QStash message delivery to your endpoint with rate and parallelism controls per flow-control key, plus pause, pin, and monitor APIs.
 ---
 
 Flow Control enables you to limit the number of messages sent to your endpoint via delaying the delivery. 

--- a/qstash/features/queues.mdx
+++ b/qstash/features/queues.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Queues"
+description: Use QStash queues for ordered FIFO message delivery and controlled parallelism, enqueuing messages to your endpoints reliably.
 ---
 
 The queue concept in QStash allows ordered delivery (FIFO).

--- a/qstash/features/retry.mdx
+++ b/qstash/features/retry.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Retry"
+description: QStash automatically retries failed message deliveries with exponential backoff, plus custom retry delays, Retry-After headers, and non-retryable errors.
 ---
 
 <Warning title="Max HTTP Response Duration">

--- a/qstash/features/schedules.mdx
+++ b/qstash/features/schedules.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedules"
+description: Schedule recurring QStash messages using cron expressions with timezone support, delivering to endpoints, URL Groups, or queues.
 ---
 
 In addition to sending a message once, you can create a schedule, and we will

--- a/qstash/features/security.mdx
+++ b/qstash/features/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Security"
+description: Authorize QStash API requests with your token and verify incoming messages using the Upstash-Signature JWT header to secure your endpoints.
 ---
 
 ### Request Authorization

--- a/qstash/features/url-groups.mdx
+++ b/qstash/features/url-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: "URL Groups"
+description: URL Groups let QStash fan out a single published message to multiple subscribed endpoints, decoupling producers from consumers.
 ---
 
 Sending messages to a single endpoint and not having to worry about retries is

--- a/qstash/howto/debug-logs.mdx
+++ b/qstash/howto/debug-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Debug Logs"
+description: Understand the QStash message lifecycle and states like ACTIVE, DELIVERED, RETRY, and FAILED to debug delivery using the console Logs tab.
 ---
 
 To debug the logs, first you need to understand the different states a message can

--- a/qstash/howto/delete-schedule.mdx
+++ b/qstash/howto/delete-schedule.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete Schedules"
+description: Delete a QStash schedule by ID with the schedules API using cURL, TypeScript, or Python, and list schedules to find the ID.
 ---
 
 

--- a/qstash/howto/handling-failures.mdx
+++ b/qstash/howto/handling-failures.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Handling Failures"
+description: Handle failed QStash message deliveries using failure callbacks and the dead letter queue to log, alert, and retry undelivered messages.
 ---
 
 Sometimes, endpoints fail due to various reasons such as network issues or server issues.

--- a/qstash/howto/local-development.mdx
+++ b/qstash/howto/local-development.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Local Development"
+description: Run the QStash development server locally with the CLI, npx, or Docker to test messages, schedules, and workflows without deploying a public API.
 ---
 
 QStash requires a publicly available API to send messages to.

--- a/qstash/howto/local-tunnel.mdx
+++ b/qstash/howto/local-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Local Tunnel"
+description: Expose your local API to QStash during development using a public tunnel with localtunnel.me or ngrok so messages reach your machine.
 ---
 
 QStash requires a publicly available API to send messages to. 

--- a/qstash/howto/multi-region.mdx
+++ b/qstash/howto/multi-region.mdx
@@ -1,5 +1,6 @@
 ---
 title: Select a Region
+description: Choose between QStash EU and US regions, migrate resources between them, and configure the SDK for single-region or multi-region migration mode.
 ---
 
 ## Overview

--- a/qstash/howto/publishing.mdx
+++ b/qstash/howto/publishing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Publish Messages"
+description: Publish messages to any HTTP endpoint with QStash, forward custom headers, and fan out to URL Groups using cURL, TypeScript, or Python.
 ---
 
 

--- a/qstash/howto/readonly-token.mdx
+++ b/qstash/howto/readonly-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Read-only Token"
+description: Share a QStash read-only token with teammates or AI agents to view logs, messages, and schedules without allowing publishing or resource changes.
 ---
 
 You can use a read-only version of your token to safely share it with your team or AI agents.

--- a/qstash/howto/reset-token.mdx
+++ b/qstash/howto/reset-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reset Token"
+description: Reset your QStash token from the console to invalidate the current one, then update it across your applications to keep publishing messages.
 ---
 
 Your token is used to interact with the QStash API. You need it to publish

--- a/qstash/howto/roll-signing-keys.mdx
+++ b/qstash/howto/roll-signing-keys.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Roll Your Signing Keys"
+description: Roll your QStash signing keys safely using the current and next key pair to rotate secrets with minimal downtime for request verification.
 ---
 
 Because your API needs to be publicly accessible from the internet, you should

--- a/qstash/howto/signature.mdx
+++ b/qstash/howto/signature.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Verify Signatures"
+description: Verify the Upstash-Signature JWT on incoming QStash requests using the Receiver in the TypeScript, Python, and Go SDKs or with manual verification.
 ---
 
 We send a JWT with each request. This JWT is signed by your individual secret

--- a/qstash/howto/url-group-endpoint.mdx
+++ b/qstash/howto/url-group-endpoint.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create URL Groups and Endpoints"
+description: Create QStash URL Groups and add endpoints through the Upstash Console or REST API using cURL, TypeScript, or Python.
 ---
 
 QStash allows you to group multiple APIs together into a single namespace,

--- a/qstash/howto/webhook.mdx
+++ b/qstash/howto/webhook.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Use as Webhook Receiver"
+description: Route webhook calls through QStash as an intermediary to add retries, delays, timeouts, callbacks, and flow control using publish or URL Groups.
 ---
 
 You can configure QStash to receive and process your webhook calls.

--- a/qstash/integrations/anthropic.mdx
+++ b/qstash/integrations/anthropic.mdx
@@ -1,5 +1,6 @@
 ---
 title: LLM with Anthropic
+description: Call Anthropic Claude models through QStash to publish, enqueue, and batch LLM requests with retries, callbacks, and long HTTP timeouts.
 ---
 
 QStash integrates smoothly with Anthropic's API, allowing you to send LLM requests and leverage QStash features like retries, callbacks, and batching. This is especially useful when working in serverless environments where LLM response times vary and traditional timeouts may be limiting. QStash provides an HTTP timeout of up to 2 hours, which is ideal for most LLM cases.

--- a/qstash/integrations/datadog.mdx
+++ b/qstash/integrations/datadog.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Datadog - Upstash QStash Integration"
+description: Connect Datadog with Upstash QStash to monitor message delivery, retries, DLQ, and schedule metrics on Datadog dashboards.
 sidebarTitle: "Datadog"
 ---
 

--- a/qstash/integrations/llm.mdx
+++ b/qstash/integrations/llm.mdx
@@ -1,5 +1,6 @@
 ---
 title: "LLM - OpenAI"
+description: Call OpenAI and OpenAI-compatible LLM APIs through QStash to publish, enqueue, and batch chat completions with retries, callbacks, and 2-hour timeouts.
 sidebarTitle: "LLM with OpenAI"
 ---
 

--- a/qstash/integrations/n8n.mdx
+++ b/qstash/integrations/n8n.mdx
@@ -1,5 +1,6 @@
 ---
 title: "n8n with QStash"
+description: Call QStash from an n8n workflow by importing a QStash request as a cURL snippet into an HTTP Request node to publish, enqueue, or schedule.
 sidebarTitle: "n8n"
 ---
 

--- a/qstash/integrations/prometheus.mdx
+++ b/qstash/integrations/prometheus.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prometheus - Upstash QStash Integration"
+description: Scrape Upstash QStash metrics into Prometheus and visualize message throughput, retries, DLQ, and schedules in a Grafana dashboard.
 sidebarTitle: "Prometheus"
 ---
 

--- a/qstash/integrations/resend.mdx
+++ b/qstash/integrations/resend.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Email - Resend"
+description: Send transactional and batch emails through QStash using the Resend provider in the qstash-js SDK with publishJSON.
 sidebarTitle: "Emails with Resend"
 ---
 

--- a/qstash/misc/license.mdx
+++ b/qstash/misc/license.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Development Server License Agreement"
+description: License terms for the QStash development server, restricting its use to local development, testing, and CI rather than production or commercial deployment.
 ---
 
 ## 1. Purpose and Scope

--- a/qstash/overall/apiexamples.mdx
+++ b/qstash/overall/apiexamples.mdx
@@ -1,5 +1,6 @@
 ---
 title: "API Examples"
+description: Get started with QStash through cURL, TypeScript, and Python examples for publishing messages, scheduling, and using URL Groups.
 ---
 
 ### Use QStash via:

--- a/qstash/overall/changelog.mdx
+++ b/qstash/overall/changelog.mdx
@@ -1,5 +1,6 @@
 ---
 title: Changelog
+description: Track new QStash features and updates across the server, console, and TypeScript and Python SDKs over time.
 ---
 
 <Note>

--- a/qstash/overall/compare.mdx
+++ b/qstash/overall/compare.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compare
+description: Compare QStash with alternatives like BullMQ, Zeplo, and Quirrel to see how its serverless message queue and scheduling differ.
 ---
 
 In this section, we will compare QStash with alternative solutions.

--- a/qstash/overall/enterprise.mdx
+++ b/qstash/overall/enterprise.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prod Pack & Enterprise
+description: Upgrade Upstash QStash to Prod Pack or Enterprise for 99.99% uptime SLA, SOC-2 compliance, encryption at rest, and Prometheus and Datadog monitoring.
 ---
 
 Upstash has Prod Pack and Enterprise plans for customers with critical production workloads. Prod Pack and Enterprise plans include additional monitoring and security features in addition to higher capacity limits and more powerful resources.

--- a/qstash/overall/getstarted.mdx
+++ b/qstash/overall/getstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+description: Get started with Upstash QStash, publish your first message to an HTTP endpoint, and explore background jobs, schedules, and delivery guarantees.
 ---
 
 QStash is a **serverless messaging and scheduling solution**. It fits easily into your existing workflow and allows you to build reliable systems without managing infrastructure.

--- a/qstash/overall/usecases.mdx
+++ b/qstash/overall/usecases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Use Cases
+description: Explore common Upstash QStash use cases like scheduled Next.js jobs, resetting billing cycles, fanning out alerts, and delayed signup messages.
 ---
 
 TODO: andreas: rework and reenable this page after we have 2 use cases ready

--- a/qstash/quickstarts/aws-lambda/nodejs.mdx
+++ b/qstash/quickstarts/aws-lambda/nodejs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AWS Lambda (Node)"
+description: Receive and verify QStash webhooks in a Node.js AWS Lambda function, deploying with the AWS CDK or manually using signature verification.
 ---
 
 ## Setting up a Lambda

--- a/qstash/quickstarts/aws-lambda/python.mdx
+++ b/qstash/quickstarts/aws-lambda/python.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AWS Lambda (Python)"
+description: Receive and verify QStash webhooks in a Python AWS Lambda function using PyJWT, then deploy and test the function on AWS.
 ---
 
 [Source Code](https://github.com/upstash/qstash-examples/tree/main/aws-lambda/python-example)

--- a/qstash/quickstarts/cloudflare-workers.mdx
+++ b/qstash/quickstarts/cloudflare-workers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cloudflare Workers"
+description: Receive and verify QStash webhooks in a Cloudflare Worker using the Upstash QStash SDK, with Worker-level and account-level secret setup.
 ---
 
 This is a step by step guide on how to receive webhooks from QStash in your

--- a/qstash/quickstarts/deno-deploy.mdx
+++ b/qstash/quickstarts/deno-deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deno Deploy"
+description: Receive and verify QStash webhooks in a Deno Deploy project using the Upstash QStash Receiver and your signing keys.
 ---
 
 [Source Code](https://github.com/upstash/qstash-examples/tree/main/deno-deploy)

--- a/qstash/quickstarts/fly-io/go.mdx
+++ b/qstash/quickstarts/fly-io/go.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Golang"
+description: Receive and verify QStash webhooks in a Go application deployed on Fly.io, using JWT signature verification with golang-jwt.
 ---
 
 [Source Code](https://github.com/upstash/qstash-examples/tree/main/fly.io/go)

--- a/qstash/quickstarts/python-vercel.mdx
+++ b/qstash/quickstarts/python-vercel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Python on Vercel"
+description: Use Upstash QStash to schedule a daily Python job on Vercel that cleans up your Redis database on a cron schedule.
 ---
 
 ## Introduction

--- a/qstash/quickstarts/vercel-nextjs.mdx
+++ b/qstash/quickstarts/vercel-nextjs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Next.js
+description: Use Upstash QStash in Next.js to run reliable background jobs with automatic retries, publishing messages and verifying signatures on Vercel.
 ---
 
 QStash is a robust message queue and task-scheduling service that integrates perfectly with Next.js. This guide will show you how to use QStash in your Next.js projects, including a quickstart and a complete example.

--- a/qstash/recipes/periodic-data-updates.mdx
+++ b/qstash/recipes/periodic-data-updates.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Periodic Data Updates"
+description: Use QStash as a cron trigger for a Next.js API route that periodically fetches Bitcoin prices from an API and stores them in Redis.
 ---
 
 <Note>

--- a/qstash/sdks/py/examples/dlq.mdx
+++ b/qstash/sdks/py/examples/dlq.mdx
@@ -1,5 +1,6 @@
 ---
 title: DLQ
+description: Manage the QStash dead letter queue with the Python SDK by listing messages with cursor pagination, retrieving, and deleting DLQ messages.
 ---
 
 <Info>

--- a/qstash/sdks/py/examples/events.mdx
+++ b/qstash/sdks/py/examples/events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Events
+description: List QStash events with cursor-based pagination using the Python SDK to track your published messages.
 ---
 
 <Info>

--- a/qstash/sdks/py/examples/flow-control.mdx
+++ b/qstash/sdks/py/examples/flow-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: Flow Control
+description: Manage QStash flow control keys with the Python SDK to inspect rate and parallelism, pause, resume, pin, unpin, and reset limits.
 ---
 
 #### Get a single flow control key

--- a/qstash/sdks/py/examples/keys.mdx
+++ b/qstash/sdks/py/examples/keys.mdx
@@ -1,5 +1,6 @@
 ---
 title: Keys
+description: Retrieve and rotate your QStash signing keys with the Python SDK to verify incoming message signatures.
 ---
 
 <Info>

--- a/qstash/sdks/py/examples/messages.mdx
+++ b/qstash/sdks/py/examples/messages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Messages
+description: Retrieve, cancel, and bulk cancel in-flight QStash messages with the Python SDK.
 ---
 
 <Info>

--- a/qstash/sdks/py/examples/overview.mdx
+++ b/qstash/sdks/py/examples/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Example usages of each method in the QStash Python SDK for publishing, scheduling, and managing messages.
 ---
 
 These are example usages of each method in the QStash SDK. You can also reference the

--- a/qstash/sdks/py/examples/publish.mdx
+++ b/qstash/sdks/py/examples/publish.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publish
+description: Publish QStash messages with the Python SDK, adding delays, headers, callbacks, retries, deduplication, timeouts, and URL groups.
 ---
 
 <Info>

--- a/qstash/sdks/py/examples/queues.mdx
+++ b/qstash/sdks/py/examples/queues.mdx
@@ -1,5 +1,6 @@
 ---
 title: Queues
+description: Create, configure, pause, resume, and delete QStash queues with parallelism using the Python SDK.
 ---
 
 #### Create a queue with parallelism

--- a/qstash/sdks/py/examples/receiver.mdx
+++ b/qstash/sdks/py/examples/receiver.mdx
@@ -1,5 +1,6 @@
 ---
 title: Receiver
+description: Verify QStash message signatures in your request handler using the Receiver helper in the Python SDK.
 ---
 
 When receiving a message from QStash, you should [verify the signature](/qstash/howto/signature).

--- a/qstash/sdks/py/examples/schedules.mdx
+++ b/qstash/sdks/py/examples/schedules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Schedules
+description: Create, list, get, pause, resume, and delete QStash cron schedules with the Python SDK, including callbacks and timeouts.
 ---
 
 <Info>

--- a/qstash/sdks/py/examples/url-groups.mdx
+++ b/qstash/sdks/py/examples/url-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: URL Groups
+description: Create, list, and manage QStash URL groups and their endpoints for fan-out delivery using the Python SDK.
 ---
 
 <Info>

--- a/qstash/sdks/py/gettingstarted.mdx
+++ b/qstash/sdks/py/gettingstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install the QStash Python SDK and start publishing messages with synchronous and asynchronous clients and configurable retries.
 ---
 
 ## Install

--- a/qstash/sdks/py/overview.mdx
+++ b/qstash/sdks/py/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: The QStash Python SDK for publishing, scheduling, and managing messages, URL groups, DLQ, and signature verification.
 ---
 
 `qstash` is an Python SDK for QStash, allowing for easy access to the QStash API.

--- a/qstash/sdks/ts/examples/dlq.mdx
+++ b/qstash/sdks/ts/examples/dlq.mdx
@@ -1,5 +1,6 @@
 ---
 title: DLQ
+description: Manage the QStash dead letter queue with the TypeScript SDK by listing, filtering, deleting, and retrying DLQ messages.
 ---
 
 #### Get all messages with pagination using cursor

--- a/qstash/sdks/ts/examples/flow-control.mdx
+++ b/qstash/sdks/ts/examples/flow-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: Flow Control
+description: Manage QStash flow control keys with the TypeScript SDK to inspect rate and parallelism, pause, resume, pin, unpin, and reset limits.
 ---
 
 #### Get a single flow control key

--- a/qstash/sdks/ts/examples/logs.mdx
+++ b/qstash/sdks/ts/examples/logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logs
+description: Retrieve QStash logs with the TypeScript SDK using cursor pagination, state filters, and message ID lookups.
 ---
 
 #### Get all logs with pagination using cursor

--- a/qstash/sdks/ts/examples/messages.mdx
+++ b/qstash/sdks/ts/examples/messages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Messages
+description: Retrieve, cancel, and bulk cancel in-flight QStash messages with filters using the TypeScript SDK.
 ---
 
 Messages are removed from the database shortly after they're delivered, so you

--- a/qstash/sdks/ts/examples/overview.mdx
+++ b/qstash/sdks/ts/examples/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Example usages of each method in the QStash TypeScript SDK for publishing, scheduling, and managing messages.
 ---
 
 These are example usages of each method in the QStash SDK. You can also reference the

--- a/qstash/sdks/ts/examples/publish.mdx
+++ b/qstash/sdks/ts/examples/publish.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publish
+description: Publish QStash messages with the TypeScript SDK, adding delays, headers, callbacks, retries, deduplication, timeouts, and URL groups.
 ---
 
 #### Publish to a URL with a 3 second delay and headers/body

--- a/qstash/sdks/ts/examples/queues.mdx
+++ b/qstash/sdks/ts/examples/queues.mdx
@@ -1,5 +1,6 @@
 ---
 title: Queues
+description: Create, configure, pause, resume, and delete QStash queues with parallelism using the TypeScript SDK.
 ---
 
 #### Create a queue with parallelism 2

--- a/qstash/sdks/ts/examples/receiver.mdx
+++ b/qstash/sdks/ts/examples/receiver.mdx
@@ -1,5 +1,6 @@
 ---
 title: Receiver
+description: Verify QStash message signatures in your request handler using the Receiver helper in the TypeScript SDK.
 ---
 
 When receiving a message from QStash, you should [verify the signature](/qstash/howto/signature).

--- a/qstash/sdks/ts/examples/schedules.mdx
+++ b/qstash/sdks/ts/examples/schedules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Schedules
+description: Create, list, get, pause, resume, and delete QStash cron schedules with the TypeScript SDK, including callbacks and timeouts.
 ---
 
 #### Create a schedule that runs every 5 minutes

--- a/qstash/sdks/ts/examples/url-groups.mdx
+++ b/qstash/sdks/ts/examples/url-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: URL Groups
+description: Create, list, and manage QStash URL groups and their endpoints for fan-out delivery using the TypeScript SDK.
 ---
 
 #### Create a URL Group and add 2 endpoints

--- a/qstash/sdks/ts/gettingstarted.mdx
+++ b/qstash/sdks/ts/gettingstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install the QStash TypeScript SDK, configure the client and retries, and run a local dev server for testing.
 ---
 
 ## Install

--- a/qstash/sdks/ts/overview.mdx
+++ b/qstash/sdks/ts/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: The QStash TypeScript SDK for publishing, scheduling, and managing messages, URL groups, DLQ, and signature verification.
 ---
 
 `@upstash/qstash` is a Typescript SDK for QStash, allowing for easy access to the QStash API.

--- a/redis/features/auto-upgrade.mdx
+++ b/redis/features/auto-upgrade.mdx
@@ -1,5 +1,6 @@
 ---
 title: Auto Upgrade
+description: Auto Upgrade automatically moves your Upstash Redis database to a higher plan when you hit bandwidth or storage limits, preventing throttling and downtime.
 ---
 
 By default, Upstash will apply usage limits based on your current plan. When you reach these limits, behavior depends on the specific limit type - bandwidth limits will throttle your traffic, while storage limits will reject new write operations. However, Upstash offers an Auto Upgrade feature that automatically upgrades your database to the next higher plan when you reach your usage limits, ensuring uninterrupted service.

--- a/redis/features/backup.mdx
+++ b/redis/features/backup.mdx
@@ -1,5 +1,6 @@
 ---
 title: Backup/Restore
+description: Create immediate or scheduled daily backups of your Upstash Redis database and restore data to any database in your account or team.
 ---
 
 You can create backups of your Redis database and restore them when needed. Backups allow you to preserve your data and recover it to any database in your account or team.

--- a/redis/features/consistency.mdx
+++ b/redis/features/consistency.mdx
@@ -1,5 +1,6 @@
 ---
 title: Consistency
+description: How Upstash Redis uses leader-based replication to provide eventual and causal consistency guarantees for reads and writes.
 ---
 
 Upstash utilizes a leader-based replication mechanism. Under this mechanism,

--- a/redis/features/credential-protection.mdx
+++ b/redis/features/credential-protection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Credential Protection
+description: Credential Protection keeps Upstash Redis database credentials out of Upstash infrastructure, exposing them only once at generation for stronger security.
 ---
 
 Enabling Credential Protection ensures your database credentials are never stored within Upstash infrastructure. This enhances security by making credentials accessible only once—at the moment they are generated.

--- a/redis/features/eviction.mdx
+++ b/redis/features/eviction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Eviction
+description: Enable eviction on Upstash Redis to automatically remove older data when the maximum size limit is reached, ideal for caching workloads.
 ---
 
 By default eviction is disabled, and Upstash Redis will reject write operations once the maximum data size

--- a/redis/features/globaldatabase.mdx
+++ b/redis/features/globaldatabase.mdx
@@ -1,5 +1,6 @@
 ---
 title: Global Database
+description: Upstash Redis Global Database replicates data across multiple regions with a primary and read regions to deliver low read latency worldwide.
 ---
 
 <Snippet

--- a/redis/features/replication.mdx
+++ b/redis/features/replication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Replication
+description: How Upstash Redis replication uses primary and read replicas to deliver high availability, better scalability, and multi-zone resilience.
 ---
 
 Replication is enabled for all paid Upstash databases. The data is replicated to

--- a/redis/features/restapi.mdx
+++ b/redis/features/restapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: REST API
+description: Access Upstash Redis over HTTP with the REST API, including commands, pipelining, transactions, pub/sub, auth tokens, and response formats.
 ---
 
 REST API enables you to access your Upstash database using REST.

--- a/redis/features/security.mdx
+++ b/redis/features/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Security
+description: Secure your Upstash Redis database with TLS, Redis ACL, encryption at rest, IP allowlisting, VPC peering, and AWS Private Link.
 ---
 
 Upstash has a set of features to help you secure your data. We will list them

--- a/redis/help/compliance.mdx
+++ b/redis/help/compliance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compliance
+description: Upstash Redis compliance details covering SOC 2, GDPR, HIPAA, and PCI, plus backups, encryption, and legal and security documents.
 ---
 
 ## Upstash Legal & Security Documents

--- a/redis/help/faq.mdx
+++ b/redis/help/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+description: Frequently asked questions about Upstash Redis covering serverless pricing, supported regions and clients, persistence, limits, and data safety.
 ---
 
 ## What is Upstash Redis?

--- a/redis/help/integration.mdx
+++ b/redis/help/integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integration with Third Parties & Partnerships
+description: Integrate Upstash into your platform with OAuth 2.0 so users can create and manage Redis, Vector, and QStash databases without leaving your app.
 ---
 
 <Frame>

--- a/redis/help/legal.mdx
+++ b/redis/help/legal.mdx
@@ -1,5 +1,6 @@
 ---
 title: Legal
+description: Upstash legal documents including the Terms of Service, Privacy Policy, and list of subcontractors.
 ---
 
 ## Upstash Legal Documents

--- a/redis/help/managing-healthcare-data.mdx
+++ b/redis/help/managing-healthcare-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing Healthcare Data
+description: Store and process Protected Health Information (PHI) on Upstash Redis with BAAs, HIPAA databases, encryption, MFA, and access controls.
 ---
 
 You can use Upstash Redis to store and process Protected Health Information (PHI). You are responsible for the following:

--- a/redis/help/production-checklist.mdx
+++ b/redis/help/production-checklist.mdx
@@ -1,5 +1,6 @@
 ---
 title: Production Checklist
+description: Essential checklist to secure and optimize your Upstash Redis database for production, covering Prod Pack, backups, ACL, IP allowlist, and monitoring.
 ---
 
 This checklist provides essential recommendations for securing and optimizing your Upstash databases for production workloads.

--- a/redis/help/shared-responsibility-model.mdx
+++ b/redis/help/shared-responsibility-model.mdx
@@ -1,5 +1,6 @@
 ---
 title: Shared Responsibility Model
+description: Understand the security and operational responsibilities split between Upstash and customers when running Upstash Redis in production.
 ---
 
 The Shared Responsibility Model defines the security and operational responsibilities between Upstash and our customers when using Upstash Redis. This model ensures clarity in who is responsible for what aspects of security, compliance, and operations.

--- a/redis/help/support.mdx
+++ b/redis/help/support.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Support & Contact Us"
+description: Get help with Upstash Redis through the Discord community, email support, and professional support from the Upstash team.
 ---
 
 ## Community

--- a/redis/help/uptime.mdx
+++ b/redis/help/uptime.mdx
@@ -1,5 +1,6 @@
 ---
 title: Uptime Monitor
+description: Track Upstash Redis uptime and regional latencies using the Upstash status page and latency monitoring page.
 ---
 
 ## Status Page

--- a/redis/howto/connect-client.mdx
+++ b/redis/howto/connect-client.mdx
@@ -1,5 +1,6 @@
 ---
 title: Connect Your Client
+description: Connect to Upstash Redis from any language with code examples for @upstash/redis, ioredis, redis-py, Jedis, phpredis, and redigo.
 ---
 
 Upstash works with Redis® API, that means you can use any Redis client with

--- a/redis/howto/connect-with-upstash-redis.mdx
+++ b/redis/howto/connect-with-upstash-redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Connect with @upstash/redis
+description: Connect to Upstash Redis using the HTTP-based @upstash/redis client, ideal for serverless functions, Cloudflare Workers, and edge environments.
 ---
 
 [@upstash/redis](https://github.com/upstash/redis-js)

--- a/redis/howto/datadog.mdx
+++ b/redis/howto/datadog.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Datadog - Upstash Redis Integration"
+description: Connect your Datadog account to Upstash Redis to monitor Pro and Enterprise database metrics in your Datadog dashboards.
 sidebarTitle: "Datadog"
 ---
 

--- a/redis/howto/emqxintegration.mdx
+++ b/redis/howto/emqxintegration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "EMQX - Upstash Redis Integration"
+description: Stream MQTT data from EMQX Cloud into Upstash Redis using data integration rules to store IoT temperature and humidity messages.
 sidebarTitle: "EMQX"
 ---
 

--- a/redis/howto/getstartedawslambda.mdx
+++ b/redis/howto/getstartedawslambda.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Started with AWS Lambda
+description: Connect an AWS Lambda function to Upstash Redis with a step-by-step Node.js tutorial, plus tips on serverless connection handling.
 ---
 
 You can connect to Upstash database from your Lambda functions using your

--- a/redis/howto/getstartedcloudflareworkers.mdx
+++ b/redis/howto/getstartedcloudflareworkers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Started with Cloudflare Workers
+description: Build a Cloudflare Workers edge function that reads from Upstash Redis over REST to serve location-based greetings using @upstash/redis.
 ---
 
 This tutorial showcases using Redis with REST API in Cloudflare Workers. We will

--- a/redis/howto/getstartedgooglecloudfunctions.mdx
+++ b/redis/howto/getstartedgooglecloudfunctions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Started with Google Cloud Functions
+description: Deploy a Google Cloud Function that connects to Upstash Redis with ioredis to increment and return a page view counter.
 ---
 
 ### Prerequisites:

--- a/redis/howto/importexport.mdx
+++ b/redis/howto/importexport.mdx
@@ -1,5 +1,6 @@
 ---
 title: Import/Export Data
+description: Import data into Upstash Redis from a backup or RDB file, and export your database as an RDB file for backup or migration.
 ---
 
 ## Importing Data

--- a/redis/howto/ioredisnote.mdx
+++ b/redis/howto/ioredisnote.mdx
@@ -1,5 +1,6 @@
 ---
 title: ioredis note
+description: Reusable note reminding you to copy the ioredis connection string from the Node tab in the Upstash Console.
 ---
 
 <Note>

--- a/redis/howto/ipallowlist.mdx
+++ b/redis/howto/ipallowlist.mdx
@@ -1,5 +1,6 @@
 ---
 title: Use IP Allowlist
+description: Restrict access to your Upstash Redis database by allowing connections only from specified IPv4 addresses or CIDR blocks.
 ---
 
 <Info>

--- a/redis/howto/keyspacenotifications.mdx
+++ b/redis/howto/keyspacenotifications.mdx
@@ -1,5 +1,6 @@
 ---
 title: Listen Keyspace Notifications
+description: Enable and listen for Upstash Redis keyspace and keyevent notifications over pubsub channels using the notify-keyspace-events config.
 ---
 
 Upstash allows you to listen for keyspace notifications over pubsub channels to 

--- a/redis/howto/metrics-and-charts.mdx
+++ b/redis/howto/metrics-and-charts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Metrics and Charts
+description: Understand the Upstash Console metrics and charts for Redis, including throughput, latency, data size, connections, keyspace, and hit rates.
 ---
 
 The Upstash Console exposes metrics in two places: the database list, and the detail page of a single database. This page explains what each chart shows.

--- a/redis/howto/migratefromregionaltoglobal.mdx
+++ b/redis/howto/migratefromregionaltoglobal.mdx
@@ -1,5 +1,6 @@
 ---
 title: Migrate Regional to Global Database
+description: Migrate your data from a legacy regional Upstash Redis database to a global database using backup and restore in the Upstash Console.
 ---
 
 This guide will help you migrate your data from a regional Upstash Redis database to a global database.

--- a/redis/howto/monitoryourusage.mdx
+++ b/redis/howto/monitoryourusage.mdx
@@ -1,5 +1,6 @@
 ---
 title: Monitor your usage
+description: Use the Redis MONITOR command with ioredis to watch all requests processed by your Upstash Redis instance in real time.
 ---
 
 We support the Redis `MONITOR` command, a debugging command that allows you to see all requests processed by your Redis instance in real-time.

--- a/redis/howto/readyourwrites.mdx
+++ b/redis/howto/readyourwrites.mdx
@@ -1,5 +1,6 @@
 ---
 title: Read Your Writes
+description: Ensure read-your-writes consistency in Upstash Redis using sync tokens, handled automatically by the TypeScript and Python SDKs or via REST headers.
 ---
 
 The "Read Your Writes" feature in Upstash Redis ensures that write operations are completed before subsequent read operations occur, maintaining data consistency in your application.

--- a/redis/howto/terraformprovider.mdx
+++ b/redis/howto/terraformprovider.mdx
@@ -1,5 +1,6 @@
 ---
 title: Terraform Provider
+description: Use the Upstash Terraform provider to create and manage Redis databases as code and output their connection credentials.
 ---
 
 You can use Upstash terraform provider to create your resources. API key is

--- a/redis/howto/upgrade-database.mdx
+++ b/redis/howto/upgrade-database.mdx
@@ -1,5 +1,6 @@
 ---
 title: Upgrade Your Database
+description: Upgrade your Upstash Redis database from the free tier to the pay-as-you-go plan by adding a payment method to raise usage limits.
 ---
 
 The free tier has limits on monthly commands, data size, and the number of databases per account. See the [pricing page](https://upstash.com/pricing/redis) for the current values.

--- a/redis/howto/vercelintegration.mdx
+++ b/redis/howto/vercelintegration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Vercel - Upstash Redis Integration"
+description: Integrate Upstash Redis, Vector, Search, or QStash with your Vercel project and inject connection credentials as environment variables.
 sidebarTitle: "Vercel"
 ---
 

--- a/redis/integrations/bullmq.mdx
+++ b/redis/integrations/bullmq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "BullMQ with Upstash Redis"
+description: Use BullMQ and Bull with Upstash Redis to run Node.js job queues, with install steps, a connection example, and billing optimization tips.
 sidebarTitle: "BullMQ"
 ---
 

--- a/redis/integrations/celery.mdx
+++ b/redis/integrations/celery.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Celery with Upstash Redis"
+description: Use Celery with Upstash Redis as broker and result backend to build scalable, serverless Python task queues.
 sidebarTitle: "Celery"
 ---
 

--- a/redis/integrations/drizzle.mdx
+++ b/redis/integrations/drizzle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "DrizzleORM with Upstash Redis"
+description: Cache Drizzle ORM queries with Upstash Redis using the upstashCache helper, with per-query and global caching plus automatic invalidation.
 sidebarTitle: "DrizzleORM"
 ---
 

--- a/redis/integrations/n8n.mdx
+++ b/redis/integrations/n8n.mdx
@@ -1,5 +1,6 @@
 ---
 title: "n8n with Upstash Redis"
+description: Connect an n8n Redis node to Upstash Redis to store data in automation workflows, with a step-by-step visit counter example.
 sidebarTitle: "n8n"
 ---
 

--- a/redis/integrations/prometheus.mdx
+++ b/redis/integrations/prometheus.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prometheus - Upstash Redis Integration"
+description: Monitor your Upstash Redis database with Prometheus and Grafana using the monitoring token, data source setup, and federation.
 sidebarTitle: "Prometheus"
 ---
 

--- a/redis/integrations/ratelimit/strapi/configurations.mdx
+++ b/redis/integrations/ratelimit/strapi/configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configure Upstash Ratelimit Strapi Plugin"
+description: Configure the Upstash Ratelimit Strapi plugin with rate limit algorithms, tokens, windows, identifier sources, and per-route strategies.
 sidebarTitle: "Configurations"
 ---
 

--- a/redis/integrations/ratelimit/strapi/getting-started.mdx
+++ b/redis/integrations/ratelimit/strapi/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Upstash Ratelimit Strapi Integration"
+description: Protect your Strapi APIs from abuse with the Upstash Ratelimit plugin, powered by HTTP and Redis based rate limiting.
 sidebarTitle: "Getting Started"
 ---
 

--- a/redis/integrations/replit-templates.mdx
+++ b/redis/integrations/replit-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Replit Templates"
+description: Explore Replit templates showcasing Upstash Redis and Vector for caching, rate limiting, real-time chat, RAG, and vector search.
 ---
 
 ## Overview

--- a/redis/integrations/sidekiq.mdx
+++ b/redis/integrations/sidekiq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sidekiq with Upstash Redis"
+description: Use Sidekiq with Upstash Redis to run Ruby background job queues, with a worker example and billing optimization tips.
 sidebarTitle: "Sidekiq"
 ---
 

--- a/redis/overall/changelog.mdx
+++ b/redis/overall/changelog.mdx
@@ -1,5 +1,6 @@
 ---
 title: Changelog
+description: Upstash Redis changelog tracking new commands, features, regions, and REST API updates over time.
 ---
 
 <Update label="March 2026">

--- a/redis/overall/compare.mdx
+++ b/redis/overall/compare.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compare
+description: Compare Upstash Redis with ElastiCache, MemoryDB, Redis Labs, DynamoDB, and FaunaDB on serverless pricing, latency, and portability.
 ---
 
 In this section, we will compare Upstash with alternative cloud based solutions.

--- a/redis/overall/compatibility.mdx
+++ b/redis/overall/compatibility.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Redis® API Compatibility: supported commands, modules, and protocols"
+description: Upstash Redis API compatibility reference listing supported Redis commands, modules, and protocols across native TCP and REST.
 sidebarTitle: "Compatibility"
 ---
 

--- a/redis/overall/enterprise.mdx
+++ b/redis/overall/enterprise.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prod Pack & Enterprise
+description: Upstash Redis Prod Pack and Enterprise plans add uptime SLA, SOC 2, multi-zone HA, encryption, monitoring, SSO, and custom limits.
 ---
 
 

--- a/redis/overall/usecases.mdx
+++ b/redis/overall/usecases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Use Cases
+description: Common Upstash Redis use cases including caching, rate limiting, queues, pub/sub, leaderboards, full-text search, and AI agent memory.
 ---
 
 The data store behind Upstash is [compatible](/redis/overall/compatibility)

--- a/redis/quickstarts/aws-lambda.mdx
+++ b/redis/quickstarts/aws-lambda.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AWS Lambda"
+description: Connect Upstash Redis to an AWS Lambda function deployed with the AWS CDK in TypeScript.
 ---
 
 <Snippet

--- a/redis/quickstarts/azure-functions.mdx
+++ b/redis/quickstarts/azure-functions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Azure Functions"
+description: Build a serverless Azure Function that reads and writes data using an Upstash Redis database.
 ---
 
 <Snippet

--- a/redis/quickstarts/cloudflareworkers.mdx
+++ b/redis/quickstarts/cloudflareworkers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cloudflare Workers"
+description: Use Upstash Redis from a Cloudflare Workers edge function for low-latency key-value access worldwide.
 ---
 
 <Snippet

--- a/redis/quickstarts/deno-deploy.mdx
+++ b/redis/quickstarts/deno-deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deno Deploy"
+description: Build a page view counter on Deno Deploy backed by an Upstash Redis database.
 ---
 
 <Snippet

--- a/redis/quickstarts/digitalocean.mdx
+++ b/redis/quickstarts/digitalocean.mdx
@@ -1,5 +1,6 @@
 ---
 title: "DigitalOcean"
+description: Connect Upstash Redis to your DigitalOcean apps and migrate off the deprecated DigitalOcean integration.
 ---
 
 <Snippet

--- a/redis/quickstarts/django.mdx
+++ b/redis/quickstarts/django.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Django"
+description: Build a Django web app in Python that increments an Upstash Redis counter on every homepage visit.
 ---
 
 <Snippet

--- a/redis/quickstarts/fastapi.mdx
+++ b/redis/quickstarts/fastapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: "FastAPI"
+description: Build a FastAPI application in Python that stores and retrieves data using Upstash Redis.
 ---
 
 <Snippet

--- a/redis/quickstarts/fastlycompute.mdx
+++ b/redis/quickstarts/fastlycompute.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fastly"
+description: Use Upstash Redis from a Fastly Compute edge application for fast, global key-value storage.
 ---
 
 <Snippet

--- a/redis/quickstarts/flask.mdx
+++ b/redis/quickstarts/flask.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Flask"
+description: Build a Flask web app in Python that increments an Upstash Redis counter on each homepage visit.
 ---
 
 <Snippet

--- a/redis/quickstarts/fly.mdx
+++ b/redis/quickstarts/fly.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fly.io"
+description: Connect Upstash Redis to applications running on the Fly.io platform for global key-value storage.
 ---
 
 <Snippet

--- a/redis/quickstarts/google-cloud-functions.mdx
+++ b/redis/quickstarts/google-cloud-functions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Google Cloud Functions"
+description: Build a serverless Google Cloud Function that reads and writes data using Upstash Redis.
 ---
 
 <Snippet

--- a/redis/quickstarts/ion.mdx
+++ b/redis/quickstarts/ion.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ion"
+description: Provision and use Upstash Redis in an SST Ion app deployed to AWS with TypeScript.
 ---
 
 <Snippet

--- a/redis/quickstarts/ioredisnote.mdx
+++ b/redis/quickstarts/ioredisnote.mdx
@@ -1,5 +1,6 @@
 ---
 title: ioredis note
+description: Connect to Upstash Redis with ioredis using the connection string from the Node tab in the console.
 ---
 
 <Note>

--- a/redis/quickstarts/koyeb.mdx
+++ b/redis/quickstarts/koyeb.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Koyeb"
+description: Connect an Upstash Redis database as a cache to a Node.js application deployed on Koyeb.
 ---
 
 <Snippet

--- a/redis/quickstarts/laravel.mdx
+++ b/redis/quickstarts/laravel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Laravel"
+description: Use Upstash Redis as the cache and data store for a PHP Laravel application.
 ---
 
 <Snippet

--- a/redis/quickstarts/nextjs-app-router.mdx
+++ b/redis/quickstarts/nextjs-app-router.mdx
@@ -1,5 +1,6 @@
 ---
 title: "App Router"
+description: Add Upstash Redis to a Next.js 15 App Router project with the @upstash/redis client.
 ---
 
 <Snippet

--- a/redis/quickstarts/nextjs-pages-router.mdx
+++ b/redis/quickstarts/nextjs-pages-router.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pages Router"
+description: Add Upstash Redis to a Next.js Pages Router project with the @upstash/redis client.
 ---
 
 <Snippet

--- a/redis/quickstarts/python-aws-lambda.mdx
+++ b/redis/quickstarts/python-aws-lambda.mdx
@@ -1,5 +1,6 @@
 ---
 title: " AWS Lambda"
+description: Connect Upstash Redis to a Python AWS Lambda function deployed with the AWS CDK.
 ---
 
 <Snippet

--- a/redis/quickstarts/sst-v2.mdx
+++ b/redis/quickstarts/sst-v2.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SST v2"
+description: Provision and use Upstash Redis in an SST v2 app deployed to AWS with TypeScript.
 ---
 
 <Snippet

--- a/redis/quickstarts/supabase.mdx
+++ b/redis/quickstarts/supabase.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Supabase Functions"
+description: Use Upstash Redis in a Supabase Edge Function to track invocation counts per region with a Redis hash.
 ---
 
 <Snippet

--- a/redis/quickstarts/vercel-functions-app-router.mdx
+++ b/redis/quickstarts/vercel-functions-app-router.mdx
@@ -1,5 +1,6 @@
 ---
 title: "App Router"
+description: Use Upstash Redis in Vercel Functions with a Next.js App Router app and the @upstash/redis client.
 ---
 
 <Snippet

--- a/redis/quickstarts/vercel-functions-pages-router.mdx
+++ b/redis/quickstarts/vercel-functions-pages-router.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pages Router"
+description: Use Upstash Redis in Vercel Serverless Functions with a Next.js Pages Router app.
 ---
 
 <Snippet

--- a/redis/quickstarts/vercel-python-runtime.mdx
+++ b/redis/quickstarts/vercel-python-runtime.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Vercel Python Runtime"
+description: Use Upstash Redis with the Vercel Python runtime in a Django app, adaptable to Flask or FastAPI.
 ---
 
 <Snippet

--- a/redis/sdks/py/commands/auth/echo.mdx
+++ b/redis/sdks/py/commands/auth/echo.mdx
@@ -1,5 +1,6 @@
 ---
 title: ECHO
+description: Echo a message back from the server with the ECHO command in the Upstash Redis Python SDK, useful for debugging your connection.
 ---
 
 Returns a message back to you. Useful for debugging the connection.

--- a/redis/sdks/py/commands/server/flushall.mdx
+++ b/redis/sdks/py/commands/server/flushall.mdx
@@ -1,5 +1,6 @@
 ---
 title: FLUSHALL
+description: Delete all keys across every database with the FLUSHALL command in the Upstash Redis Python SDK, using sync or async execution.
 ---
 
 

--- a/redis/sdks/py/commands/server/flushdb.mdx
+++ b/redis/sdks/py/commands/server/flushdb.mdx
@@ -1,5 +1,6 @@
 ---
 title: FLUSHDB
+description: Delete all keys in the selected database with the FLUSHDB command in the Upstash Redis Python SDK, using sync or async execution.
 ---
 
 

--- a/redis/sdks/py/features.mdx
+++ b/redis/sdks/py/features.mdx
@@ -1,5 +1,6 @@
 ---
 title: Features
+description: Explore upstash-redis Python SDK features including BITFIELD, custom commands, REST encoding, retries, pipelines, transactions, and telemetry.
 ---
 
 ### BITFIELD and BITFIELD_RO

--- a/redis/sdks/py/gettingstarted.mdx
+++ b/redis/sdks/py/gettingstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install the upstash-redis Python SDK and connect a sync or async client to your Upstash Redis database to start running commands.
 ---
 
 <Snippet

--- a/redis/sdks/py/overview.mdx
+++ b/redis/sdks/py/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: upstash-redis is a connectionless, HTTP-based Redis client for Python built for serverless environments like AWS Lambda and Vercel.
 ---
 
 `upstash-redis` is a connectionless, HTTP-based Redis client for Python,

--- a/redis/sdks/ratelimit-py/algorithms.mdx
+++ b/redis/sdks/ratelimit-py/algorithms.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ratelimiting Algorithms
+description: Compare fixed window, sliding window, and token bucket rate limiting algorithms in the Upstash Ratelimit Python SDK.
 ---
 
 ## Fixed Window

--- a/redis/sdks/ratelimit-py/features.mdx
+++ b/redis/sdks/ratelimit-py/features.mdx
@@ -1,5 +1,6 @@
 ---
 title: Features
+description: Use advanced Upstash Ratelimit Python features like block until ready, multiple limits per user tier, and custom token rates.
 ---
 
 ## Block until ready

--- a/redis/sdks/ratelimit-py/gettingstarted.mdx
+++ b/redis/sdks/ratelimit-py/gettingstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install upstash-ratelimit for Python and add Redis-backed rate limiting to your serverless app in a few lines of code.
 ---
 
 ## Install

--- a/redis/sdks/ratelimit-py/overview.mdx
+++ b/redis/sdks/ratelimit-py/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: upstash-ratelimit is a connectionless rate limiting library for Python built for serverless environments like AWS Lambda and Vercel.
 ---
 
 `upstash-ratelimit` is a connectionless rate limiting library for Python,

--- a/redis/sdks/ratelimit-ts/algorithms.mdx
+++ b/redis/sdks/ratelimit-ts/algorithms.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ratelimiting Algorithms
+description: Compare fixed window, sliding window, and token bucket rate limiting algorithms in the Upstash Ratelimit TypeScript SDK.
 ---
 
 We provide different algorithms to use out of the box. Each has pros and cons.

--- a/redis/sdks/ratelimit-ts/costs.mdx
+++ b/redis/sdks/ratelimit-ts/costs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Costs
+description: Understand the Redis command cost of each Upstash Ratelimit algorithm, method, deny list, and analytics to optimize latency and spend.
 ---
 
 This page details the cost of the Ratelimit algorithms in terms of the number of Redis commands. Note that these are calculated for Regional Ratelimits. For [Multi Region Ratelimit](/redis/sdks/ratelimit-ts/features#multi-region), costs will be higher. Additionally, if a Global Upstash Redis is used as the database, number of commands should be calculated as `(1+readRegionCount) * writeCommandCount + readCommandCount` and plus 1 if analytics is enabled.

--- a/redis/sdks/ratelimit-ts/features.mdx
+++ b/redis/sdks/ratelimit-ts/features.mdx
@@ -1,5 +1,6 @@
 ---
 title: Features
+description: Configure Upstash Ratelimit features like caching, timeouts, analytics, multi-region, multiple limits, custom rates, and dynamic limits.
 ---
 
 ## Caching

--- a/redis/sdks/ratelimit-ts/gettingstarted.mdx
+++ b/redis/sdks/ratelimit-ts/gettingstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install @upstash/ratelimit and protect your API endpoints with Upstash Redis-backed rate limiting in TypeScript in a few steps.
 ---
 
 ## Create your Redis instance

--- a/redis/sdks/ratelimit-ts/integrations/strapi/configurations.mdx
+++ b/redis/sdks/ratelimit-ts/integrations/strapi/configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configure Upstash Ratelimit Strapi Plugin"
+description: Configure the Upstash Ratelimit Strapi plugin with per-route algorithms, rates, identifiers, and analytics for your Strapi API.
 sidebarTitle: "Configurations"
 ---
 

--- a/redis/sdks/ratelimit-ts/integrations/strapi/getting-started.mdx
+++ b/redis/sdks/ratelimit-ts/integrations/strapi/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Upstash Ratelimit Strapi Integration"
+description: Install and configure the Upstash Ratelimit Strapi plugin to protect your Strapi CMS APIs from abuse with Redis-backed rate limiting.
 sidebarTitle: "Getting Started"
 ---
 

--- a/redis/sdks/ratelimit-ts/methods.mdx
+++ b/redis/sdks/ratelimit-ts/methods.mdx
@@ -1,5 +1,6 @@
 ---
 title: Methods
+description: Reference for Upstash Ratelimit methods including limit, blockUntilReady, resetUsedTokens, getRemaining, and dynamic limit controls.
 ---
 
 This page contains information on what methods are available in Ratelimit and how they can be used. For information on the

--- a/redis/sdks/ratelimit-ts/overview.mdx
+++ b/redis/sdks/ratelimit-ts/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: "@upstash/ratelimit is a connectionless, HTTP-based rate limiting library for serverless, edge, and Cloudflare Workers environments."
 ---
 
 # Upstash Rate Limit

--- a/redis/sdks/ratelimit-ts/traffic-protection.mdx
+++ b/redis/sdks/ratelimit-ts/traffic-protection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Traffic Protection
+description: Block malicious traffic with Upstash Ratelimit deny lists and the auto IP deny list, filtering by IP, country, user agent, or identifier.
 ---
 
 ### Deny List

--- a/redis/sdks/ts/advanced.mdx
+++ b/redis/sdks/ts/advanced.mdx
@@ -1,5 +1,6 @@
 ---
 title: Advanced
+description: Fine-tune the @upstash/redis TypeScript SDK with serialization, keep-alive connections, request timeouts, and telemetry options.
 ---
 
 ## Disable automatic serialization

--- a/redis/sdks/ts/commands/auth/echo.mdx
+++ b/redis/sdks/ts/commands/auth/echo.mdx
@@ -1,5 +1,6 @@
 ---
 title: ECHO
+description: Echo a message back from the server with the ECHO command in the Upstash Redis TypeScript SDK, useful for debugging your connection.
 ---
 
 Returns a message back to you. Useful for debugging the connection.

--- a/redis/sdks/ts/commands/server/flushall.mdx
+++ b/redis/sdks/ts/commands/server/flushall.mdx
@@ -1,5 +1,6 @@
 ---
 title: FLUSHALL
+description: Delete all keys across every database with the FLUSHALL command in the Upstash Redis TypeScript SDK, using sync or async execution.
 ---
 
 

--- a/redis/sdks/ts/commands/server/flushdb.mdx
+++ b/redis/sdks/ts/commands/server/flushdb.mdx
@@ -1,5 +1,6 @@
 ---
 title: FLUSHDB
+description: Delete all keys in the selected database with the FLUSHDB command in the Upstash Redis TypeScript SDK, using sync or async execution.
 ---
 
 

--- a/redis/sdks/ts/commands/string.mdx
+++ b/redis/sdks/ts/commands/string.mdx
@@ -1,5 +1,6 @@
 ---
 title: String Commands
+description: Work with Redis string commands like MGET, MSET, SET, and SETEX in the Upstash Redis TypeScript SDK.
 ---
 
 

--- a/redis/sdks/ts/deployment.mdx
+++ b/redis/sdks/ts/deployment.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deployment
+description: Deploy @upstash/redis on Node.js, Cloudflare Workers, Fastly Compute@Edge, and Deno with the correct imports and environment setup.
 ---
 
 We support various platforms, such as nodejs, cloudflare and fastly. Platforms

--- a/redis/sdks/ts/developing.mdx
+++ b/redis/sdks/ts/developing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Developing or Testing
+description: Develop and test @upstash/redis locally with Serverless Redis HTTP (SRH), a Redis HTTP proxy for CI, Docker, and Kubernetes.
 ---
 
 When developing or testing your application, you might not want or can not use

--- a/redis/sdks/ts/getstarted.mdx
+++ b/redis/sdks/ts/getstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Started
+description: Install the @upstash/redis TypeScript SDK and run your first commands on strings, sets, lists, and hashes against Upstash Redis.
 ---
 
 <Snippet

--- a/redis/sdks/ts/overview.mdx
+++ b/redis/sdks/ts/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: "@upstash/redis is a connectionless, HTTP/REST-based Redis client for serverless, edge, and Cloudflare Workers environments."
 ---
 
 [@upstash/redis](https://github.com/upstash/redis-js)

--- a/redis/sdks/ts/pipelining/auto-pipeline.mdx
+++ b/redis/sdks/ts/pipelining/auto-pipeline.mdx
@@ -1,5 +1,6 @@
 ---
 title: Auto-Pipelining
+description: Batch Redis commands automatically with auto-pipelining in the @upstash/redis TypeScript SDK to reduce HTTP requests and latency.
 ---
 
 ### Auto Pipelining

--- a/redis/sdks/ts/pipelining/pipeline-transaction.mdx
+++ b/redis/sdks/ts/pipelining/pipeline-transaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Pipeline & Transaction
+description: Send multiple Redis commands in one request using pipelines and atomic transactions with the @upstash/redis TypeScript SDK.
 ---
 
 ### Pipeline

--- a/redis/sdks/ts/retries.mdx
+++ b/redis/sdks/ts/retries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Retries
+description: Configure automatic retries and custom backoff for network errors in the @upstash/redis TypeScript SDK constructor.
 ---
 
 By default `@upstash/redis` will retry sending you request when network errors

--- a/redis/sdks/ts/troubleshooting.mdx
+++ b/redis/sdks/ts/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Fix common @upstash/redis issues like missing fetch, base64-hashed responses, and large numbers returned as strings.
 ---
 
 ## ReferenceError: fetch is not defined

--- a/redis/search/aggregation-operators/bucket-aggregations/date-histogram.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/date-histogram.mdx
@@ -1,5 +1,6 @@
 ---
 title: $dateHistogram
+description: Group DATE fields into fixed time buckets with the $dateHistogram aggregation for time-series analytics in Upstash Redis Search.
 ---
 
 `$dateHistogram` groups date values into fixed time buckets.

--- a/redis/search/aggregation-operators/bucket-aggregations/facet.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/facet.mdx
@@ -1,5 +1,6 @@
 ---
 title: $facet
+description: Build hierarchical bucket trees from FACET field paths with the $facet aggregation for drill-down category navigation in Upstash Redis Search.
 ---
 
 `$facet` builds a hierarchical bucket tree from FACET field paths.

--- a/redis/search/aggregation-operators/bucket-aggregations/histogram.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/histogram.mdx
@@ -1,5 +1,6 @@
 ---
 title: $histogram
+description: Group numeric values into fixed-width interval buckets with the $histogram aggregation for distribution charts in Upstash Redis Search.
 ---
 
 `$histogram` groups numeric values into fixed-width interval buckets.

--- a/redis/search/aggregation-operators/bucket-aggregations/overview.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Group documents into buckets with $terms, $range, $histogram, $dateHistogram, and $facet aggregations for segmented analytics in Upstash Redis Search.
 ---
 
 Bucket aggregations group matching documents into buckets.

--- a/redis/search/aggregation-operators/bucket-aggregations/range.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/range.mdx
@@ -1,5 +1,6 @@
 ---
 title: $range
+description: Group documents into custom from/to range buckets with the $range aggregation for pricing tiers and business-logic ranges in Upstash Redis Search.
 ---
 
 `$range` groups documents into custom ranges.

--- a/redis/search/aggregation-operators/bucket-aggregations/terms.mdx
+++ b/redis/search/aggregation-operators/bucket-aggregations/terms.mdx
@@ -1,5 +1,6 @@
 ---
 title: $terms
+description: Group documents by distinct field values with the $terms aggregation, controlling size, ordering, and count accuracy in Upstash Redis Search.
 ---
 
 `$terms` groups documents by distinct field values.

--- a/redis/search/aggregation-operators/metric-aggregations/avg.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/avg.mdx
@@ -1,5 +1,6 @@
 ---
 title: $avg
+description: Compute the arithmetic mean of a numeric field across matching documents with the $avg metric aggregation in Upstash Redis Search.
 ---
 
 `$avg` computes the arithmetic mean of a field across matching documents.

--- a/redis/search/aggregation-operators/metric-aggregations/cardinality.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/cardinality.mdx
@@ -1,5 +1,6 @@
 ---
 title: $cardinality
+description: Count the number of distinct values in a field with the $cardinality metric aggregation in Upstash Redis Search.
 ---
 
 `$cardinality` returns the number of distinct values in a field.

--- a/redis/search/aggregation-operators/metric-aggregations/count.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/count.mdx
@@ -1,5 +1,6 @@
 ---
 title: $count
+description: Count how many documents contribute a value for a field with the $count metric aggregation in Upstash Redis Search.
 ---
 
 `$count` returns how many documents contribute a value for a field.

--- a/redis/search/aggregation-operators/metric-aggregations/extended-stats.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/extended-stats.mdx
@@ -1,5 +1,6 @@
 ---
 title: $extendedStats
+description: Compute count, sum, min, max, avg plus variance and standard deviation for a field with the $extendedStats aggregation in Upstash Redis Search.
 ---
 
 `$extendedStats` returns `$stats` plus additional distribution metrics.

--- a/redis/search/aggregation-operators/metric-aggregations/max.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/max.mdx
@@ -1,5 +1,6 @@
 ---
 title: $max
+description: Return the maximum field value across matching documents with the $max metric aggregation in Upstash Redis Search.
 ---
 
 `$max` returns the maximum field value across matching documents.

--- a/redis/search/aggregation-operators/metric-aggregations/min.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/min.mdx
@@ -1,5 +1,6 @@
 ---
 title: $min
+description: Return the minimum field value across matching documents with the $min metric aggregation in Upstash Redis Search.
 ---
 
 `$min` returns the minimum field value across matching documents.

--- a/redis/search/aggregation-operators/metric-aggregations/overview.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Compute summary metrics like avg, sum, min, max, count, cardinality, stats, and percentiles over matched documents in Upstash Redis Search.
 ---
 
 Metric aggregations compute summary numbers over all documents that matched your `filter`.

--- a/redis/search/aggregation-operators/metric-aggregations/percentiles.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/percentiles.mdx
@@ -1,5 +1,6 @@
 ---
 title: $percentiles
+description: Return percentile cut points for a field to analyze value distribution with the $percentiles metric aggregation in Upstash Redis Search.
 ---
 
 `$percentiles` returns percentile cut points for a field.

--- a/redis/search/aggregation-operators/metric-aggregations/stats.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/stats.mdx
@@ -1,5 +1,6 @@
 ---
 title: $stats
+description: Compute count, sum, min, max, and avg for a field in a single pass with the $stats metric aggregation in Upstash Redis Search.
 ---
 
 `$stats` returns multiple basic metrics in one pass.

--- a/redis/search/aggregation-operators/metric-aggregations/sum.mdx
+++ b/redis/search/aggregation-operators/metric-aggregations/sum.mdx
@@ -1,5 +1,6 @@
 ---
 title: $sum
+description: Compute the total of a numeric field across matching documents with the $sum metric aggregation in Upstash Redis Search.
 ---
 
 `$sum` computes the total of a field across matching documents.

--- a/redis/search/aggregations.mdx
+++ b/redis/search/aggregations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Aggregations
+description: Compute analytics over indexed data with metric and bucket aggregations, from averages and sums to terms, ranges, and histograms in Upstash Redis Search.
 ---
 
 Aggregations let you compute analytics over your indexed data — metrics like averages, sums, and statistics,

--- a/redis/search/aliases.mdx
+++ b/redis/search/aliases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Aliases
+description: Create alternative names for search indices and atomically swap them for zero-downtime reindexing in Upstash Redis Search.
 ---
 
 Aliases let you create alternative names for your search indices. This is useful for zero-downtime reindexing — you can build a new index, then atomically swap the alias to point to it.

--- a/redis/search/command-reference.mdx
+++ b/redis/search/command-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+description: Complete reference of all Upstash Redis Search SEARCH.* commands, their syntax, arguments, and return values.
 ---
 
 A complete reference of all Upstash Redis Search commands, their syntax, and return values.

--- a/redis/search/counting.mdx
+++ b/redis/search/counting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Counting
+description: Count documents matching a query without retrieving them using the SEARCH.COUNT command in Upstash Redis Search.
 ---
 
 The `SEARCH.COUNT` command returns the number of documents matching a query without retrieving them.

--- a/redis/search/document-updates.mdx
+++ b/redis/search/document-updates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Document Updates
+description: Keep your search index in sync automatically using regular Redis write commands, with no separate update command in Upstash Redis Search.
 ---
 
 Documents in a search index are regular Redis keys.

--- a/redis/search/getting-started.mdx
+++ b/redis/search/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Quickstart
+description: Create an index, add documents, and run your first full-text query with Upstash Redis Search using TypeScript or Python.
 ---
 
 ## 1. Create Index

--- a/redis/search/index-management.mdx
+++ b/redis/search/index-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Indices
+description: Create and manage search indices with a name, key prefix, and schema for fast full-text search and filtering in Upstash Redis Search.
 ---
 
 An index is a data structure that enables **fast full-text search and filtering across your Redis data**. Without an index, searching requires scanning every key in your database: an operation that becomes very slow as your data grows.

--- a/redis/search/introduction.mdx
+++ b/redis/search/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+description: Search JSON, Hashes, and Strings in Redis with Upstash Redis Search, a fast full-text and vector search engine built on Rust-based Tantivy.
 ---
 
 Upstash Redis Search is our first extension beyond the official Redis spec. Using the Rust-based Tantivy under the hood, we provide an extremely fast way to search through Redis data.

--- a/redis/search/query-operators/boolean-operators/boost.mdx
+++ b/redis/search/query-operators/boolean-operators/boost.mdx
@@ -1,5 +1,6 @@
 ---
 title: $boost
+description: Adjust the relevance score contribution of a boolean clause to fine-tune result ranking with the $boost operator in Upstash Redis Search.
 ---
 
 The `$boost` operator adjusts the score contribution of a boolean clause.

--- a/redis/search/query-operators/boolean-operators/must-not.mdx
+++ b/redis/search/query-operators/boolean-operators/must-not.mdx
@@ -1,5 +1,6 @@
 ---
 title: $mustNot
+description: Exclude documents that match any of the specified conditions with the $mustNot boolean operator in Upstash Redis Search.
 ---
 
 The `$mustNot` operator excludes documents that match any of the specified conditions.

--- a/redis/search/query-operators/boolean-operators/must.mdx
+++ b/redis/search/query-operators/boolean-operators/must.mdx
@@ -1,5 +1,6 @@
 ---
 title: $must
+description: Require all specified conditions to match with the $must boolean operator, implementing logical AND queries in Upstash Redis Search.
 ---
 
 The `$must` operator requires all specified conditions to match.

--- a/redis/search/query-operators/boolean-operators/overview.mdx
+++ b/redis/search/query-operators/boolean-operators/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Combine conditions into complex queries with the $must, $should, $mustNot, and $boost boolean operators in Upstash Redis Search.
 ---
 
 Boolean operators combine multiple conditions to build complex queries.

--- a/redis/search/query-operators/boolean-operators/should.mdx
+++ b/redis/search/query-operators/boolean-operators/should.mdx
@@ -1,5 +1,6 @@
 ---
 title: $should
+description: Match at least one condition as a logical OR, or boost scores when combined with $must, using the $should boolean operator in Upstash Redis Search.
 ---
 
 The `$should` operator specifies conditions where at least one should match.

--- a/redis/search/query-operators/field-operators/boost.mdx
+++ b/redis/search/query-operators/field-operators/boost.mdx
@@ -1,5 +1,6 @@
 ---
 title: $boost
+description: Adjust the relevance score contribution of a field match to prioritize certain matches in result ranking with the $boost operator in Upstash Redis Search.
 ---
 
 The `$boost` operator adjusts the relevance score contribution of a field match.

--- a/redis/search/query-operators/field-operators/eq.mdx
+++ b/redis/search/query-operators/field-operators/eq.mdx
@@ -1,5 +1,6 @@
 ---
 title: $eq
+description: Perform explicit equality matching on a field with the $eq operator, required when combining with other operators in Upstash Redis Search.
 ---
 
 The `$eq` operator performs explicit equality matching on a field.

--- a/redis/search/query-operators/field-operators/fuzzy.mdx
+++ b/redis/search/query-operators/field-operators/fuzzy.mdx
@@ -1,5 +1,6 @@
 ---
 title: $fuzzy
+description: Match terms that are similar but not identical using Levenshtein distance to handle typos and misspellings with the $fuzzy operator in Upstash Redis Search.
 ---
 
 The `$fuzzy` operator matches terms that are similar but not identical to the search term.

--- a/redis/search/query-operators/field-operators/in.mdx
+++ b/redis/search/query-operators/field-operators/in.mdx
@@ -1,5 +1,6 @@
 ---
 title: $in
+description: Match documents where a field equals any value in an array with the $in operator for multi-value filtering in Upstash Redis Search.
 ---
 
 The `$in` operator matches documents where the field value equals any one of the specified values.

--- a/redis/search/query-operators/field-operators/overview.mdx
+++ b/redis/search/query-operators/field-operators/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Control how individual fields match with $smart, $eq, $in, range, $phrase, $fuzzy, $regex, and $boost field operators in Upstash Redis Search.
 ---
 
 Field operators provide precise control over how individual fields are matched.

--- a/redis/search/query-operators/field-operators/phrase.mdx
+++ b/redis/search/query-operators/field-operators/phrase.mdx
@@ -1,5 +1,6 @@
 ---
 title: $phrase
+description: Match documents where terms appear in an exact sequence, with optional slop and prefix, using the $phrase operator in Upstash Redis Search.
 ---
 
 The `$phrase` operator matches documents where terms appear in a specific sequence.

--- a/redis/search/query-operators/field-operators/range-operators.mdx
+++ b/redis/search/query-operators/field-operators/range-operators.mdx
@@ -1,5 +1,6 @@
 ---
 title: Range Operators
+description: Filter documents by numeric or date field boundaries with the $gt, $gte, $lt, and $lte range operators in Upstash Redis Search.
 ---
 
 Range operators filter documents based on numeric or date field boundaries.

--- a/redis/search/query-operators/field-operators/regex.mdx
+++ b/redis/search/query-operators/field-operators/regex.mdx
@@ -1,5 +1,6 @@
 ---
 title: $regex
+description: Match field terms against a regular expression pattern for flexible text matching with the $regex operator in Upstash Redis Search.
 ---
 
 The `$regex` operator matches documents where field terms match a regular expression pattern.

--- a/redis/search/query-operators/field-operators/smart-matching.mdx
+++ b/redis/search/query-operators/field-operators/smart-matching.mdx
@@ -1,5 +1,6 @@
 ---
 title: Smart Matching
+description: Understand default smart matching, which applies exact checks on numeric fields and intelligent multi-stage matching on text fields in Upstash Redis Search.
 ---
 
 When you provide a value directly to a field (without explicit operators like `$phrase` or `$fuzzy`),

--- a/redis/search/querying.mdx
+++ b/redis/search/querying.mdx
@@ -1,5 +1,6 @@
 ---
 title: Queries
+description: Search indexed documents with JSON queries, field filters, sorting, and pagination using TypeScript or Python in Upstash Redis Search.
 ---
 
 Queries are JSON strings that describe which documents to return. If the index doesn't exist, queries return `null`.

--- a/redis/search/recipes/blog-search.mdx
+++ b/redis/search/recipes/blog-search.mdx
@@ -1,5 +1,6 @@
 ---
 title: Blog Search
+description: Build full-text blog search with highlighted snippets, phrase matching, and date filtering using Upstash Redis Search.
 ---
 
 This recipe demonstrates building a full-text blog search with highlighted snippets,

--- a/redis/search/recipes/e-commerce-search.mdx
+++ b/redis/search/recipes/e-commerce-search.mdx
@@ -1,5 +1,6 @@
 ---
 title: E-commerce Search
+description: Build a product catalog search with filtering, sorting, typo tolerance, and relevance boosting using Upstash Redis Search.
 ---
 
 This recipe demonstrates building a product catalog search with filtering, sorting,

--- a/redis/search/recipes/overview.mdx
+++ b/redis/search/recipes/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Real-world Upstash Redis Search recipes for e-commerce, blog, and user directory search, each with schema design, sample data, and query patterns.
 ---
 
 This section provides complete, real-world examples demonstrating how to use Redis Search

--- a/redis/search/recipes/user-directory.mdx
+++ b/redis/search/recipes/user-directory.mdx
@@ -1,5 +1,6 @@
 ---
 title: User Directory
+description: Build a searchable employee directory with autocomplete, fuzzy name matching, and department filtering using Upstash Redis Search.
 ---
 
 This recipe demonstrates building a searchable employee directory with autocomplete,

--- a/redis/search/schema-definition.mdx
+++ b/redis/search/schema-definition.mdx
@@ -1,5 +1,6 @@
 ---
 title: Schemas
+description: Define type-safe index schemas with the s schema builder, choosing field types like text, numeric, keyword, and FACET in Upstash Redis Search.
 ---
 
 Every search index requires a schema that defines the structure of searchable documents. The schema allows for type-safety and allows us to optimize your data for very fast queries.

--- a/redis/search/troubleshooting.mdx
+++ b/redis/search/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Diagnose and fix common Upstash Redis Search errors, from index creation conflicts to schema and query issues.
 ---
 
 Common errors and how to resolve them when working with Upstash Redis Search.

--- a/redis/troubleshooting/command_count_increases_unexpectedly.mdx
+++ b/redis/troubleshooting/command_count_increases_unexpectedly.mdx
@@ -1,5 +1,6 @@
 ---
 title: Unexpected Increase in Command Count
+description: Understand why your Upstash Redis command count rises with no connected clients, caused by normal Console operations like the Data Browser.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/db_capacity_quota_exceeded.mdx
+++ b/redis/troubleshooting/db_capacity_quota_exceeded.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR DB capacity quota exceeded
+description: Fix the Upstash Redis DB capacity quota exceeded error by deleting entries, setting TTLs, enabling eviction, or upgrading your plan.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/econn_reset.mdx
+++ b/redis/troubleshooting/econn_reset.mdx
@@ -1,5 +1,6 @@
 ---
 title: Error read ECONNRESET
+description: Resolve the read ECONNRESET error when connecting to Upstash Redis by enabling TLS and using a rediss:// connection URL.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/http_unauthorized.mdx
+++ b/redis/troubleshooting/http_unauthorized.mdx
@@ -1,5 +1,6 @@
 ---
 title: WRONGPASS invalid or missing auth token
+description: Fix the Upstash Redis WRONGPASS error over HTTP by setting the correct UPSTASH_REDIS_REST_TOKEN from the console REST section.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/max_concurrent_connections.mdx
+++ b/redis/troubleshooting/max_concurrent_connections.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR max concurrent connections exceeded
+description: Fix the Upstash Redis max concurrent connections exceeded error by managing connections efficiently or using the REST-based client.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/max_daily_request_limit.mdx
+++ b/redis/troubleshooting/max_daily_request_limit.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR max daily request limit exceeded
+description: Fix the Upstash Redis max daily request limit exceeded error by sending fewer commands or upgrading to a paid plan.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/max_key_size_exceeded.mdx
+++ b/redis/troubleshooting/max_key_size_exceeded.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR max key size exceeded
+description: Resolve the Upstash Redis max key size exceeded error by reducing your key size below the hardcoded 32Kb limit.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/max_record_size_exceeded.mdx
+++ b/redis/troubleshooting/max_record_size_exceeded.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR max single record size exceeded
+description: Fix the Upstash Redis max single record size exceeded error by splitting data into smaller entries or upgrading past the 100Mb limit.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/max_request_size_exceeded.mdx
+++ b/redis/troubleshooting/max_request_size_exceeded.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR max request size exceeded
+description: Fix the Upstash Redis max request size exceeded error by splitting commands into smaller chunks below the 10MB per-request limit.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/max_requests_limit.mdx
+++ b/redis/troubleshooting/max_requests_limit.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR max requests limit exceeded
+description: Fix the Upstash Redis max requests limit exceeded error by sending fewer monthly commands or upgrading to a paid plan.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/no_auth.mdx
+++ b/redis/troubleshooting/no_auth.mdx
@@ -1,5 +1,6 @@
 ---
 title: NOAUTH Authentication Required
+description: Fix the Upstash Redis NOAUTH Authentication required error by adding the password to your connection URL with the correct ioredis format.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/readonly_connection.mdx
+++ b/redis/troubleshooting/readonly_connection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Connecting with Read-Only Access
+description: Connect to Upstash Redis with a read-only token over TCP using the default_ro user or a custom read-only ACL user to avoid WRONGPASS errors.
 ---
 
 ### Symptom

--- a/redis/troubleshooting/stream_pel_limit.mdx
+++ b/redis/troubleshooting/stream_pel_limit.mdx
@@ -1,5 +1,6 @@
 ---
 title: ERR XReadGroup is cancelled
+description: Fix the Upstash Redis XReadGroup is cancelled error by acknowledging pending stream messages with XACK to free the consumer PEL.
 ---
 
 ### Symptom

--- a/redis/tutorials/api_with_cdk.mdx
+++ b/redis/tutorials/api_with_cdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy a Serverless API with AWS CDK and AWS Lambda"
+description: Build and deploy a serverless view-counter API on AWS Lambda with the AWS CDK in TypeScript, using Upstash Redis for state.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/aws-cdk-typescript" horizontal>
   You can find the project source code on GitHub.

--- a/redis/tutorials/auto_complete_with_serverless_redis.mdx
+++ b/redis/tutorials/auto_complete_with_serverless_redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Autocomplete API with Serverless Redis
+description: Build an autocomplete API using Upstash Redis sorted sets and ZRANK to return term suggestions from prefixes.
 ---
 
 This tutorial implements an autocomplete API powered by serverless Redis. See

--- a/redis/tutorials/cloudflare_workers_with_redis.mdx
+++ b/redis/tutorials/cloudflare_workers_with_redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Use Redis in Cloudflare Workers"
+description: Use Upstash Redis via REST API in a Cloudflare Workers edge function to serve location-based greetings.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/cloudflare-workers-with-typescript" horizontal>
   You can find the project source code on GitHub.

--- a/redis/tutorials/coin_price_list.mdx
+++ b/redis/tutorials/coin_price_list.mdx
@@ -1,5 +1,6 @@
 ---
 title: Backendless Coin Price List with GraphQL API, Serverless Redis and Next.JS
+description: Build a backendless coin price list with Next.js and the Upstash GraphQL API, reading Redis directly from the client.
 
 image: img/coin-price-list/coin-price-list.png
 ---

--- a/redis/tutorials/goapi.mdx
+++ b/redis/tutorials/goapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: Serverless Golang API with Redis
+description: Build a serverless Golang page-view counter API on AWS Lambda with Upstash Redis, deployed using AWS SAM.
 ---
 
 This tutorial shows how to build a serverless API with Golang and Redis. The API

--- a/redis/tutorials/laravel_caching.mdx
+++ b/redis/tutorials/laravel_caching.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Caching in Laravel with Redis"
+description: Add caching to a Laravel application with Upstash Redis to speed up database-backed queries.
 ---
 
 ## Project Setup

--- a/redis/tutorials/nextjs_with_redis.mdx
+++ b/redis/tutorials/nextjs_with_redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Next.js with Redis"
+description: Use Upstash Redis as a state store in a Next.js App Router app by building a simple page-view counter.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/nextjs-app-router" horizontal>
   You can find the project source code on GitHub.

--- a/redis/tutorials/python_fastapi_caching.mdx
+++ b/redis/tutorials/python_fastapi_caching.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Redis as a Cache for Your FastAPI App"
+description: Cache FastAPI responses with Upstash Redis to cut database queries and speed up an external weather API app.
 ---
 
 ### Introduction

--- a/redis/tutorials/python_multithreading.mdx
+++ b/redis/tutorials/python_multithreading.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multithreaded Web Scraping with Redis Caching
+description: Build a multithreaded Python web scraper that caches HTTP responses in Upstash Redis to avoid redundant requests.
 ---
 
 In this tutorial, we’ll build a multithreaded web scraper in Python that leverages Redis for caching responses to minimize redundant HTTP requests. The scraper will be capable of handling groups of URLs across multiple threads while caching responses to reduce load and improve performance.

--- a/redis/tutorials/python_rate_limiting.mdx
+++ b/redis/tutorials/python_rate_limiting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Rate Limiting for Your FastAPI App"
+description: Add rate limiting to a FastAPI app with Upstash Redis using a fixed window limiter to control API usage.
 ---
 
 ### Introduction

--- a/redis/tutorials/python_realtime_chat.mdx
+++ b/redis/tutorials/python_realtime_chat.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Build a Real-Time Chat Application with Serverless Redis"
+description: Build a real-time chat app with Flask, SocketIO, and Upstash Redis Pub/Sub for low-latency message handling.
 ---
 
 In this tutorial, we will build a real-time chat application using Flask and SocketIO, leveraging Upstash Redis for efficient message handling. Redis, being a fast, in-memory data store, provides an ideal backbone for real-time messaging systems due to its low latency and support for Pub/Sub messaging patterns.

--- a/redis/tutorials/python_session.mdx
+++ b/redis/tutorials/python_session.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Manage Sessions in Python with Serverless Redis"
+description: Implement session management in a FastAPI app using cookies and Upstash Redis for fast, expiring session storage.
 ---
 
 In this tutorial, we’ll see how to implement session management in a FastAPI application using Upstash Redis. We’ll use cookies to store session IDs, while session data is maintained in Redis for its speed and expiration features.

--- a/redis/tutorials/python_url_shortener.mdx
+++ b/redis/tutorials/python_url_shortener.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Building a URL Shortener with Redis"
+description: Build a URL shortener in Python with Upstash Redis, generating short codes and setting expiration times for links.
 ---
 
 ### Introduction

--- a/redis/tutorials/pythonapi.mdx
+++ b/redis/tutorials/pythonapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: Serverless Python API with Redis
+description: Build a serverless Python page-view counter API on AWS Lambda with Upstash Redis, deployed using the AWS CDK.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/aws-cdk-python" horizontal>
   You can find the project source code on GitHub.

--- a/redis/tutorials/rate-limiting.mdx
+++ b/redis/tutorials/rate-limiting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AWS Lambda Rate Limiting with Serverless Redis"
+description: Rate limit an AWS Lambda function by client IP using @upstash/ratelimit, Upstash Redis, and the Serverless Framework.
 ---
 
 In this tutorial, we will deploy a AWS Lambda function ratelimited based on the client's IP address using `@upstash/ratelimit` and Serverless Framework.

--- a/redis/tutorials/serverless_java_redis.mdx
+++ b/redis/tutorials/serverless_java_redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Serverless API with Java and Redis
+description: Build a stateful serverless page-view counter API with Java and Upstash Redis on AWS Lambda.
 ---
 
 In this tutorial, we will build a stateful serverless API using Java and Redis

--- a/redis/tutorials/using_aws_sam.mdx
+++ b/redis/tutorials/using_aws_sam.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using AWS SAM
+description: Build and deploy a serverless application to AWS Lambda with Upstash Redis using the AWS SAM CLI.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/aws-sam" horizontal>
   You can find the project source code on GitHub.

--- a/redis/tutorials/using_google_cloud_functions.mdx
+++ b/redis/tutorials/using_google_cloud_functions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Serverless Redis on Google Cloud Functions
+description: Build a serverless view-counter API on Google Cloud Functions using Upstash Redis as the data store.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/google-cloud-functions" horizontal>
   You can find the project source code on GitHub.

--- a/redis/tutorials/using_serverless_framework.mdx
+++ b/redis/tutorials/using_serverless_framework.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using Serverless Framework
+description: Build and deploy a serverless application to AWS Lambda with Upstash Redis using the Serverless Framework.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/serverless-framework/counter" horizontal>
   You can find the project source code on GitHub.

--- a/workflow/agents/examples.mdx
+++ b/workflow/agents/examples.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Examples"
+description: Explore examples of building agent systems with the Upstash Workflow Agents API, from architectural patterns to real-world implementations.
 ---
 
 Explore our collection of examples to learn how to build robust agent systems. From architectural patterns to real-world implementations, these examples demonstrate the full potential of our Agents API.

--- a/workflow/agents/features.mdx
+++ b/workflow/agents/features.mdx
@@ -1,5 +1,6 @@
 ---
 Title: "Features"
+description: Explore the features of the Upstash Workflow Agents API, including models, tools from AI SDK and LangChain, and multi-agent orchestration.
 ---
 
 On this page, we explain the features of the Workflow Agents API in more detail.

--- a/workflow/agents/getting-started.mdx
+++ b/workflow/agents/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+description: Build your first AI agent endpoint with Upstash Workflow and Next.js, from installation to defining reliable, tool-using agents.
 ---
 
 In this guide, we will be using **Next.js**. If you're working with a different supported framework, you can find instructions on how to define a workflow endpoint in the [quickstarts](/workflow/quickstarts/platforms).

--- a/workflow/agents/overview.mdx
+++ b/workflow/agents/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Run single or multi-agent AI systems with Upstash Workflow, integrating AI SDK or LangChain tools with reliable, timeout-free execution.
 ---
 
 The **Agents API** of Upstash Workflow enables you to:  

--- a/workflow/agents/patterns/evaluator-optimizer.mdx
+++ b/workflow/agents/patterns/evaluator-optimizer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Evaluator-Optimizer"
+description: Build an evaluator-optimizer agent pattern with Upstash Workflow, where a generator refines its output from evaluator feedback until it passes.
 ---
 
 <img src="/img/workflow/agents/diagram/evaluator-diagram.png" />

--- a/workflow/agents/patterns/orchestrator-workers.mdx
+++ b/workflow/agents/patterns/orchestrator-workers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Orchestrator-Workers"
+description: Build an orchestrator-workers agent pattern with Upstash Workflow, directing multiple worker agents on subtasks and synthesizing their outputs.
 ---
 
 <img src="/img/workflow/agents/diagram/orchestrator-diagram.png" />

--- a/workflow/agents/patterns/parallelization.mdx
+++ b/workflow/agents/patterns/parallelization.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Parallelization"
+description: Build a parallelization agent pattern with Upstash Workflow, calling multiple agents simultaneously and aggregating their results.
 ---
 
 <img src="/img/workflow/agents/diagram/parallel-diagram.png" />

--- a/workflow/agents/patterns/prompt-chaining.mdx
+++ b/workflow/agents/patterns/prompt-chaining.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prompt Chaining"
+description: Build a prompt chaining agent pattern with Upstash Workflow, where each agent's output feeds the next in a sequence of LLM calls.
 ---
 
 <img src="/img/workflow/agents/diagram/prompt-chain-diagram.png" />

--- a/workflow/basics/caveats.mdx
+++ b/workflow/basics/caveats.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Caveats"
+description: Best practices and caveats for Upstash Workflow, including running business logic inside context.run and avoiding common pitfalls.
 ---
 
 ## Introduction

--- a/workflow/basics/client.mdx
+++ b/workflow/basics/client.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Use the Upstash Workflow Client to programmatically interact with your workflow runs from your own app or any external service.
 ---
 
 The Workflow Client lets you programmatically interact with your workflow runs.

--- a/workflow/basics/client/cancel.mdx
+++ b/workflow/basics/client/cancel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.cancel"
+description: Cancel one or more Upstash Workflow runs by ID, using filters, or all at once with the client.cancel method.
 ---
 
 Cancel one or more workflow runs. You can pass IDs directly, use filters, or cancel all at once.

--- a/workflow/basics/client/dlq/callback.mdx
+++ b/workflow/basics/client/dlq/callback.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.dlq.retryFailureFunction"
+description: Retry a failed failureFunction or failureUrl request in Upstash Workflow using the client.dlq.retryFailureFunction method.
 ---
 
 If a workflow's `failureFunction` or `failureUrl` request has failed, you can retry it using the `retryFailureFunction` method:

--- a/workflow/basics/client/dlq/delete.mdx
+++ b/workflow/basics/client/dlq/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.dlq.delete"
+description: Delete one or more workflow runs from the Upstash Workflow Dead Letter Queue by ID, array of IDs, or filters with client.dlq.delete.
 ---
 
 The `dlq.delete` method deletes one or more workflow runs from the **Dead Letter Queue (DLQ)**.

--- a/workflow/basics/client/dlq/list.mdx
+++ b/workflow/basics/client/dlq/list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.dlq.list"
+description: List failed workflow and QStash messages in the Upstash Workflow Dead Letter Queue with pagination using the client.dlq.list method.
 ---
 
 The `dlq.list` method retrieves messages that were sent to the **Dead Letter Queue (DLQ)**.

--- a/workflow/basics/client/dlq/restart.mdx
+++ b/workflow/basics/client/dlq/restart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.dlq.restart"
+description: Restart failed workflow runs from the Upstash Workflow Dead Letter Queue from the beginning using the client.dlq.restart method.
 ---
 
 The `dlq.restart` method restarts one or more workflow runs from **Dead Letter Queue (DLQ)**.

--- a/workflow/basics/client/dlq/resume.mdx
+++ b/workflow/basics/client/dlq/resume.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.dlq.resume"
+description: Resume failed workflow runs from the Upstash Workflow Dead Letter Queue at the failed step using the client.dlq.resume method.
 ---
 
 The `dlq.resume` method resumes one or more workflow runs from the **Dead Letter Queue (DLQ)** at the point where they previously failed.

--- a/workflow/basics/client/logs.mdx
+++ b/workflow/basics/client/logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.logs"
+description: Retrieve Upstash Workflow run logs with pagination and filtering using the client.logs method.
 ---
 
 The `logs` method retrieves workflow run logs using the [List Workflow Runs API](/workflow/api-reference/logs/list-workflow-run-logs).

--- a/workflow/basics/client/notify.mdx
+++ b/workflow/basics/client/notify.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.notify"
+description: Notify Upstash Workflow runs waiting at a waitForEvent step and resume them with event data using the client.notify method.
 ---
 
 The `notify` method notifies workflows that are waiting for a specific event.

--- a/workflow/basics/client/trigger.mdx
+++ b/workflow/basics/client/trigger.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.trigger"
+description: Start one or more Upstash Workflow runs and get their workflowRunId using the client.trigger method.
 ---
 
 The `trigger` method starts a new workflow run and returns its `workflowRunId`.

--- a/workflow/basics/client/waiters.mdx
+++ b/workflow/basics/client/waiters.mdx
@@ -1,5 +1,6 @@
 ---
 title: "client.getWaiters"
+description: Retrieve all workflow runs currently paused at a waitForEvent step for a given event using the client.getWaiters method.
 ---
 
 The `getWaiters` method retrieves all waiters that are currently listening for a given event.

--- a/workflow/basics/how.mdx
+++ b/workflow/basics/how.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How Workflow Works"
+description: Understand how Upstash Workflow orchestrates durable, scalable, and cost-efficient multi-step workflows built on top of Upstash QStash.
 ---
 
 Upstash Workflow is an orchestration layer that allows you to write **multi‑step workflows** which are:

--- a/workflow/basics/serve.mdx
+++ b/workflow/basics/serve.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Define a workflow endpoint with the Upstash Workflow serve() function, passing a route function of steps and configuration options.
 ---
 
 Use the `serve()` function to define an endpoint that runs a workflow.

--- a/workflow/basics/serve/advanced.mdx
+++ b/workflow/basics/serve/advanced.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Advanced Options"
+description: Advanced serve() options for Upstash Workflow, including failureFunction, retries, and settings for edge cases and testing pipelines.
 ---
 
 Advanced Options are intended to support edge cases or testing pipelines and are **not required for regular use**.

--- a/workflow/changelog.mdx
+++ b/workflow/changelog.mdx
@@ -1,5 +1,6 @@
 ---
 title: Changelog
+description: Changelog for Upstash Workflow, tracking new features and updates to the TypeScript (workflow-js) and Python (workflow-py) SDKs.
 ---
 
 <Note>

--- a/workflow/examples/allInOne.mdx
+++ b/workflow/examples/allInOne.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AI Generation"
+description: Process large datasets with Upstash Workflow by downloading data, processing chunks with OpenAI GPT-4, aggregating results, and generating a report.
 ---
 
 ## Introduction

--- a/workflow/examples/authWebhook.mdx
+++ b/workflow/examples/authWebhook.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Auth Provider Webhook"
+description: Build an authentication provider webhook with Upstash Workflow to handle user creation, Stripe trials, and automated email reminders.
 ---
 
 This example demonstrates an authentication provider webhook process using Upstash Workflow. 

--- a/workflow/examples/customRetry.mdx
+++ b/workflow/examples/customRetry.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Retry Logic"
+description: Implement custom retry logic in Upstash Workflow using response status codes and headers to control retries when calling third-party APIs like OpenAI.
 ---
 
 ## Key Features

--- a/workflow/examples/customerOnboarding.mdx
+++ b/workflow/examples/customerOnboarding.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Customer Onboarding"
+description: Build a customer onboarding workflow with Upstash Workflow that registers users, sends welcome emails, and reacts to user activity over time.
 ---
 
 This example demonstrates a customer onboarding process using Upstash Workflow. The following example workflow registers a new user, sends welcome emails, and periodically checks and responds to the user's activity state.

--- a/workflow/examples/dynamicWorkflow.mdx
+++ b/workflow/examples/dynamicWorkflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Dynamic Workflows"
+description: Build dynamic, configurable workflows with Upstash Workflow that run runtime-defined steps while safely handling ordering, naming, and versioning.
 ---
 
 This example demonstrates how to build **dynamic, configurable workflows** using Upstash Workflow, while safely handling ordering, naming, and versioning constraints. 

--- a/workflow/examples/eCommerceOrderFulfillment.mdx
+++ b/workflow/examples/eCommerceOrderFulfillment.mdx
@@ -1,5 +1,6 @@
 ---
 title: "E-commerce Order Fulfillment"
+description: Automate e-commerce order fulfillment with Upstash Workflow by verifying stock, processing payment, dispatching orders, and notifying customers.
 ---
 
 ## Introduction

--- a/workflow/examples/imageProcessing.mdx
+++ b/workflow/examples/imageProcessing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Image Processing"
+description: Process images with Upstash Workflow by uploading, resizing into multiple resolutions, applying filters, and storing the processed versions.
 ---
 
 <Note>

--- a/workflow/examples/paymentRetry.mdx
+++ b/workflow/examples/paymentRetry.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Retries"
+description: Build a payment retry workflow with Upstash Workflow that retries failed charges, sends invoice emails, and suspends accounts after repeated failures.
 ---
 
 This example demonstrates a payment retry process using Upstash Workflow.

--- a/workflow/examples/waitForEvent.mdx
+++ b/workflow/examples/waitForEvent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Waiting for Events"
+description: Pause and resume workflows with Upstash Workflow's wait-for-event feature, letting an external system notify order processing when it is ready.
 ---
 
 <Note>

--- a/workflow/features/dlq.mdx
+++ b/workflow/features/dlq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: The Dead Letter Queue automatically captures failed Upstash Workflow runs after all retries, preserving execution context for restart, resume, or delete.
 ---
 
 The Dead Letter Queue (DLQ) automatically captures failed workflow runs that have exhausted all retry attempts.

--- a/workflow/features/dlq/callback.mdx
+++ b/workflow/features/dlq/callback.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Rerun Failure Function"
+description: Rerun a workflow's failure function from the DLQ to complete cleanup, logging, or alerting tasks that failed after an Upstash Workflow run failed.
 ---
 
 The **Rerun Failure Function** action allows you to retry the failure function that executes when a workflow run enters the Dead Letter Queue (DLQ).

--- a/workflow/features/dlq/delete.mdx
+++ b/workflow/features/dlq/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete"
+description: Delete failed Upstash Workflow runs from the Dead Letter Queue individually, in bulk by ID, or by filters like label, URL, or date range.
 ---
 
 The **Delete** action allows you to remove failed workflow runs from the Dead Letter Queue when no recovery action is needed.

--- a/workflow/features/dlq/restart.mdx
+++ b/workflow/features/dlq/restart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Restart"
+description: Restart a failed Upstash Workflow run from the beginning, discarding previous step results and executing from scratch with the original payload.
 ---
 
 The **Restart** action allows you to re-execute a failed workflow run from the beginning.

--- a/workflow/features/dlq/resume.mdx
+++ b/workflow/features/dlq/resume.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Resume"
+description: Resume a failed Upstash Workflow run from the exact point of failure, preserving all successfully completed steps and their results.
 ---
 
 The **Resume** action allows you to continue a failed workflow run from the exact point of failure, preserving all successfully completed steps and their results.

--- a/workflow/features/failure-callback.mdx
+++ b/workflow/features/failure-callback.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Attach a failure function to your Upstash Workflow to run custom cleanup, logging, or alerting when a run fails after exhausting all retries.
 ---
 
 When you define a workflow endpoint, you can attach a failure function to the workflow that allows you to execute custom logic when a workflow run fails after exhausting all retry attempts.

--- a/workflow/features/failureFunction/advanced.mdx
+++ b/workflow/features/failureFunction/advanced.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Advanced failureUrl Option"
+description: Use the failureUrl option to send Upstash Workflow failure callbacks to a separate endpoint, handling failures on infrastructure independent of your workflow.
 ---
 
 The `failureUrl` is an advanced option that sends failure callback to a different endpoint rather than to the workflow endpoint (failure function).

--- a/workflow/features/failureFunction/reliability.mdx
+++ b/workflow/features/failureFunction/reliability.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reliability of Failure Function"
+description: Understand how Upstash Workflow retries a failing failure function and how to inspect and rerun failed executions from the DLQ dashboard.
 ---
 
 The failure function is executed whenever a workflow run fails.

--- a/workflow/features/flow-control.mdx
+++ b/workflow/features/flow-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Flow Control limits how many Upstash Workflow steps run by queuing and delaying delivery to respect rate, period, and parallelism constraints.
 ---
 
 Flow Control allows you to limit how many workflow steps are executed by delaying and queuing their delivery.

--- a/workflow/features/flow-control/monitor.mdx
+++ b/workflow/features/flow-control/monitor.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Monitor & Manage"
+description: Monitor and manage Upstash Workflow flow control keys from the console or REST API, including pausing delivery, pinning configs, and resetting rate counts.
 ---
 
 You can monitor wait list size of your flow control key's from the console `FlowControl` tab. The console also allows you to pin, unpin, and reset rate for flow control keys directly.

--- a/workflow/features/flow-control/parallelism.mdx
+++ b/workflow/features/flow-control/parallelism.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Parallelism"
+description: Limit how many Upstash Workflow steps run concurrently with a token-based parallelism control that queues excess requests in a waitlist.
 ---
 
 The parallelism limit controls the maximum number of calls that can be executed concurrently.

--- a/workflow/features/flow-control/rate-period.mdx
+++ b/workflow/features/flow-control/rate-period.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Rate and Period"
+description: Control how many Upstash Workflow steps start within a time window using rate and period limits, queuing excess steps for the next window.
 ---
 
 The rate specifies the maximum number of requests allowed in a given period (time window).

--- a/workflow/features/invoke.mdx
+++ b/workflow/features/invoke.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Use context.invoke to start another Upstash Workflow from within a workflow and await its result, orchestrating multiple workflows together.
 ---
 
 You can start another workflow run inside a workflow and await its execution to complete.

--- a/workflow/features/invoke/serveMany.mdx
+++ b/workflow/features/invoke/serveMany.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Using Serve Many"
+description: Expose multiple Upstash Workflows under one route with serveMany and invoke them by object with full type safety, no URLs required.
 ---
 
 Normally, workflows are created with `serve()`, which exposes each workflow as its own HTTP endpoint.

--- a/workflow/features/notify.mdx
+++ b/workflow/features/notify.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notify"
+description: Notify Upstash Workflow runs waiting on an event ID from inside a workflow or an external system, with lookback to prevent race conditions.
 ---
 
 You can notify all the workflow runs waitingi for a specific event ID.

--- a/workflow/features/parallel-steps.mdx
+++ b/workflow/features/parallel-steps.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Parallel Steps"
+description: Run multiple Upstash Workflow steps concurrently with Promise.all to execute independent operations in parallel with no extra configuration.
 ---
 
 Upstash Workflow supports executing multiple steps in parallel.

--- a/workflow/features/retries.mdx
+++ b/workflow/features/retries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Upstash Workflow automatically retries failed steps with configurable attempt counts and exponential backoff to handle transient errors reliably.
 ---
 
 Upstash Workflow provides an automatic retry mechanism to improve reliability and make workflows resilient against temporary failures.

--- a/workflow/features/retries/prevent-retries.mdx
+++ b/workflow/features/retries/prevent-retries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prevent Retries"
+description: Stop Upstash Workflow execution without retries using WorkflowNonRetryableError, context.cancel, or conditional guards to exit early gracefully.
 ---
 
 It is recommended to enable retries for workflow runs to improve reliability.

--- a/workflow/features/sleep.mdx
+++ b/workflow/features/sleep.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sleep"
+description: Pause Upstash Workflow execution with context.sleep and sleepUntil to build time-based delays without consuming compute or serverless timeouts.
 ---
 
 Upstash Workflow provides a **Sleep** feature that allows you to pause workflow execution for specified durations without consuming compute resources. 

--- a/workflow/features/wait-for-event.mdx
+++ b/workflow/features/wait-for-event.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Pause an Upstash Workflow with waitForEvent until an external event arrives, with timeouts and lookback strategies to avoid notify race conditions.
 ---
 
 Wait for Event feature that allows you to pause workflow execution until an external event occurs.

--- a/workflow/features/wait.mdx
+++ b/workflow/features/wait.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wait"
+description: Pause an Upstash Workflow run with waitForEvent until a matching event is published, using configurable timeouts to handle waits gracefully.
 ---
 
 You can pause a workflow run with the `waitForEvent` step. An event is uniquely identified by event ID.

--- a/workflow/features/webhooks.mdx
+++ b/workflow/features/webhooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Webhooks"
+description: Pause an Upstash Workflow and wait for a callback URL with createWebhook and waitForWebhook, integrating third-party APIs with built-in lookback.
 ---
 
 The Webhook feature allows you to pause workflow execution and wait for a webhook URL to be called, enabling seamless integration with third-party APIs and asynchronous operations.

--- a/workflow/getstarted.mdx
+++ b/workflow/getstarted.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Upstash Workflow lets you write durable, reliable serverless functions with delivery guarantees, automatic retries, and scheduling, with no infrastructure to manage.
 ---
 
 Upstash Workflow lets you write **durable, reliable and performant serverless functions**. Get delivery guarantees, automatic retries on failure, scheduling and more without managing any infrastructure.

--- a/workflow/howto/cancel.mdx
+++ b/workflow/howto/cancel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cancel a Run"
+description: Cancel a running Upstash Workflow from the console, the client.cancel method, or the REST API using the workflow run ID.
 ---
 
 You can cancel a running workflow both programatically and from your Upstash Workflow console.

--- a/workflow/howto/changes.mdx
+++ b/workflow/howto/changes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update a Workflow"
+description: Update Upstash Workflow code safely by understanding step-order constraints and strategies for handling in-progress runs during deployments.
 ---
 
 Workflows are composed of multiple steps. When you modify workflow code, it's important to consider how these changes might affect in-progress workflows.

--- a/workflow/howto/configure.mdx
+++ b/workflow/howto/configure.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configure a Run"
+description: Configure an Upstash Workflow run with retries, retry delay, and flow control options when triggering it with the client.
 ---
 
 You can configure a workflow run when starting it. The following are the options you can configure:

--- a/workflow/howto/failures.mdx
+++ b/workflow/howto/failures.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Handle Failed Runs"
+description: Gracefully handle failed Upstash Workflow runs with failure functions, failureUrl callbacks, retries, and DLQ recovery for debugging and resuming.
 ---
 
 This guide shows you how to **gracefully handle failed workflow runs**. This involves best practices on resolving runtime errors, logging and manually retrying runs that have failed multiple times.

--- a/workflow/howto/local-development/development-server.mdx
+++ b/workflow/howto/local-development/development-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Development Server"
+description: Run Upstash Workflow locally with the QStash development server, using QSTASH_DEV for automatic setup or manual configuration with the CLI.
 ---
 
 Upstash Workflow is built on top of Upstash QStash.

--- a/workflow/howto/local-development/local-tunnel.mdx
+++ b/workflow/howto/local-development/local-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Local Tunnel"
+description: Expose your local Upstash Workflow endpoint publicly with an ngrok tunnel so managed QStash servers can reach it during development.
 ---
 
 Upstash Workflow requires your application to be publicly accessible in production.

--- a/workflow/howto/middlewares.mdx
+++ b/workflow/howto/middlewares.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Middlewares"
+description: Hook into Upstash Workflow lifecycle and debug events with built-in or custom middleware for logging, monitoring, and error tracking.
 ---
 
 Middlewares allow you to intercept and respond to workflow lifecycle events and debug messages. They're useful for logging, monitoring, error tracking, and custom integrations.

--- a/workflow/howto/migrations.mdx
+++ b/workflow/howto/migrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Migration Guide"
+description: Migrate between Upstash Workflow versions, including the 1.0.0 TypeScript release breaking changes and moving from @upstash/qstash.
 ---
 
 This guide covers migration between different versions of Upstash Workflow.

--- a/workflow/howto/multi-region.mdx
+++ b/workflow/howto/multi-region.mdx
@@ -1,5 +1,6 @@
 ---
 title: Select a Region
+description: Choose between Upstash Workflow's EU and US regions and migrate resources between them using single-region or migration mode configuration.
 ---
 
 ## Overview

--- a/workflow/howto/parallel-runs.mdx
+++ b/workflow/howto/parallel-runs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Parallel Runs"
+description: Run multiple Upstash Workflow steps at the same time with Promise.all, executing independent steps concurrently within a single run.
 ---
 
 <Note>

--- a/workflow/howto/readonly-token.mdx
+++ b/workflow/howto/readonly-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Read-only Token"
+description: Share a read-only Upstash Workflow token that accesses logs, messages, and schedules but cannot publish messages or modify resources.
 ---
 
 You can use a read-only version of your token to safely share it with your team or AI agents.

--- a/workflow/howto/realtime/basic.mdx
+++ b/workflow/howto/realtime/basic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Realtime Quickstart"
+description: Integrate Upstash Workflow with Upstash Realtime to emit step events and stream live workflow progress to your frontend over Server-Sent Events.
 ---
 
 [**Upstash Realtime**](/realtime/overall/quickstart) lets you emit events from your workflow and subscribe to them in real-time on your frontend.

--- a/workflow/howto/realtime/human-in-the-loop.mdx
+++ b/workflow/howto/realtime/human-in-the-loop.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Human-in-the-Loop"
+description: Build human-in-the-loop Upstash Workflows that pause for user approval with waitForEvent and stream real-time status updates using Upstash Realtime.
 ---
 
 Some workflows require human approval or input before proceeding. When combined with [**Upstash Realtime**](/realtime/overall/quickstart), you can create interactive workflows that pause for user input and provide real-time feedback to your frontend during the entire process.

--- a/workflow/howto/schedule.mdx
+++ b/workflow/howto/schedule.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedule a Workflow"
+description: Schedule Upstash Workflows to run periodically with QStash cron schedules, from the dashboard or programmatically with per-user schedule IDs.
 ---
 
 You can schedule a workflow to run periodically using a cron definition.

--- a/workflow/howto/security.mdx
+++ b/workflow/howto/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Secure a Workflow"
+description: Secure your Upstash Workflow endpoint with built-in Upstash-Signature request verification or a custom authorization method.
 ---
 
 To prevent unauthorized access to your workflow endpoint, you can add an authorization layer.

--- a/workflow/howto/start.mdx
+++ b/workflow/howto/start.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Start a Run"
+description: Start an Upstash Workflow run with the recommended client.trigger method or a direct HTTP request, passing body, headers, retries, and more.
 ---
 
 You’ve defined your workflow, and the final step is to trigger the endpoint!

--- a/workflow/howto/use-webhooks.mdx
+++ b/workflow/howto/use-webhooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Webhooks"
+description: Handle incoming webhooks in Upstash Workflow by setting up endpoints, validating requests, and processing events as trackable steps.
 sidebarTitle: "Handle Webhooks"
 ---
 

--- a/workflow/integrations/aisdk.mdx
+++ b/workflow/integrations/aisdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: Vercel AI SDK
+description: Integrate Upstash Workflow with the Vercel AI SDK to build durable AI applications with automatic retries, workflow steps, and tool calling.
 ---
 
 <Note>

--- a/workflow/integrations/anthropic.mdx
+++ b/workflow/integrations/anthropic.mdx
@@ -1,5 +1,6 @@
 ---
 title: Anthropic
+description: Call the Anthropic messages API from Upstash Workflow using the type-safe context.api.anthropic.call method for durable text generation.
 ---
 
 The standard way to call a third-party endpoint in your workflow is by using [`context.call`](/workflow/basics/context#context-call).

--- a/workflow/integrations/datadog.mdx
+++ b/workflow/integrations/datadog.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Datadog - Upstash QStash Integration"
+description: Connect Datadog with Upstash QStash to monitor message delivery, retries, DLQ, and schedules with dashboards and analytics.
 sidebarTitle: "Datadog"
 ---
 

--- a/workflow/integrations/openai.mdx
+++ b/workflow/integrations/openai.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenAI
+description: Call the OpenAI chat completions API from Upstash Workflow using the type-safe context.api.openai.call method for durable text generation.
 ---
 
 ### Calling OpenAI

--- a/workflow/integrations/prometheus.mdx
+++ b/workflow/integrations/prometheus.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prometheus - Upstash QStash Integration"
+description: Scrape Upstash QStash metrics into Prometheus and visualize them in Grafana to monitor message delivery and performance.
 sidebarTitle: "Prometheus"
 ---
 

--- a/workflow/integrations/resend.mdx
+++ b/workflow/integrations/resend.mdx
@@ -1,5 +1,6 @@
 ---
 title: Resend
+description: Send emails from Upstash Workflow using the type-safe context.api.resend.call method for durable single and batch email delivery.
 ---
 
 The standard way to call a third-party endpoint in your workflow is by using [`context.call`](/workflow/basics/context#context-call).

--- a/workflow/pricing.mdx
+++ b/workflow/pricing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pricing"
+description: Understand Upstash Workflow's pay-as-you-go pricing, based on QStash messages per workflow run, and how each step contributes to cost.
 ---
 Upstash Workflow is based on QStash and uses a "pay-as-you-go" pricing model. You only incur costs when your app receives traffic, meaning there's no charge when it's not in use. Click [here](https://upstash.com/pricing/workflow) to view the pricing.
 

--- a/workflow/quickstarts/astro.mdx
+++ b/workflow/quickstarts/astro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Astro
+description: Use Upstash Workflow with Astro in this step-by-step quickstart, with a complete example project on GitHub.
 ---
 
 <Card

--- a/workflow/quickstarts/cloudflare-workers.mdx
+++ b/workflow/quickstarts/cloudflare-workers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cloudflare Workers"
+description: Deploy Upstash Workflow on Cloudflare Workers with this step-by-step guide, including Hono.js examples and best practices.
 ---
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-js/tree/main/examples/cloudflare-workers" horizontal>
   You can find the project source code on GitHub.

--- a/workflow/quickstarts/express.mdx
+++ b/workflow/quickstarts/express.mdx
@@ -1,5 +1,6 @@
 ---
 title: Express.js
+description: Use Upstash Workflow with Express.js in this step-by-step quickstart, with a complete example project on GitHub.
 ---
 
 <Card

--- a/workflow/quickstarts/fastapi.mdx
+++ b/workflow/quickstarts/fastapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: FastAPI
+description: Use Upstash Workflow with FastAPI in Python through this step-by-step quickstart, with an end-to-end example project on GitHub.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-py/tree/master/examples/fastapi" horizontal>

--- a/workflow/quickstarts/flask.mdx
+++ b/workflow/quickstarts/flask.mdx
@@ -1,5 +1,6 @@
 ---
 title: Flask
+description: Use Upstash Workflow with Flask in Python through this step-by-step quickstart, with an end-to-end example project on GitHub.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-py/tree/master/examples/flask" horizontal>

--- a/workflow/quickstarts/hono.mdx
+++ b/workflow/quickstarts/hono.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hono
+description: Deploy Upstash Workflow with Hono on Cloudflare Workers in this step-by-step quickstart, with an end-to-end example project.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-js/tree/main/examples/hono" horizontal>

--- a/workflow/quickstarts/nextjs-fastapi.mdx
+++ b/workflow/quickstarts/nextjs-fastapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: Next.js & FastAPI
+description: Build durable workflows with Upstash Workflow using a Next.js frontend and FastAPI backend in this step-by-step quickstart.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-py/tree/master/examples/nextjs-fastapi" horizontal>

--- a/workflow/quickstarts/nextjs-flask.mdx
+++ b/workflow/quickstarts/nextjs-flask.mdx
@@ -1,5 +1,6 @@
 ---
 title: Next.js & Flask
+description: Build durable workflows with Upstash Workflow using a Next.js frontend and Flask backend in this step-by-step quickstart.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-py/tree/master/examples/nextjs-flask" horizontal>

--- a/workflow/quickstarts/nuxt.mdx
+++ b/workflow/quickstarts/nuxt.mdx
@@ -1,5 +1,6 @@
 ---
 title: Nuxt
+description: Deploy Upstash Workflow with Nuxt in this step-by-step quickstart, featuring a one-click Vercel deploy and example project.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-js/tree/main/examples/nuxt" horizontal>

--- a/workflow/quickstarts/platforms.mdx
+++ b/workflow/quickstarts/platforms.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Supported Platforms"
+description: Explore the platforms and frameworks natively supported by Upstash Workflow across JavaScript, TypeScript, and Python.
 ---
 
 Upstash Workflow natively supports the following platforms:

--- a/workflow/quickstarts/solidjs.mdx
+++ b/workflow/quickstarts/solidjs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SolidJS"
+description: Use Upstash Workflow with SolidJS in this step-by-step quickstart, with an end-to-end example project on GitHub.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-js/tree/main/examples/solidjs" horizontal>

--- a/workflow/quickstarts/svelte.mdx
+++ b/workflow/quickstarts/svelte.mdx
@@ -1,5 +1,6 @@
 ---
 title: SvelteKit
+description: Deploy Upstash Workflow with SvelteKit in this step-by-step quickstart, featuring a one-click Vercel deploy and example project.
 ---
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/workflow-js/tree/main/examples/sveltekit" horizontal>

--- a/workflow/quickstarts/tanstack-start.mdx
+++ b/workflow/quickstarts/tanstack-start.mdx
@@ -1,5 +1,6 @@
 ---
 title: TanStack Start
+description: Use Upstash Workflow with TanStack Start in this step-by-step quickstart, with a complete example project on GitHub.
 ---
 
 <Card

--- a/workflow/quickstarts/vercel-nextjs.mdx
+++ b/workflow/quickstarts/vercel-nextjs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Next.js
+description: Deploy Upstash Workflow with Next.js on Vercel in this step-by-step quickstart, featuring a one-click deploy and example project.
 ---
 
 This guide provides step-by-step instructions on how to use and deploy Upstash Workflow with Next.js.

--- a/workflow/steps.mdx
+++ b/workflow/steps.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: Explore the Upstash Workflow context object that exposes step APIs plus run properties like the request payload, headers, and metadata.
 ---
 
 A workflow's **context** is an object provided by the route function.

--- a/workflow/steps/api.mdx
+++ b/workflow/steps/api.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.api"
+description: Make type-safe third-party API requests to OpenAI, Anthropic, and Resend as workflow steps with the context.api namespace.
 ---
 
 In addition to `context.call`, you can also make third‑party requests using the `context.api` namespace.

--- a/workflow/steps/call.mdx
+++ b/workflow/steps/call.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.call"
+description: Perform HTTP requests as a workflow step with context.call, supporting response times up to 12 hours without consuming compute.
 ---
 
 `context.call()` performs an HTTP request as a workflow step, supporting longer response times up to 12 hours.

--- a/workflow/steps/cancel.mdx
+++ b/workflow/steps/cancel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.cancel"
+description: Explicitly cancel the current workflow run from within your code using the Upstash Workflow context.cancel method.
 ---
 
 All of the methods covered so far are used to define workflow steps.

--- a/workflow/steps/createWebhook.mdx
+++ b/workflow/steps/createWebhook.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.createWebhook"
+description: Create a unique webhook URL that external services can call to resume workflow execution with the context.createWebhook method.
 ---
 
 `context.createWebhook()` creates a unique webhook that can be called by external services to trigger workflow continuation.

--- a/workflow/steps/invoke.mdx
+++ b/workflow/steps/invoke.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.invoke"
+description: Trigger another workflow and pause until it finishes with context.invoke, resuming when it succeeds, fails, or is canceled.
 ---
 
 `context.invoke()` triggers another workflow run and pauses until the invoked workflow finishes.

--- a/workflow/steps/notify.mdx
+++ b/workflow/steps/notify.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.notify"
+description: Notify workflows waiting at a waitForEvent step and pass an optional payload using the Upstash Workflow context.notify method.
 ---
 
 `context.notify()` notifies workflows that are waiting for a specific event, passing along an optional payload.

--- a/workflow/steps/run.mdx
+++ b/workflow/steps/run.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.run"
+description: Execute custom business logic as a workflow step with context.run, running steps sequentially or in parallel in Upstash Workflow.
 ---
 
 `context.run()` executes a piece of custom business logic as a workflow step.

--- a/workflow/steps/sleep.mdx
+++ b/workflow/steps/sleep.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.sleep"
+description: Pause workflow execution for a set duration with context.sleep, consuming no compute resources while the workflow sleeps.
 ---
 
 `context.sleep()` pauses workflow execution for a specified duration.

--- a/workflow/steps/sleepUntil.mdx
+++ b/workflow/steps/sleepUntil.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.sleepUntil"
+description: Pause workflow execution until a specific timestamp with context.sleepUntil, consuming no compute resources while sleeping.
 ---
 
 `context.sleepUntil()` pauses workflow execution until a specific timestamp.

--- a/workflow/steps/waitForEvent.mdx
+++ b/workflow/steps/waitForEvent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.waitForEvent"
+description: Pause workflow execution until an event occurs or a timeout is reached with the Upstash Workflow context.waitForEvent step.
 ---
 
 `context.waitForEvent` pauses workflow execution until a given event occurs or a timeout is reached.

--- a/workflow/steps/waitForWebhook.mdx
+++ b/workflow/steps/waitForWebhook.mdx
@@ -1,5 +1,6 @@
 ---
 title: "context.waitForWebhook"
+description: Pause workflow execution until a created webhook is called or a timeout is reached with the context.waitForWebhook step.
 ---
 
 `context.waitForWebhook()` pauses workflow execution until the webhook created by `createWebhook` is called or a timeout is reached.

--- a/workflow/troubleshooting/general.mdx
+++ b/workflow/troubleshooting/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: "General"
+description: Troubleshoot common Upstash Workflow issues, including the WorkflowAbort error from running steps inside try/catch blocks.
 sidebarTitle: "General"
 ---
 

--- a/workflow/troubleshooting/vercel.mdx
+++ b/workflow/troubleshooting/vercel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Vercel"
+description: Troubleshoot Upstash Workflow on Vercel, including bypassing preview deployment protection with a bypass secret.
 sidebarTitle: "Vercel"
 ---
 


### PR DESCRIPTION
https://linear.app/upstash/issue/DX-2820/docs-add-descriptions-to-pages

Adds a description frontmatter field to 386 pages that were missing one, across Upstash Redis (incl. SDK, Search, tutorials), QStash, Workflow, and Box. Missing descriptions leave search snippets and social/LLM previews to be auto-generated; each page now has a page-specific, ~100-155 char description.