### PR TITLE
DX-2806: fix landing sidebar mis-render at the root (footer-avoidance race)

### DIFF
--- a/script.js
+++ b/script.js
@@ -119,62 +119,45 @@ function initialize() {
 
 initialize();
 
-/* On hard loads of /introduction (mode: frame + custom landing content),
-   Mintlify sometimes mis-measures its fixed sidebar during hydration and sets a
-   negative inline `top` on #sidebar (e.g. -604px), leaving the sidebar stuck
-   under the header showing the tail of the nav. Any real scroll makes Mintlify
-   re-measure and snap it back, so reproduce that: scroll 1px down, restore next
-   frame. Nudge whenever the page lands on /introduction (Mintlify stamps
-   data-current-path on <html> after hydration / on SPA navs) and whenever
-   #sidebar's inline top goes negative — which is never a legitimate state. */
-let sidebarNudging = false;
-function nudgeSidebar() {
-  if (sidebarNudging) return;
-  sidebarNudging = true;
-  // double rAF: let any in-flight reflow finish before nudging
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      const x = window.scrollX;
-      const y = window.scrollY;
-      window.scrollTo(x, y + 1);
-      requestAnimationFrame(() => {
-        window.scrollTo(x, y);
-        window.dispatchEvent(new Event("resize"));
-        sidebarNudging = false;
-      });
-    });
-  });
-}
-
-function isSidebarBroken() {
+/* Mintlify positions the fixed #sidebar with an inline `top` computed in a
+   window "scroll" listener (handleFooterAndSidebarScrollTop): when the footer
+   enters the viewport it shifts the sidebar up (negative top) to clear it, and
+   nothing but another scroll event ever recomputes it. If the page height
+   changes after a measurement (the /introduction body is client-rendered, so
+   the pre-hydration page is short with the footer in view), the sidebar is
+   left stuck above the viewport. style.css reserves min-height:100vh on
+   #content so that short state can't be painted or measured in the first
+   place; this watcher is a backstop for residual cases (e.g. the browser
+   clamping a restored scroll position against the not-yet-grown page). Heal by
+   re-running Mintlify's own listener with a synthetic scroll event: no actual
+   scrolling, so nothing visibly moves - and unlike the old 1px scroll nudge it
+   also works when the page is too short to scroll at all, which is exactly the
+   state the bug is born in. */
+function sidebarLooksBroken() {
   const sidebar = document.getElementById("sidebar");
   if (!sidebar) return false;
   const top = parseFloat(sidebar.style.top);
   if (!(top < 0)) return false;
-  // Negative top is legitimate only while the footer is in (or near) view:
-  // Mintlify raises the sidebar to clear it, updating top on every scroll —
-  // nudging then loops against Mintlify's own updates and shakes the page.
-  // A negative top with the footer nowhere near the viewport is the
-  // hydration mis-measure (happens at any restored scroll position).
-  const footer = document.querySelector("footer");
+  // Negative top is legitimate while the footer is in (or near) view; broken
+  // is negative top with the footer nowhere near the viewport.
+  const footer = document.getElementById("footer");
   if (!footer) return true;
   return footer.getBoundingClientRect().top > window.innerHeight + 200;
 }
 
-function watchIntroductionSidebar() {
+function watchSidebar() {
   let watchedSidebar = null;
-  let autoRepairs = 0;
+  // cap repairs per page as a guard against fighting a future Mintlify version
+  let repairs = 0;
+  const repair = () => {
+    if (repairs++ < 10) window.dispatchEvent(new Event("scroll"));
+  };
+
   const styleObserver = new MutationObserver(() => {
-    // cap observer-driven repairs as a backstop against any feedback loop
-    if (autoRepairs < 5 && isSidebarBroken()) {
-      autoRepairs++;
-      nudgeSidebar();
-    }
+    if (sidebarLooksBroken()) repair();
   });
 
-  const check = () => {
-    const path = document.documentElement.getAttribute("data-current-path");
-    if (path !== "/introduction") return;
+  const attach = () => {
     // React can recreate #sidebar across SPA navs; re-attach when it changes
     const sidebar = document.getElementById("sidebar");
     if (sidebar && sidebar !== watchedSidebar) {
@@ -185,31 +168,22 @@ function watchIntroductionSidebar() {
         attributeFilter: ["style"],
       });
     }
-    if (isSidebarBroken()) nudgeSidebar();
+    if (sidebarLooksBroken()) repair();
   };
 
-  let lastPath = null;
   new MutationObserver(() => {
-    const path = document.documentElement.getAttribute("data-current-path");
-    if (path === lastPath) return;
-    lastPath = path;
-    if (path === "/introduction") {
-      autoRepairs = 0;
-      // landing on the page always gets one nudge: it also covers the reflow
-      // from style.css collapsing the ToC column after the attribute lands
-      nudgeSidebar();
-      check();
-    }
+    repairs = 0;
+    attach();
   }).observe(document.documentElement, {
     attributes: true,
     attributeFilter: ["data-current-path"],
   });
 
-  window.addEventListener("load", check);
-  check();
+  window.addEventListener("load", attach);
+  attach();
 }
 
-watchIntroductionSidebar();
+watchSidebar();
 
 function createCookieConsentBanner() {
   if (document.getElementById("cookie-consent-banner")) return;

--- a/style.css
+++ b/style.css
@@ -32,13 +32,10 @@
    data-current-path hook (only the /introduction page). NOTE: still targets
    Mintlify-internal ids (#content-area / #content-side-layout); revisit if a
    Mintlify upgrade renames them. Collapse to zero width, not display:none (which
-   broke the sticky sidebar, making it render scrolled on load). Even width:0 can
-   race Mintlify's sidebar measurement on load — script.js nudges a re-measure
-   (see nudgeSidebar) whenever data-current-path lands on /introduction.
+   broke the sticky sidebar, making it render scrolled on load).
    2026-07: production's renderer no longer has #content-side-layout (rule is
    inert there, frame mode fills the width natively now), but local `mint dev`
-   still renders it; keep until the CLI catches up. The sidebar mis-render still
-   happens on prod regardless of this rule — see script.js. */
+   still renders it; keep until the CLI catches up. */
 html[data-current-path="/introduction"] #content-side-layout {
   width: 0 !important;
   min-width: 0 !important;
@@ -47,6 +44,25 @@ html[data-current-path="/introduction"] #content-side-layout {
 }
 html[data-current-path="/introduction"] #content-area {
   width: 100% !important;
+}
+
+/* The landing body is client-rendered (imported MDX snippet components are not
+   SSR'd), so on a hard load the content area is empty at first paint. That let
+   the footer sit inside the viewport, where Mintlify's footer-avoidance —
+   which sets a negative inline `top` on the fixed #sidebar and only re-runs on
+   scroll — pinned the sidebar above the viewport; when the body then hydrated
+   and the footer moved out of view, nothing re-ran the handler and the sidebar
+   stayed stuck showing only the tail of the nav. Reserve a viewport of height
+   from the first paint so the footer can never be in view while the body is
+   still empty. Must be #content[data-page-href]: it is server-rendered with
+   the real path, while html[data-current-path] SSRs as "/" and is only stamped
+   after hydration - too late. Local `mint dev` stamps the attribute with its
+   build path ("/src/_props/introduction"), hence the second selector. Don't
+   collapse them into [data-page-href$="/introduction"]: that would also match
+   pages like /redis/search/introduction. Runtime backstop lives in script.js. */
+#content[data-page-href="/introduction"],
+#content[data-page-href="/src/_props/introduction"] {
+  min-height: 100vh;
 }
 
 


