### PR TITLE
fix: agentkit eve extension requires eve >= 0.43.0

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8168,7 +8168,7 @@ Yes, we take regular snapshots of the data cluster to the AWS S3 platform.
 
 ## Does Upstash encrypt data?
 
-Customers can enable TLS when creating a database or cluster, and we recommend this for production environments. Additionally, we encrypt data at rest upon enabling the [Prod Pack add-on](https://upstash.com/docs/redis/overall/enterprise#prod-pack-features).
+Customers can enable TLS when creating a database or cluster, and we recommend this for production environments. Additionally, we encrypt data at rest upon enabling [Prod Pack add-on](https://upstash.com/docs/redis/overall/enterprise#prod-pack-features).
 
 # Legal
 Source: https://upstash.com/docs/common/help/legal
@@ -73157,8 +73157,9 @@ Two packages bring AgentKit to **Eve, the Vercel agent framework**. They work to
 Mount the extension for the bundled setup. Add the package when you need a rate-limit gate, an Upstash
 Box sandbox, or control over an individual tool file.
 
-Start from an eve project (0.25.2 or later). Scaffold one, which installs `eve` and an AI-SDK provider
-for you:
+Start from an eve project (**0.43.0 or later** — the published extension is prebuilt, and its
+compatibility manifest requires eve ≥ 0.43's contribution formats). Scaffold one, which installs `eve`
+and an AI-SDK provider for you:
 
 ```bash
 npx eve@latest init my-agent
@@ -73676,8 +73677,9 @@ Two packages bring AgentKit to **Eve, the Vercel agent framework**. They work to
 Mount the extension for the bundled setup. Add the package when you need a rate-limit gate, an Upstash
 Box sandbox, or control over an individual tool file.
 
-Start from an eve project (0.25.2 or later). Scaffold one, which installs `eve` and an AI-SDK provider
-for you:
+Start from an eve project (**0.43.0 or later** — the published extension is prebuilt, and its
+compatibility manifest requires eve ≥ 0.43's contribution formats). Scaffold one, which installs `eve`
+and an AI-SDK provider for you:
 
 ```bash
 npx eve@latest init my-agent

--- a/redis/sdks/agentkit/eve.mdx
+++ b/redis/sdks/agentkit/eve.mdx
@@ -18,8 +18,9 @@ Two packages bring AgentKit to **Eve, the Vercel agent framework**. They work to
 Mount the extension for the bundled setup. Add the package when you need a rate-limit gate, an Upstash
 Box sandbox, or control over an individual tool file.
 
-Start from an eve project (0.25.2 or later). Scaffold one, which installs `eve` and an AI-SDK provider
-for you:
+Start from an eve project (**0.43.0 or later** — the published extension is prebuilt, and its
+compatibility manifest requires eve ≥ 0.43's contribution formats). Scaffold one, which installs `eve`
+and an AI-SDK provider for you:
 
 ```bash
 npx eve@latest init my-agent


### PR DESCRIPTION
The published @upstash/agentkit-eve-extension dist is prebuilt and its compatibility manifest requires eve 0.43's contribution formats, so the page's "0.25.2 or later" requirement was stale (upstash/agentkit#22).