### PR TITLE
docs: update QStash user API schema

### DIFF
--- a/devops/developer-api/openapi.yml
+++ b/devops/developer-api/openapi.yml
@@ -2950,13 +2950,13 @@ components:
           format: uuid
           description: Unique identifier for the QStash user account
           example: 99a4c327-31f0-490f-a594-043ade84085a
-        password:
-          type: string
-          description: QStash authentication password
-          example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
         token:
           type: string
           description: Authentication token for QStash operations
+          example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
+        read_only_token:
+          type: string
+          description: Read-only authentication token for QStash operations
           example: ZXhhbXBsZUB1cHN0YXNoLmNvbTpuYWJlcg==
         active:
           type: boolean
@@ -2968,119 +2968,79 @@ components:
           example: active
         modifying_state:
           type: string
-          description: Transitional state while the console applies an async change (e.g. `suspended` during suspension)
+          description: Transitional state while the console applies an async change (e.g. `suspended` during suspension). Omitted when no change is in progress.
           example: suspended
         last_plan_upgrade_time:
           type: integer
           format: int64
           description: Unix timestamp of the last plan upgrade
-          example: 1761267303
+          example: 0
         max_message_size:
           type: integer
           description: Maximum message size in bytes
-          example: 52428800
+          example: 1048576
         max_requests_per_day:
           type: integer
           description: Soft limit for maximum requests per day
-          example: 1000000
+          example: 1000
         max_requests_per_day_hard:
           type: integer
           description: Hard limit for maximum requests per day
-          example: 10000000
+          example: 1000
         max_endpoints_per_topic:
           type: integer
           description: Maximum number of endpoints allowed per topic
-          example: 1000
+          example: 100
         max_requests_per_second:
           type: integer
           description: Maximum requests per second (rate limit)
-          example: 500
+          example: 100
         max_dlq_size:
           type: integer
           description: Maximum dead letter queue size
-          example: 2147483647
-        max_completion_tokens_per_day:
-          type: integer
-          description: Daily limit for completion tokens (LLM-related usage)
-          example: 10000
-        max_completion_tokens_per_minute:
-          type: integer
-          description: Per-minute limit for completion tokens
-          example: 1000
-        max_completions_per_day:
-          type: integer
-          description: Daily cap on completion requests
-          example: 100
-        max_completions_per_minute:
-          type: integer
-          description: Per-minute cap on completion requests
-          example: 10
+          example: 1000000
         max_retries:
           type: integer
           description: Maximum number of retry attempts for failed messages
-          example: 20
+          example: 999
         max_topics:
           type: integer
           description: Maximum number of topics allowed
-          example: 1000
+          example: 1
         max_schedules:
           type: integer
           description: Maximum number of schedules allowed
-          example: 1000000
+          example: 10
         max_events_size:
           type: integer
           description: Maximum size for events
-          example: 100000
+          example: 10000
         max_dlq_retention_time_milis:
           type: integer
           format: int64
           description: Maximum retention time for dead letter queue in milliseconds
-          example: 2592000000
+          example: 259200000
         max_delay:
           type: integer
           description: Maximum delay for scheduled messages in seconds
-          example: 2147483647
+          example: 604800
         max_parallelism:
           type: integer
           description: Maximum parallel processing per endpoint
-          example: 10
+          example: 2
         max_global_parallelism:
           type: integer
           description: Maximum global parallel processing across all endpoints
-          example: 200
+          example: 10
         max_queues:
           type: integer
           description: Maximum number of queues allowed
-          example: 1000
-        retention:
+          example: 10
+        max_bandwidth_per_second:
           type: integer
-          description: Message retention period (see product defaults for unit/context)
-          example: 7
-        timeout:
-          type: integer
-          description: Request timeout in seconds
-          example: 21600
-        rate_limit:
-          type: integer
-          description: Account-level rate limit configuration value exposed by the API
-          example: 100
-        type:
-          type: string
-          description: Account billing plan category
-          enum: [free, paid]
-          example: paid
-        reserved_type:
-          type: string
-          description: |
-            Fixed-tier or enterprise label when applicable. May be empty/absent for non-fixed plans.
-            Known values include `qstash_fixed_1m`, `qstash_fixed_10m`, `qstash_fixed_100m`, `qstash_fixed`.
-            Enterprise accounts may use the prefix `enterprise:` followed by an identifier (e.g. `enterprise:acme`).
-          example: qstash_fixed_1m
-        reserved_price:
-          type: number
-          format: float
-          description: Reserved plan price (may be `0`)
-          example: 180
+          format: int64
+          description: Maximum bandwidth per second in bytes
+          example: 1048576
         prod_pack_enabled:
           type: boolean
           description: Whether production pack features are enabled
@@ -3090,6 +3050,49 @@ components:
           description: Whether Prometheus metrics export is enabled (`"true"` / `"false"` string as returned by the API)
           enum: ["true", "false"]
           example: "false"
+        timeout:
+          type: integer
+          description: Request timeout in seconds
+          example: 900
+        type:
+          type: string
+          description: Account billing plan category
+          enum: [free, paid]
+          example: free
+        region:
+          type: string
+          description: Region where the QStash instance is deployed
+          enum: [eu-central-1, us-east-1]
+          example: eu-central-1
+        reserved_type:
+          type: string
+          description: |
+            Fixed-tier or enterprise label when applicable. May be empty/absent for non-fixed plans.
+            Known values include `qstash_fixed_1m`, `qstash_fixed_10m`, `qstash_fixed_100m`, `qstash_fixed`.
+            Enterprise accounts may use the prefix `enterprise:` followed by an identifier (e.g. `enterprise:acme`).
+          example: ""
+        reserved_price:
+          type: integer
+          description: Reserved plan price (may be `0`)
+          example: 0
+        created_by:
+          type: string
+          description: Email of the user who created this account
+          example: cahidarda@upstash.com
+        creation_time:
+          type: integer
+          format: int64
+          description: Unix timestamp of account creation
+          example: 1781871358
+        deletion_time:
+          type: integer
+          format: int64
+          description: Unix timestamp of account deletion (`0` if not deleted)
+          example: 0
+        budget:
+          type: integer
+          description: Monthly spending budget limit in dollars. 0 means no limit.
+          example: 0
         enterprise:
           type: object
           description: Present for enterprise accounts
@@ -3098,24 +3101,6 @@ components:
               type: boolean
               description: Whether enterprise features are enabled
               example: true
-        region:
-          type: string
-          description: Region where the QStash instance is deployed
-          enum: [eu-central-1, us-east-1]
-          example: us-east-1
-        budget:
-          type: integer
-          description: Monthly spending budget limit in dollars. 0 means no limit.
-          example: 0
-        created_by:
-          type: string
-          description: Email of the user who created this account
-          example: example@upstash.com
-        creation_time:
-          type: integer
-          format: int64
-          description: Unix timestamp of account creation
-          example: 1760423113
     QStashStats:
       type: object
       properties:


### PR DESCRIPTION
Align the QStashUser schema (shared by GET /qstash/users and GET /qstash/user/{id}) with backend response: add the missing read_only_token, modifying_state, max_bandwidth_per_second, reserved_price, deletion_time and budget fields; drop completion-token, retention and rate_limit fields; and correct example values.