### PR DESCRIPTION
The custom docs landing (mode: frame, introduced in e7e3bec1 / #748) renders its body client-side, so on a hard load the page is short and the footer sits inside the viewport. Mintlify's footer-avoidance scroll handler then pins the fixed sidebar above the viewport (negative inline top) and only recomputes on a scroll event - once the body hydrates and the footer moves away, nothing re-runs it and the sidebar stays stuck showing the tail of the nav.

Replaces the scroll-nudge auto-repair (ba7a78b5 / #757), which repaired after the wrong paint (visible snap) and silently failed exactly when the bug is born: the pre-hydration page can be too short to scroll, so its 1px scroll fired no scroll event (and the resize event it also dispatched does not trigger Mintlify's handler at all).

- style.css: reserve min-height:100vh on #content for /introduction from the first paint, so the footer can never be in view while the body is empty and the bad measurement becomes impossible. Keyed on data-page-href, which is SSR'd with the real path (data-current-path SSRs as "/" and is stamped only after hydration - too late). Second selector covers local mint dev, which stamps the attribute as /src/_props/introduction.
- script.js: replace the nudge machinery with a small backstop that, if a stuck state ever appears (negative top with the footer far from view), re-runs Mintlify's own listener via a synthetic window scroll event - nothing visibly moves, and it works on an unscrollable page.