### PR TITLE
fix: redirect legacy doc URLs that 404 to current paths

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2134,6 +2134,66 @@
     {
       "source": "/docs/redis/examples",
       "destination": "https://upstash.com/examples"
+    },
+    {
+      "source": "/redis/howto/developerapi",
+      "destination": "/common/account/developerapi"
+    },
+    {
+      "source": "/redis/account/developerapi",
+      "destination": "/common/account/developerapi"
+    },
+    {
+      "source": "/redis/sdks/redis-ts/getstarted",
+      "destination": "/redis/sdks/ts/getstarted"
+    },
+    {
+      "source": "/redis/sdks/javascriptsdk/overview",
+      "destination": "/redis/sdks/ts/overview"
+    },
+    {
+      "source": "/redis/sdks/javascriptsdk/troubleshooting",
+      "destination": "/redis/sdks/ts/troubleshooting"
+    },
+    {
+      "source": "/redis/sdks/overview",
+      "destination": "/redis/sdks/ts/overview"
+    },
+    {
+      "source": "/redis/howto/connectwithtls",
+      "destination": "/redis/howto/connect-client"
+    },
+    {
+      "source": "/howto/connectwithtls",
+      "destination": "/redis/howto/connect-client"
+    },
+    {
+      "source": "/docs/howto/connectwithtls",
+      "destination": "/redis/howto/connect-client"
+    },
+    {
+      "source": "/features/restapi",
+      "destination": "/redis/features/restapi"
+    },
+    {
+      "source": "/help/support",
+      "destination": "/common/help/support"
+    },
+    {
+      "source": "/redis/integration/n8n",
+      "destination": "/redis/integrations/n8n"
+    },
+    {
+      "source": "/vector/features/semanticcache",
+      "destination": "/vector/sdk/semantic-cache-js"
+    },
+    {
+      "source": "/qstash/api/messages/create",
+      "destination": "/qstash/api-reference/messages/publish-a-message"
+    },
+    {
+      "source": "/context7",
+      "destination": "https://context7.com/docs/overview"
     }
   ]
 }


### PR DESCRIPTION
Recovers high-authority backlinks (Cloudflare, StackOverflow, Docker Hub, jsDelivr, pub.dev, Railway, Pulumi, habr, zenn, val.town, eesel, azion) that pointed at doc paths orphaned by the docs restructure.