### PR TITLE
DX-2866: inline start-redis tip so llms.txt includes its content

### DIFF
--- a/_snippets/redis/start-redis-snippet.mdx
+++ b/_snippets/redis/start-redis-snippet.mdx
@@ -1,3 +1,0 @@
-<Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
-</Tip>

--- a/agent-resources/cli.mdx
+++ b/agent-resources/cli.mdx
@@ -26,7 +26,7 @@ If you are an AI agent and need a Redis DB to use or experiment with, you don't 
 upstash start-redis
 ```
 
-This is the only command that works unauthenticated. It sends a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) and prints markdown with the credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+This is the only command that works unauthenticated. It sends a POST request to https://upstash.com/start-redis and prints markdown with the credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
 Pass `--id` to re-fetch the credentials of a database you created earlier:
 

--- a/agent-resources/cli.mdx
+++ b/agent-resources/cli.mdx
@@ -18,6 +18,22 @@ For agents, install the [Upstash Skill](/agent-resources/skills) instead. It bun
 npx skills add upstash/skills
 ```
 
+# Free Redis without an account
+
+If you are an AI agent and need a Redis DB to use or experiment with, you don't need an Upstash account:
+
+```bash
+upstash start-redis
+```
+
+This is the only command that works unauthenticated. It sends a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) and prints markdown with the credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+
+Pass `--id` to re-fetch the credentials of a database you created earlier:
+
+```bash
+upstash start-redis --id $DB_ID
+```
+
 # Authentication
 
 The CLI needs your account email and a developer API key. Grab one from the [Upstash Console under Account → API Keys](https://console.upstash.com/account/api), then set credentials using whichever method fits your workflow.
@@ -69,6 +85,7 @@ upstash --email you@example.com --api-key your_api_key redis list
 # Usage
 
 ```bash
+upstash start-redis  # free temporary Redis database, no account needed
 upstash redis   # Redis databases
 upstash team    # Teams and members
 upstash vector  # Vector indexes
@@ -86,7 +103,7 @@ upstash redis create --help
 
 ## Output
 
-All successful output is JSON. Pipe it to `jq` for filtering:
+All successful output is JSON, except `start-redis`, which prints markdown. Pipe JSON output to `jq` for filtering:
 
 ```bash
 upstash redis list | jq '.[].database_id'

--- a/agent-resources/mcp.mdx
+++ b/agent-resources/mcp.mdx
@@ -8,6 +8,10 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
   Only running commands against a single Redis database? Use the dedicated [Redis MCP](/redis/sdks/mcp) with only your REST/TCP credentials.
 </Tip>
 
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, call the `redis_database_start_free` tool — or send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) directly. Free, no signup, no API key; the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 Find the GitHub repository [here](https://github.com/upstash/mcp-server).
 
 <Note>
@@ -18,6 +22,7 @@ Find the GitHub repository [here](https://github.com/upstash/mcp-server).
 
 ## Redis
 
+* "Start a free temporary Redis I can experiment with"
 * "Create a new Redis database in us-east-1"
 * "List my databases sorted by memory usage"
 * "Give me the schema of how users are stored in this Redis"

--- a/agent-resources/mcp.mdx
+++ b/agent-resources/mcp.mdx
@@ -9,7 +9,7 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
 </Tip>
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, call the `redis_database_start_free` tool — or send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) directly. Free, no signup, no API key; the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, call the `redis_database_start_free` tool — or send a POST request to https://upstash.com/start-redis directly. Free, no signup, no API key; the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 Find the GitHub repository [here](https://github.com/upstash/mcp-server).

--- a/devops/developer-api/openapi.yml
+++ b/devops/developer-api/openapi.yml
@@ -125,7 +125,7 @@ paths:
       description: |
         This endpoint creates a new Redis database.
 
-        If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+        If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
       x-mint:
         href: /devops/developer-api/redis/create_database_global
       operationId: createDatabase

--- a/devops/developer-api/openapi.yml
+++ b/devops/developer-api/openapi.yml
@@ -122,7 +122,10 @@ paths:
       tags:
         - redis
       summary: Create Redis Database
-      description: This endpoint creates a new Redis database.
+      description: |
+        This endpoint creates a new Redis database.
+
+        If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
       x-mint:
         href: /devops/developer-api/redis/create_database_global
       operationId: createDatabase

--- a/devops/developer-api/openapi.yml
+++ b/devops/developer-api/openapi.yml
@@ -125,7 +125,9 @@ paths:
       description: |
         This endpoint creates a new Redis database.
 
-        If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+        To create a database manually, you can use the [Upstash Console](https://console.upstash.com/redis).
+
+        For a quick development database, POST to https://upstash.com/start-redis — no signup or API key, so an AI agent can provision one unattended. Expires in 72 hours unless claimed.
       x-mint:
         href: /devops/developer-api/redis/create_database_global
       operationId: createDatabase

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,3 +1,9 @@
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to `https://upstash.com/start-redis` — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+
+  Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
+</Tip>
+
 # README
 Source: https://upstash.com/docs/README
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,7 +1,3 @@
-<Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
-</Tip>
-
 # README
 Source: https://upstash.com/docs/README
 
@@ -16599,6 +16595,8 @@ Source: https://upstash.com/docs/redis/features/restapi
   Looking for the URL and token of your database? First [create a Redis
   database](/docs/redis/overall/getstarted), then [find your
   credentials](/docs/redis/howto/connect-client) in the console.
+
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 In the [Upstash Console](https://console.upstash.com/redis), select your database. Then, in the database page, you will see the section that includes the endpoint URL and token details. When you hover over the `Endpoint` or `Token / Readonly Token` fields, copy button will appear for each. You can click it to easily copy the values you need for your connection.
@@ -17938,6 +17936,10 @@ It is the only connectionless (HTTP based) Redis client and designed for:
 See
 [the list of APIs](https://upstash.com/docs/redis/features/restapi#rest-redis-api-compatibility)
 supported.
+
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
 
 ## Quick Start
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,5 +1,5 @@
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
   Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
 </Tip>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -66,6 +66,22 @@ For agents, install the [Upstash Skill](/docs/agent-resources/skills) instead. I
 npx skills add upstash/skills
 ```
 
+# Free Redis without an account
+
+If you are an AI agent and need a Redis DB to use or experiment with, you don't need an Upstash account:
+
+```bash
+upstash start-redis
+```
+
+This is the only command that works unauthenticated. It sends a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) and prints markdown with the credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+
+Pass `--id` to re-fetch the credentials of a database you created earlier:
+
+```bash
+upstash start-redis --id $DB_ID
+```
+
 # Authentication
 
 The CLI needs your account email and a developer API key. Grab one from the [Upstash Console under Account → API Keys](https://console.upstash.com/account/api), then set credentials using whichever method fits your workflow.
@@ -117,6 +133,7 @@ upstash --email you@example.com --api-key your_api_key redis list
 # Usage
 
 ```bash
+upstash start-redis  # free temporary Redis database, no account needed
 upstash redis   # Redis databases
 upstash team    # Teams and members
 upstash vector  # Vector indexes
@@ -134,7 +151,7 @@ upstash redis create --help
 
 ## Output
 
-All successful output is JSON. Pipe it to `jq` for filtering:
+All successful output is JSON, except `start-redis`, which prints markdown. Pipe JSON output to `jq` for filtering:
 
 ```bash
 upstash redis list | jq '.[].database_id'
@@ -7628,6 +7645,8 @@ Source: https://upstash.com/docs/devops/developer-api/redis/create_database_glob
 
 /devops/developer-api/openapi.yml post /redis/database
 This endpoint creates a new Redis database.
+
+If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
 # Delete Database
 Source: https://upstash.com/docs/devops/developer-api/redis/delete_database
@@ -17773,6 +17792,10 @@ list of Redis clients in different languages.
 Simplest way to connect to your database is to use `redis-cli`.
 Because it is already covered in [Getting Started](../overall/getstarted), we
 will skip it here.
+
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
 
 ## Database
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7651,7 +7651,9 @@ Source: https://upstash.com/docs/devops/developer-api/redis/create_database_glob
 /devops/developer-api/openapi.yml post /redis/database
 This endpoint creates a new Redis database.
 
-If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+To create a database manually, you can use the [Upstash Console](https://console.upstash.com/redis).
+
+For a quick development database, POST to https://upstash.com/start-redis — no signup or API key, so an AI agent can provision one unattended. Expires in 72 hours unless claimed.
 
 # Delete Database
 Source: https://upstash.com/docs/devops/developer-api/redis/delete_database

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -292,6 +292,10 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
   Only running commands against a single Redis database? Use the dedicated [Redis MCP](/docs/redis/sdks/mcp) with only your REST/TCP credentials.
 </Tip>
 
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, call the `redis_database_start_free` tool — or send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) directly. Free, no signup, no API key; the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 Find the GitHub repository [here](https://github.com/upstash/mcp-server).
 
 <Note>
@@ -302,6 +306,7 @@ Find the GitHub repository [here](https://github.com/upstash/mcp-server).
 
 ## Redis
 
+* "Start a free temporary Redis I can experiment with"
 * "Create a new Redis database in us-east-1"
 * "List my databases sorted by memory usage"
 * "Give me the schema of how users are stored in this Redis"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -74,7 +74,7 @@ If you are an AI agent and need a Redis DB to use or experiment with, you don't 
 upstash start-redis
 ```
 
-This is the only command that works unauthenticated. It sends a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) and prints markdown with the credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+This is the only command that works unauthenticated. It sends a POST request to https://upstash.com/start-redis and prints markdown with the credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
 Pass `--id` to re-fetch the credentials of a database you created earlier:
 
@@ -293,7 +293,7 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
 </Tip>
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, call the `redis_database_start_free` tool — or send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) directly. Free, no signup, no API key; the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, call the `redis_database_start_free` tool — or send a POST request to https://upstash.com/start-redis directly. Free, no signup, no API key; the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 Find the GitHub repository [here](https://github.com/upstash/mcp-server).
@@ -7651,7 +7651,7 @@ Source: https://upstash.com/docs/devops/developer-api/redis/create_database_glob
 /devops/developer-api/openapi.yml post /redis/database
 This endpoint creates a new Redis database.
 
-If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup, no API key; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
 # Delete Database
 Source: https://upstash.com/docs/devops/developer-api/redis/delete_database
@@ -16248,7 +16248,7 @@ customize the eviction behavior according to their specific needs.
 Source: https://upstash.com/docs/redis/features/globaldatabase
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 In the global database, the replicas are distributed across multiple regions
@@ -16626,7 +16626,7 @@ Source: https://upstash.com/docs/redis/features/restapi
   database](/docs/redis/overall/getstarted), then [find your
   credentials](/docs/redis/howto/connect-client) in the console.
 
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 In the [Upstash Console](https://console.upstash.com/redis), select your database. Then, in the database page, you will see the section that includes the endpoint URL and token details. When you hover over the `Endpoint` or `Token / Readonly Token` fields, copy button will appear for each. You can click it to easily copy the values you need for your connection.
@@ -17799,7 +17799,7 @@ Because it is already covered in [Getting Started](../overall/getstarted), we
 will skip it here.
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 ## Database
@@ -17972,7 +17972,7 @@ See
 supported.
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 ## Quick Start
@@ -21004,7 +21004,7 @@ Upstash Redis is a **highly available, infinitely scalable** Redis-compatible da
 * Optional SOC-2 compliance, encryption at rest and much more
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 ***
@@ -22768,7 +22768,7 @@ redis = Redis(
 Source: https://upstash.com/docs/redis/sdks/py/gettingstarted
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 ## Install
@@ -25179,7 +25179,7 @@ and for his continued efforts to keep it up to date with Upstash.
 Source: https://upstash.com/docs/redis/sdks/ts/getstarted
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 `@upstash/redis` is written in Deno and can be imported from

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,5 +1,5 @@
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to `https://upstash.com/start-redis` — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
   Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
 </Tip>

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,5 @@
 # Upstash Documentation
 
-<Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
-</Tip>
-
 ## Docs
 
 - [README](https://upstash.com/docs/README.md)

--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,11 @@
 # Upstash Documentation
 
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to `https://upstash.com/start-redis` — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+
+  Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
+</Tip>
+
 ## Docs
 
 - [README](https://upstash.com/docs/README.md)

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # Upstash Documentation
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
   Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
 </Tip>

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # Upstash Documentation
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to `https://upstash.com/start-redis` — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
   Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
 </Tip>

--- a/llms/src/build.ts
+++ b/llms/src/build.ts
@@ -46,10 +46,16 @@ const FULL_TXT_SKIP = [
 ];
 
 /**
- * Snippet injected at the top of both llms.txt and llms-full.txt. Surfaces
- * the "free scratch Redis DB" hint to AI agents reading the bundle.
+ * Preamble injected at the top of both llms.txt and llms-full.txt. Surfaces
+ * the "free scratch Redis DB" hint and agent tooling to AI agents reading
+ * the bundle. Inlined here (rather than referencing a `_snippets/` file) so
+ * the text always lands in the generated output.
  */
-const PREAMBLE_SNIPPET = "redis/start-redis-snippet.mdx";
+const PREAMBLE = `<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to \`https://upstash.com/start-redis\` — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+
+  Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
+</Tip>`;
 
 interface Entry {
   title: string;
@@ -160,8 +166,7 @@ function addOrphanMdxFiles(): void {
 
 function writeLlmsTxt(): void {
   const lines: string[] = ["# Upstash Documentation", ""];
-  const preamble = loadSnippet(PREAMBLE_SNIPPET);
-  if (preamble) lines.push(preamble, "");
+  lines.push(PREAMBLE, "");
   lines.push("## Docs", "");
   for (const e of entries) {
     const url = `${SITE_URL}/${e.path}.md`;
@@ -201,8 +206,7 @@ function writeLlmsFullTxt(): void {
   // contributes; pages always carry leading/trailing blanks so they stay
   // visually separated from neighbours.
   const chunks: string[] = [];
-  const preamble = loadSnippet(PREAMBLE_SNIPPET);
-  if (preamble) chunks.push(`${preamble}\n\n`);
+  chunks.push(`${PREAMBLE}\n\n`);
   for (const e of entries) {
     if (isExcludedFromFullTxt(e.path)) {
       const url = `${SITE_URL}/${e.path}.md`;

--- a/llms/src/build.ts
+++ b/llms/src/build.ts
@@ -52,7 +52,7 @@ const FULL_TXT_SKIP = [
  * the text always lands in the generated output.
  */
 const PREAMBLE = `<Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [\`https://upstash.com/start-redis\`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
   Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
 </Tip>`;

--- a/llms/src/build.ts
+++ b/llms/src/build.ts
@@ -52,7 +52,7 @@ const FULL_TXT_SKIP = [
  * the text always lands in the generated output.
  */
 const PREAMBLE = `<Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to \`https://upstash.com/start-redis\` — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [\`https://upstash.com/start-redis\`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 
   Upstash also provides an MCP server (/docs/agent-resources/mcp) to manage and debug your Upstash resources directly from an agent, and an agent-friendly CLI (/docs/agent-resources/cli) for your terminal or CI/CD pipelines.
 </Tip>`;

--- a/redis/features/globaldatabase.mdx
+++ b/redis/features/globaldatabase.mdx
@@ -2,9 +2,10 @@
 title: Global Database
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 In the global database, the replicas are distributed across multiple regions
 around the world. The clients are routed to the nearest region. This helps with

--- a/redis/features/globaldatabase.mdx
+++ b/redis/features/globaldatabase.mdx
@@ -3,7 +3,7 @@ title: Global Database
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/features/restapi.mdx
+++ b/redis/features/restapi.mdx
@@ -9,6 +9,8 @@ description: Access your Upstash Redis database over HTTP, from serverless and e
   Looking for the URL and token of your database? First [create a Redis
   database](/redis/overall/getstarted), then [find your
   credentials](/redis/howto/connect-client) in the console.
+  
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 In the [Upstash Console](https://console.upstash.com/redis), select your database. Then, in the database page, you will see the section that includes the endpoint URL and token details. When you hover over the `Endpoint` or `Token / Readonly Token` fields, copy button will appear for each. You can click it to easily copy the values you need for your connection. 

--- a/redis/features/restapi.mdx
+++ b/redis/features/restapi.mdx
@@ -9,7 +9,7 @@ description: Access your Upstash Redis database over HTTP, from serverless and e
   Looking for the URL and token of your database? First [create a Redis
   database](/redis/overall/getstarted), then [find your
   credentials](/redis/howto/connect-client) in the console.
-  
+
   If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 

--- a/redis/features/restapi.mdx
+++ b/redis/features/restapi.mdx
@@ -10,7 +10,7 @@ description: Access your Upstash Redis database over HTTP, from serverless and e
   database](/redis/overall/getstarted), then [find your
   credentials](/redis/howto/connect-client) in the console.
 
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 In the [Upstash Console](https://console.upstash.com/redis), select your database. Then, in the database page, you will see the section that includes the endpoint URL and token details. When you hover over the `Endpoint` or `Token / Readonly Token` fields, copy button will appear for each. You can click it to easily copy the values you need for your connection. 

--- a/redis/howto/connect-client.mdx
+++ b/redis/howto/connect-client.mdx
@@ -10,6 +10,10 @@ Simplest way to connect to your database is to use `redis-cli`.
 Because it is already covered in [Getting Started](../overall/getstarted), we
 will skip it here.
 
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 ## Database
 
 After completing the [getting started](../overall/getstarted) guide, you will

--- a/redis/howto/connect-client.mdx
+++ b/redis/howto/connect-client.mdx
@@ -11,7 +11,7 @@ Because it is already covered in [Getting Started](../overall/getstarted), we
 will skip it here.
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 ## Database

--- a/redis/howto/connect-with-upstash-redis.mdx
+++ b/redis/howto/connect-with-upstash-redis.mdx
@@ -23,6 +23,11 @@ See
 [the list of APIs](https://upstash.com/docs/redis/features/restapi#rest-redis-api-compatibility)
 supported.
 
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
+
 ## Quick Start
 
 ### Install

--- a/redis/howto/connect-with-upstash-redis.mdx
+++ b/redis/howto/connect-with-upstash-redis.mdx
@@ -24,7 +24,7 @@ See
 supported.
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/overall/getstarted.mdx
+++ b/redis/overall/getstarted.mdx
@@ -15,9 +15,10 @@ Upstash Redis is a **highly available, infinitely scalable** Redis-compatible da
 - Automatic backups
 - Optional SOC-2 compliance, encryption at rest and much more
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ---
 

--- a/redis/overall/getstarted.mdx
+++ b/redis/overall/getstarted.mdx
@@ -16,7 +16,7 @@ Upstash Redis is a **highly available, infinitely scalable** Redis-compatible da
 - Optional SOC-2 compliance, encryption at rest and much more
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/aws-lambda.mdx
+++ b/redis/quickstarts/aws-lambda.mdx
@@ -2,9 +2,10 @@
 title: "AWS Lambda"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/aws-cdk-typescript" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/aws-lambda.mdx
+++ b/redis/quickstarts/aws-lambda.mdx
@@ -3,7 +3,7 @@ title: "AWS Lambda"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/azure-functions.mdx
+++ b/redis/quickstarts/azure-functions.mdx
@@ -2,9 +2,10 @@
 title: "Azure Functions"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/azure-functions" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/azure-functions.mdx
+++ b/redis/quickstarts/azure-functions.mdx
@@ -3,7 +3,7 @@ title: "Azure Functions"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/cloudflareworkers.mdx
+++ b/redis/quickstarts/cloudflareworkers.mdx
@@ -2,9 +2,10 @@
 title: "Cloudflare Workers"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ### Database Setup
 

--- a/redis/quickstarts/cloudflareworkers.mdx
+++ b/redis/quickstarts/cloudflareworkers.mdx
@@ -3,7 +3,7 @@ title: "Cloudflare Workers"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/deno-deploy.mdx
+++ b/redis/quickstarts/deno-deploy.mdx
@@ -2,9 +2,10 @@
 title: "Deno Deploy"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 This is a step-by-step guide on how to use Upstash Redis to create a view
 counter in your Deno deploy project.

--- a/redis/quickstarts/deno-deploy.mdx
+++ b/redis/quickstarts/deno-deploy.mdx
@@ -3,7 +3,7 @@ title: "Deno Deploy"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/digitalocean.mdx
+++ b/redis/quickstarts/digitalocean.mdx
@@ -2,9 +2,10 @@
 title: "DigitalOcean"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Warning>
   Upstash Redis on DigitalOcean is deprecated and will be permanently shut down

--- a/redis/quickstarts/digitalocean.mdx
+++ b/redis/quickstarts/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/django.mdx
+++ b/redis/quickstarts/django.mdx
@@ -2,9 +2,10 @@
 title: "Django"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ### Introduction
 

--- a/redis/quickstarts/django.mdx
+++ b/redis/quickstarts/django.mdx
@@ -3,7 +3,7 @@ title: "Django"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/elixir.mdx
+++ b/redis/quickstarts/elixir.mdx
@@ -3,9 +3,10 @@ title: "Elixir"
 description: "Tutorial on Using Upstash Redis In Your Phoenix App and Deploying it on Fly."
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 This tutorial showcases how one can use [fly.io](https://fly.io) to deploy a Phoenix
 app using Upstash Redis to store results of external API calls.

--- a/redis/quickstarts/elixir.mdx
+++ b/redis/quickstarts/elixir.mdx
@@ -4,7 +4,7 @@ description: "Tutorial on Using Upstash Redis In Your Phoenix App and Deploying 
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/fastapi.mdx
+++ b/redis/quickstarts/fastapi.mdx
@@ -2,9 +2,10 @@
 title: "FastAPI"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/fastapi" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/fastapi.mdx
+++ b/redis/quickstarts/fastapi.mdx
@@ -3,7 +3,7 @@ title: "FastAPI"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/fastlycompute.mdx
+++ b/redis/quickstarts/fastlycompute.mdx
@@ -2,9 +2,10 @@
 title: "Fastly"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ### Database Setup
 

--- a/redis/quickstarts/fastlycompute.mdx
+++ b/redis/quickstarts/fastlycompute.mdx
@@ -3,7 +3,7 @@ title: "Fastly"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/flask.mdx
+++ b/redis/quickstarts/flask.mdx
@@ -2,9 +2,10 @@
 title: "Flask"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ### Introduction
 

--- a/redis/quickstarts/flask.mdx
+++ b/redis/quickstarts/flask.mdx
@@ -3,7 +3,7 @@ title: "Flask"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/fly.mdx
+++ b/redis/quickstarts/fly.mdx
@@ -2,9 +2,10 @@
 title: "Fly.io"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Info>
   Fly.io has a native integration with Upstash where the databases are hosted in

--- a/redis/quickstarts/fly.mdx
+++ b/redis/quickstarts/fly.mdx
@@ -3,7 +3,7 @@ title: "Fly.io"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/google-cloud-functions.mdx
+++ b/redis/quickstarts/google-cloud-functions.mdx
@@ -2,9 +2,10 @@
 title: "Google Cloud Functions"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/google-cloud-functions" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/google-cloud-functions.mdx
+++ b/redis/quickstarts/google-cloud-functions.mdx
@@ -3,7 +3,7 @@ title: "Google Cloud Functions"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/ion.mdx
+++ b/redis/quickstarts/ion.mdx
@@ -2,9 +2,10 @@
 title: "Ion"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/ion" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/ion.mdx
+++ b/redis/quickstarts/ion.mdx
@@ -3,7 +3,7 @@ title: "Ion"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/koyeb.mdx
+++ b/redis/quickstarts/koyeb.mdx
@@ -2,9 +2,10 @@
 title: "Koyeb"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 Integrate a serverless Upstash Redis database with your Koyeb applications. Combine the serverless features of Koyeb on the application side and Upstash for your key-value storage to deploy and scale applications globally with ease.
 

--- a/redis/quickstarts/koyeb.mdx
+++ b/redis/quickstarts/koyeb.mdx
@@ -3,7 +3,7 @@ title: "Koyeb"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/laravel.mdx
+++ b/redis/quickstarts/laravel.mdx
@@ -2,9 +2,10 @@
 title: "Laravel"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ## Project Setup
 

--- a/redis/quickstarts/laravel.mdx
+++ b/redis/quickstarts/laravel.mdx
@@ -3,7 +3,7 @@ title: "Laravel"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/nextjs-app-router.mdx
+++ b/redis/quickstarts/nextjs-app-router.mdx
@@ -2,9 +2,10 @@
 title: "App Router"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ---
 

--- a/redis/quickstarts/nextjs-app-router.mdx
+++ b/redis/quickstarts/nextjs-app-router.mdx
@@ -3,7 +3,7 @@ title: "App Router"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/nextjs-pages-router.mdx
+++ b/redis/quickstarts/nextjs-pages-router.mdx
@@ -2,9 +2,10 @@
 title: "Pages Router"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/nextjs-pages-router" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/nextjs-pages-router.mdx
+++ b/redis/quickstarts/nextjs-pages-router.mdx
@@ -3,7 +3,7 @@ title: "Pages Router"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/python-aws-lambda.mdx
+++ b/redis/quickstarts/python-aws-lambda.mdx
@@ -2,9 +2,10 @@
 title: " AWS Lambda"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/aws-cdk-python" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/python-aws-lambda.mdx
+++ b/redis/quickstarts/python-aws-lambda.mdx
@@ -3,7 +3,7 @@ title: " AWS Lambda"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/sst-v2.mdx
+++ b/redis/quickstarts/sst-v2.mdx
@@ -2,9 +2,10 @@
 title: "SST v2"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/sst-v2" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/sst-v2.mdx
+++ b/redis/quickstarts/sst-v2.mdx
@@ -3,7 +3,7 @@ title: "SST v2"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/supabase.mdx
+++ b/redis/quickstarts/supabase.mdx
@@ -2,9 +2,10 @@
 title: "Supabase Functions"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 The below is an example for a Redis counter that stores a
 [hash](https://redis.io/commands/hincrby/) of Supabase function invocation count

--- a/redis/quickstarts/supabase.mdx
+++ b/redis/quickstarts/supabase.mdx
@@ -3,7 +3,7 @@ title: "Supabase Functions"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/vercel-functions-app-router.mdx
+++ b/redis/quickstarts/vercel-functions-app-router.mdx
@@ -2,9 +2,10 @@
 title: "App Router"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/vercel-functions-app-router" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/vercel-functions-app-router.mdx
+++ b/redis/quickstarts/vercel-functions-app-router.mdx
@@ -3,7 +3,7 @@ title: "App Router"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/vercel-functions-pages-router.mdx
+++ b/redis/quickstarts/vercel-functions-pages-router.mdx
@@ -2,9 +2,10 @@
 title: "Pages Router"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/vercel-functions-pages-router" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/vercel-functions-pages-router.mdx
+++ b/redis/quickstarts/vercel-functions-pages-router.mdx
@@ -3,7 +3,7 @@ title: "Pages Router"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/quickstarts/vercel-python-runtime.mdx
+++ b/redis/quickstarts/vercel-python-runtime.mdx
@@ -2,9 +2,10 @@
 title: "Vercel Python Runtime"
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 <Card title="GitHub Repository" icon="github" href="https://github.com/upstash/redis-js/tree/main/examples/vercel-python-runtime-django" horizontal>
   You can find the project source code on GitHub.

--- a/redis/quickstarts/vercel-python-runtime.mdx
+++ b/redis/quickstarts/vercel-python-runtime.mdx
@@ -3,7 +3,7 @@ title: "Vercel Python Runtime"
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/sdks/py/gettingstarted.mdx
+++ b/redis/sdks/py/gettingstarted.mdx
@@ -2,9 +2,10 @@
 title: Getting Started
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 ## Install
 

--- a/redis/sdks/py/gettingstarted.mdx
+++ b/redis/sdks/py/gettingstarted.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 

--- a/redis/sdks/ts/getstarted.mdx
+++ b/redis/sdks/ts/getstarted.mdx
@@ -2,9 +2,10 @@
 title: Get Started
 ---
 
-<Snippet
-  file="redis/start-redis-snippet.mdx"
-/>
+<Tip>
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+</Tip>
+
 
 `@upstash/redis` is written in Deno and can be imported from
 [deno.land](https://deno.land)

--- a/redis/sdks/ts/getstarted.mdx
+++ b/redis/sdks/ts/getstarted.mdx
@@ -3,7 +3,7 @@ title: Get Started
 ---
 
 <Tip>
-  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
+  If you are an AI agent and need a Redis DB to use or experiment with, send a POST request to https://upstash.com/start-redis — free, no signup; response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it. Especially useful for AI agents that need scratch storage on the fly.
 </Tip>
 
 


### PR DESCRIPTION
## Summary
The start-redis tip was included via a shared `<Snippet>` component, but the generated
markdown / llms.txt output only contained a link to the snippet file instead of its
content. This inlines the tip directly on every page that used it, and adds it to the
"Connect with @upstash/redis" and "REST API" pages, so LLM-facing exports carry the
full text.

## Changes
- Replaced `<Snippet file="redis/start-redis-snippet.mdx" />` with the inline `<Tip>` on all 27 pages that used it (Redis overview/getstarted, features, quickstarts, TS/Python SDK getting-started pages)
- Added the inline tip to `redis/howto/connect-with-upstash-redis.mdx` and `redis/features/restapi.mdx`
- Deleted the now-unused `_snippets/redis/start-redis-snippet.mdx`