### PR TITLE
DX-2834: add Upstash Redis MCP docs page

### DIFF
--- a/agent-resources/mcp.mdx
+++ b/agent-resources/mcp.mdx
@@ -4,7 +4,11 @@ title: MCP Server
 
 The Upstash MCP server lets your agent manage and debug your Upstash resources directly, across Redis, QStash, Workflow, and [Upstash Box](/box/overall/quickstart).
 
-Find the GitHub repository [here](https://github.com/upstash/mcp).
+<Tip>
+  Only running commands against a single Redis database? Use the dedicated [Redis MCP](/redis/integrations/mcp) with only your REST/TCP credentials.
+</Tip>
+
+Find the GitHub repository [here](https://github.com/upstash/mcp-server).
 
 <Note>
   For most workflows, prefer installing the [Upstash Skill](/agent-resources/skills) and letting your agent drive [`@upstash/cli`](/agent-resources/cli) over running the MCP server.

--- a/docs.json
+++ b/docs.json
@@ -2103,10 +2103,6 @@
       "destination": "/agent-resources/cli"
     },
     {
-      "source": "/redis/integrations/mcp",
-      "destination": "/agent-resources/mcp"
-    },
-    {
       "source": "/qstash/api-refence/:slug*",
       "destination": "/qstash/api-reference/:slug*"
     },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -269,7 +269,11 @@ Source: https://upstash.com/docs/agent-resources/mcp
 
 The Upstash MCP server lets your agent manage and debug your Upstash resources directly, across Redis, QStash, Workflow, and [Upstash Box](/docs/box/overall/quickstart).
 
-Find the GitHub repository [here](https://github.com/upstash/mcp).
+<Tip>
+  Only running commands against a single Redis database? Use the dedicated [Redis MCP](/docs/redis/integrations/mcp) with only your REST/TCP credentials.
+</Tip>
+
+Find the GitHub repository [here](https://github.com/upstash/mcp-server).
 
 <Note>
   For most workflows, prefer installing the [Upstash Skill](/docs/agent-resources/skills) and letting your agent drive [`@upstash/cli`](/docs/agent-resources/cli) over running the MCP server.
@@ -19561,8 +19565,101 @@ await db.$cache?.invalidate({ tags: ["custom_key"] })
 
 For more details on this integration, refer to the [Drizzle ORM caching documentation](https://cache.drizzle-orm-fe.pages.dev/docs/cache).
 
-# Upstash MCP
+# Upstash Redis MCP
 Source: https://upstash.com/docs/redis/integrations/mcp
+
+The Upstash Redis MCP server connects your agent directly to a Redis database. It is lightweight and ships with just two tools:
+
+* **`redis_run_commands`**: run any Redis command (including the `SEARCH.*` family), as a pipeline or an atomic transaction.
+* **`redis_search_docs`**: search the Upstash Redis docs live, so the agent can look up commands and features on demand.
+
+Find the GitHub repository [here](https://github.com/upstash/redis-mcp).
+
+<Note>
+  To manage your whole Upstash account (create databases, read QStash and Workflow logs, drive Upstash Box), use the [Upstash MCP server](/docs/agent-resources/mcp) instead.
+</Note>
+
+# Installation
+
+Grab your database's REST URL and token from the [Upstash Console](https://console.upstash.com) (open your Redis database and copy `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` from the **REST API** section), then add the server to your MCP client.
+
+To connect over TCP instead, set `UPSTASH_REDIS_TCP_URL` to your `rediss://` connection string in place of the two REST variables.
+
+<AccordionGroup>
+  <Accordion title="Claude Code">
+    ```sh
+    claude mcp add upstash-redis \
+      -e UPSTASH_REDIS_REST_URL=https://YOUR_DB.upstash.io \
+      -e UPSTASH_REDIS_REST_TOKEN=YOUR_REST_TOKEN \
+      -- npx -y @upstash/redis-mcp
+    ```
+  </Accordion>
+
+  <Accordion title="Cursor">
+    [![Add to Cursor]()](https://cursor.com/install-mcp?name=upstash-redis&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB1cHN0YXNoL3JlZGlzLW1jcCJdfQ==)
+
+    ```json
+    {
+      "mcpServers": {
+        "upstash-redis": {
+          "command": "npx",
+          "args": ["-y", "@upstash/redis-mcp"],
+          "env": {
+            "UPSTASH_REDIS_REST_URL": "https://YOUR_DB.upstash.io",
+            "UPSTASH_REDIS_REST_TOKEN": "YOUR_REST_TOKEN"
+          }
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="VS Code">
+    ```json
+    {
+      "servers": {
+        "upstash-redis": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@upstash/redis-mcp"],
+          "env": {
+            "UPSTASH_REDIS_REST_URL": "https://YOUR_DB.upstash.io",
+            "UPSTASH_REDIS_REST_TOKEN": "YOUR_REST_TOKEN"
+          }
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="OpenAI Codex">
+    ```toml
+    [mcp_servers.upstash-redis]
+    command = "npx"
+    args = ["-y", "@upstash/redis-mcp"]
+    env = { UPSTASH_REDIS_REST_URL = "https://YOUR_DB.upstash.io", UPSTASH_REDIS_REST_TOKEN = "YOUR_REST_TOKEN" }
+    ```
+  </Accordion>
+
+  <Accordion title="OpenCode">
+    ```json
+    {
+      "mcp": {
+        "upstash-redis": {
+          "type": "local",
+          "command": ["npx", "-y", "@upstash/redis-mcp"],
+          "environment": {
+            "UPSTASH_REDIS_REST_URL": "https://YOUR_DB.upstash.io",
+            "UPSTASH_REDIS_REST_TOKEN": "YOUR_REST_TOKEN"
+          }
+        }
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+Any MCP-compatible client works. If yours isn't listed, add a stdio server that runs `npx -y @upstash/redis-mcp` with the two env vars above.
 
 # n8n with Upstash Redis
 Source: https://upstash.com/docs/redis/integrations/n8n
@@ -21024,7 +21121,7 @@ Congratulations! You have created an ultra-fast Upstash Redis database! 🎉
 <Check>
 **New: Manage Upstash Redis with your agent**
 
-Manage Upstash Redis databases from Claude and other AI tools by using our [MCP server](/docs/agent-resources/mcp).
+Manage Upstash Redis databases from Claude and other AI tools by using our [MCP server](/docs/agent-resources/mcp). To let an agent run commands directly against a single database, use the dedicated [Redis MCP](/docs/redis/integrations/mcp).
 </Check>
 
 ## Next steps

--- a/llms.txt
+++ b/llms.txt
@@ -311,7 +311,7 @@
 - [BullMQ with Upstash Redis](https://upstash.com/docs/redis/integrations/bullmq.md)
 - [Celery with Upstash Redis](https://upstash.com/docs/redis/integrations/celery.md)
 - [DrizzleORM with Upstash Redis](https://upstash.com/docs/redis/integrations/drizzle.md)
-- [Upstash MCP](https://upstash.com/docs/redis/integrations/mcp.md)
+- [Upstash Redis MCP](https://upstash.com/docs/redis/integrations/mcp.md)
 - [n8n with Upstash Redis](https://upstash.com/docs/redis/integrations/n8n.md)
 - [Prometheus - Upstash Redis Integration](https://upstash.com/docs/redis/integrations/prometheus.md)
 - [Configure Upstash Ratelimit Strapi Plugin](https://upstash.com/docs/redis/integrations/ratelimit/strapi/configurations.md)

--- a/redis/integrations/mcp.mdx
+++ b/redis/integrations/mcp.mdx
@@ -1,5 +1,97 @@
 ---
-title: "Upstash MCP"
+title: "Upstash Redis MCP"
 sidebarTitle: "MCP"
-url: "/agent-resources/mcp"
 ---
+
+The Upstash Redis MCP server connects your agent directly to a Redis database. It is lightweight and ships with just two tools:
+
+* **`redis_run_commands`**: run any Redis command (including the `SEARCH.*` family), as a pipeline or an atomic transaction.
+* **`redis_search_docs`**: search the Upstash Redis docs live, so the agent can look up commands and features on demand.
+
+Find the GitHub repository [here](https://github.com/upstash/redis-mcp).
+
+<Note>
+  To manage your whole Upstash account (create databases, read QStash and Workflow logs, drive Upstash Box), use the [Upstash MCP server](/agent-resources/mcp) instead.
+</Note>
+
+# Installation
+
+Grab your database's REST URL and token from the [Upstash Console](https://console.upstash.com) (open your Redis database and copy `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` from the **REST API** section), then add the server to your MCP client.
+
+To connect over TCP instead, set `UPSTASH_REDIS_TCP_URL` to your `rediss://` connection string in place of the two REST variables.
+
+<AccordionGroup>
+  <Accordion title="Claude Code">
+    ```sh
+    claude mcp add upstash-redis \
+      -e UPSTASH_REDIS_REST_URL=https://YOUR_DB.upstash.io \
+      -e UPSTASH_REDIS_REST_TOKEN=YOUR_REST_TOKEN \
+      -- npx -y @upstash/redis-mcp
+    ```
+  </Accordion>
+
+  <Accordion title="Cursor">
+    [![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=upstash-redis&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB1cHN0YXNoL3JlZGlzLW1jcCJdfQ==)
+
+    ```json
+    {
+      "mcpServers": {
+        "upstash-redis": {
+          "command": "npx",
+          "args": ["-y", "@upstash/redis-mcp"],
+          "env": {
+            "UPSTASH_REDIS_REST_URL": "https://YOUR_DB.upstash.io",
+            "UPSTASH_REDIS_REST_TOKEN": "YOUR_REST_TOKEN"
+          }
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="VS Code">
+    ```json
+    {
+      "servers": {
+        "upstash-redis": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@upstash/redis-mcp"],
+          "env": {
+            "UPSTASH_REDIS_REST_URL": "https://YOUR_DB.upstash.io",
+            "UPSTASH_REDIS_REST_TOKEN": "YOUR_REST_TOKEN"
+          }
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="OpenAI Codex">
+    ```toml
+    [mcp_servers.upstash-redis]
+    command = "npx"
+    args = ["-y", "@upstash/redis-mcp"]
+    env = { UPSTASH_REDIS_REST_URL = "https://YOUR_DB.upstash.io", UPSTASH_REDIS_REST_TOKEN = "YOUR_REST_TOKEN" }
+    ```
+  </Accordion>
+
+  <Accordion title="OpenCode">
+    ```json
+    {
+      "mcp": {
+        "upstash-redis": {
+          "type": "local",
+          "command": ["npx", "-y", "@upstash/redis-mcp"],
+          "environment": {
+            "UPSTASH_REDIS_REST_URL": "https://YOUR_DB.upstash.io",
+            "UPSTASH_REDIS_REST_TOKEN": "YOUR_REST_TOKEN"
+          }
+        }
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+Any MCP-compatible client works. If yours isn't listed, add a stdio server that runs `npx -y @upstash/redis-mcp` with the two env vars above.

--- a/redis/overall/getstarted.mdx
+++ b/redis/overall/getstarted.mdx
@@ -75,7 +75,7 @@ Congratulations! You have created an ultra-fast Upstash Redis database! 🎉
 <Check>
 **New: Manage Upstash Redis with your agent**
 
-Manage Upstash Redis databases from Claude and other AI tools by using our [MCP server](/agent-resources/mcp).
+Manage Upstash Redis databases from Claude and other AI tools by using our [MCP server](/agent-resources/mcp). To let an agent run commands directly against a single database, use the dedicated [Redis MCP](/redis/integrations/mcp).
 </Check>
 
 ## Next steps


### PR DESCRIPTION
## Summary

Documents the newly published `@upstash/redis-mcp` under Redis > Integrations.

## Changes

- New `redis/integrations/mcp` page: capabilities + per-client install (was a redirect stub).
- Removed the stale `docs.json` redirect that sent `/redis/integrations/mcp` to the account MCP page. Without this, the nav link bounces users off the new page.
- Linked the Redis MCP from the MCP Server page and the Redis get-started page.

## Testing

Rendered locally with `mintlify dev`; both pages compile and `docs.json` validates.