### PR TITLE
docs: sync agent-resources skills and MCP pages with upstash/skills

### DIFF
--- a/agent-resources/mcp.mdx
+++ b/agent-resources/mcp.mdx
@@ -197,6 +197,45 @@ The Upstash MCP server works with any MCP-compatible client. If your client isn'
     ```
   </Accordion>
 
+  <Accordion title="Zed">
+    The [`upstash/skills`](https://github.com/upstash/skills) repo ships a Zed MCP extension. Once it is listed in the [Zed extension registry](https://github.com/zed-industries/extensions), install **Upstash Redis MCP Server** from **Settings → AI → MCP Servers → Add Server → Install from Extensions**; Zed will prompt for `upstash_email` and `upstash_api_key`.
+
+    To skip the extension, add the server to your Zed settings by hand (`zed: open settings file`). See the [Zed MCP docs](https://zed.dev/docs/ai/mcp) for more info.
+
+    ```json
+    {
+      "context_servers": {
+        "upstash": {
+          "command": "npx",
+          "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+        }
+      }
+    }
+    ```
+
+    <Note>
+      Context servers are project-scoped in Zed. Open a folder before testing, otherwise the server never starts.
+    </Note>
+  </Accordion>
+
+  <Accordion title="DeepSeek Harness">
+    Installing the [Upstash Skill](/agent-resources/skills) as a DeepSeek Harness bundle also installs the MCP server. Requires `pnpm` on your `PATH`.
+
+    ```bash
+    # Install into a profile (`web` is the one `dsh web` boots)
+    dsh plugin --profile web add github:upstash/skills
+
+    # Start the harness
+    dsh web
+    ```
+
+    Then store your credentials from inside a session. The MCP server connects as soon as both are set; the skills work without them.
+
+    ```
+    /upstash-login YOUR_EMAIL YOUR_API_KEY
+    ```
+  </Accordion>
+
   <Accordion title="Gemini CLI">
     Open the Gemini CLI settings file at `~/.gemini/settings.json` and add Upstash to `mcpServers`. See [Gemini CLI Configuration](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html) for details.
 

--- a/agent-resources/skills.mdx
+++ b/agent-resources/skills.mdx
@@ -14,11 +14,14 @@ Find the GitHub repository [here](https://github.com/upstash/skills).
 
 | Skill | Description |
 |-------|-------------|
-| [upstash](https://github.com/upstash/skills/tree/main/skills/upstash) | Combined skill covering all Upstash SDKs and the `upstash-cli`. |
+| [upstash](https://github.com/upstash/skills/tree/main/skills/upstash) | Combined skill covering all Upstash SDKs and the `upstash` CLI. |
 | [upstash-box-js](https://github.com/upstash/skills/tree/main/skills/upstash-box-js) | Sandboxed cloud containers with AI agents, shell, filesystem, and git. |
+| [upstash-box-py](https://github.com/upstash/skills/tree/main/skills/upstash-box-py) | The same sandboxed cloud containers, from the Python SDK. |
+| [upstash-cli](https://github.com/upstash/skills/tree/main/skills/upstash-cli) | Drive the Upstash Developer API from the terminal with the [`upstash` CLI](/agent-resources/cli). |
 | [upstash-qstash-js](https://github.com/upstash/skills/tree/main/skills/upstash-qstash-js) | Serverless messaging and scheduling via HTTP endpoints. |
 | [upstash-ratelimit-js](https://github.com/upstash/skills/tree/main/skills/upstash-ratelimit-js) | Rate limiting with the Redis Rate Limit TypeScript SDK. |
 | [upstash-redis-js](https://github.com/upstash/skills/tree/main/skills/upstash-redis-js) | Serverless Redis for caching, sessions, leaderboards, full-text search. |
+| [upstash-redis-start](https://github.com/upstash/skills/tree/main/skills/upstash-redis-start) | Provision a zero-config, no-signup scratch Redis database for an agent. |
 | [upstash-search-js](https://github.com/upstash/skills/tree/main/skills/upstash-search-js) | Full-text search quick starts, core concepts, and TypeScript SDK. |
 | [upstash-vector-js](https://github.com/upstash/skills/tree/main/skills/upstash-vector-js) | Vector database features, SDK usage, and framework integrations. |
 | [upstash-workflow-js](https://github.com/upstash/skills/tree/main/skills/upstash-workflow-js) | Durable workflows. Define, trigger, and manage multi-step processes. |
@@ -41,17 +44,105 @@ Install the combined `upstash` skill unless you only need a single SDK.
 
 # Installation
 
-Use the [Agent Skills CLI](https://agentskills.io/) to install into any compatible agent:
+The [`upstash/skills`](https://github.com/upstash/skills) repo is an [Agent Skills](https://agentskills.io/) repo, a Claude Code plugin, a Cursor plugin, an OpenAI Codex plugin, and a DeepSeek Harness bundle, so you can install it with whichever mechanism your agent supports.
+
+## Any agent
+
+The [Agent Skills CLI](https://github.com/vercel-labs/skills) detects the agents on your machine and installs into all of them:
 
 ```bash
 npx skills add upstash/skills
 ```
 
-To install only a specific SDK skill, append its name:
+To install only a specific SDK skill, pass its name with `--skill`:
 
 ```bash
-npx skills add upstash/skills/upstash-qstash-js
+npx skills add upstash/skills --skill upstash-qstash-js
 ```
+
+Add `--global` (`-g`) to make the skills available in every project instead of just the current one, and `--agent` (`-a`) to target a specific agent.
+
+## Per agent
+
+<AccordionGroup>
+  <Accordion title="Claude Code">
+    Install as a plugin from inside Claude Code. See the [Claude Code plugin docs](https://code.claude.com/docs/en/plugins) for more info.
+
+    ```
+    /plugin marketplace add upstash/skills
+    /plugin install upstash@upstash
+    ```
+  </Accordion>
+
+  <Accordion title="Cursor">
+    The plugin is pending review for the official [Cursor Marketplace](https://cursor.com/marketplace). Once listed, install it from **Customize** in the Cursor sidebar. Until then, use the Agent Skills CLI:
+
+    ```bash
+    npx skills add upstash/skills --agent cursor
+    ```
+  </Accordion>
+
+  <Accordion title="OpenAI Codex">
+    Install as a plugin with the Codex CLI. See the [Codex plugin docs](https://developers.openai.com/codex/plugins/build) for more info.
+
+    ```bash
+    codex plugin marketplace add upstash/skills
+    codex plugin add upstash@upstash
+    ```
+  </Accordion>
+
+  <Accordion title="OpenCode">
+    OpenCode loads [Agent Skills](https://opencode.ai/docs/skills) from `.agents/skills/` in a project and `~/.config/opencode/skills/` globally, which is where the Agent Skills CLI writes them for OpenCode:
+
+    ```bash
+    # Available in every project
+    npx skills add upstash/skills --agent opencode --global
+
+    # Or just this project
+    npx skills add upstash/skills --agent opencode
+    ```
+
+    OpenCode exposes the installed skills to the agent through its native `skill` tool, so only the sub-skill relevant to the task is loaded. For live access to your account, also add the [MCP server](/agent-resources/mcp).
+  </Accordion>
+
+  <Accordion title="Zed">
+    Zed loads [Agent Skills](https://zed.dev/docs/ai/skills) from `.agents/skills/` in a project and `~/.agents/skills/` globally, which is where the Agent Skills CLI writes them for Zed:
+
+    ```bash
+    # Available in every project
+    npx skills add upstash/skills --agent zed --global
+
+    # Or just this project
+    npx skills add upstash/skills --agent zed
+    ```
+
+    The skills show up in Zed's Agent Panel, and the agent can load them on its own or via `/upstash`. Zed's extension marketplace has no channel for skills, so the CLI is the only way to install them; the Zed extension covers the [MCP server](/agent-resources/mcp) instead.
+  </Accordion>
+
+  <Accordion title="Context7 CLI">
+    ```bash
+    npx ctx7 skills install upstash/skills
+    ```
+  </Accordion>
+
+  <Accordion title="DeepSeek Harness">
+    Installs the skills **and** the [MCP server](/agent-resources/mcp) in one step. Requires `pnpm` on your `PATH`.
+
+    ```bash
+    # Install into a profile (`web` is the one `dsh web` boots)
+    dsh plugin --profile web add github:upstash/skills
+
+    # Start the harness
+    dsh web
+    ```
+
+    Then store your Upstash credentials from inside a session so the MCP server can connect. The skills work without them.
+
+    ```
+    /upstash-login YOUR_EMAIL YOUR_API_KEY
+    ```
+  </Accordion>
+</AccordionGroup>
 
 # Managing resources
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -481,6 +481,45 @@ The Upstash MCP server works with any MCP-compatible client. If your client isn'
     ```
   </Accordion>
 
+  <Accordion title="Zed">
+    The [`upstash/skills`](https://github.com/upstash/skills) repo ships a Zed MCP extension. Once it is listed in the [Zed extension registry](https://github.com/zed-industries/extensions), install **Upstash Redis MCP Server** from **Settings → AI → MCP Servers → Add Server → Install from Extensions**; Zed will prompt for `upstash_email` and `upstash_api_key`.
+
+    To skip the extension, add the server to your Zed settings by hand (`zed: open settings file`). See the [Zed MCP docs](https://zed.dev/docs/ai/mcp) for more info.
+
+    ```json
+    {
+      "context_servers": {
+        "upstash": {
+          "command": "npx",
+          "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+        }
+      }
+    }
+    ```
+
+    <Note>
+      Context servers are project-scoped in Zed. Open a folder before testing, otherwise the server never starts.
+    </Note>
+  </Accordion>
+
+  <Accordion title="DeepSeek Harness">
+    Installing the [Upstash Skill](/docs/agent-resources/skills) as a DeepSeek Harness bundle also installs the MCP server. Requires `pnpm` on your `PATH`.
+
+    ```bash
+    # Install into a profile (`web` is the one `dsh web` boots)
+    dsh plugin --profile web add github:upstash/skills
+
+    # Start the harness
+    dsh web
+    ```
+
+    Then store your credentials from inside a session. The MCP server connects as soon as both are set; the skills work without them.
+
+    ```
+    /upstash-login YOUR_EMAIL YOUR_API_KEY
+    ```
+  </Accordion>
+
   <Accordion title="Gemini CLI">
     Open the Gemini CLI settings file at `~/.gemini/settings.json` and add Upstash to `mcpServers`. See [Gemini CLI Configuration](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html) for details.
 
@@ -556,11 +595,14 @@ Find the GitHub repository [here](https://github.com/upstash/skills).
 
 | Skill | Description |
 |-------|-------------|
-| [upstash](https://github.com/upstash/skills/tree/main/skills/upstash) | Combined skill covering all Upstash SDKs and the `upstash-cli`. |
+| [upstash](https://github.com/upstash/skills/tree/main/skills/upstash) | Combined skill covering all Upstash SDKs and the `upstash` CLI. |
 | [upstash-box-js](https://github.com/upstash/skills/tree/main/skills/upstash-box-js) | Sandboxed cloud containers with AI agents, shell, filesystem, and git. |
+| [upstash-box-py](https://github.com/upstash/skills/tree/main/skills/upstash-box-py) | The same sandboxed cloud containers, from the Python SDK. |
+| [upstash-cli](https://github.com/upstash/skills/tree/main/skills/upstash-cli) | Drive the Upstash Developer API from the terminal with the [`upstash` CLI](/docs/agent-resources/cli). |
 | [upstash-qstash-js](https://github.com/upstash/skills/tree/main/skills/upstash-qstash-js) | Serverless messaging and scheduling via HTTP endpoints. |
 | [upstash-ratelimit-js](https://github.com/upstash/skills/tree/main/skills/upstash-ratelimit-js) | Rate limiting with the Redis Rate Limit TypeScript SDK. |
 | [upstash-redis-js](https://github.com/upstash/skills/tree/main/skills/upstash-redis-js) | Serverless Redis for caching, sessions, leaderboards, full-text search. |
+| [upstash-redis-start](https://github.com/upstash/skills/tree/main/skills/upstash-redis-start) | Provision a zero-config, no-signup scratch Redis database for an agent. |
 | [upstash-search-js](https://github.com/upstash/skills/tree/main/skills/upstash-search-js) | Full-text search quick starts, core concepts, and TypeScript SDK. |
 | [upstash-vector-js](https://github.com/upstash/skills/tree/main/skills/upstash-vector-js) | Vector database features, SDK usage, and framework integrations. |
 | [upstash-workflow-js](https://github.com/upstash/skills/tree/main/skills/upstash-workflow-js) | Durable workflows. Define, trigger, and manage multi-step processes. |
@@ -583,17 +625,105 @@ Install the combined `upstash` skill unless you only need a single SDK.
 
 # Installation
 
-Use the [Agent Skills CLI](https://agentskills.io/) to install into any compatible agent:
+The [`upstash/skills`](https://github.com/upstash/skills) repo is an [Agent Skills](https://agentskills.io/) repo, a Claude Code plugin, a Cursor plugin, an OpenAI Codex plugin, and a DeepSeek Harness bundle, so you can install it with whichever mechanism your agent supports.
+
+## Any agent
+
+The [Agent Skills CLI](https://github.com/vercel-labs/skills) detects the agents on your machine and installs into all of them:
 
 ```bash
 npx skills add upstash/skills
 ```
 
-To install only a specific SDK skill, append its name:
+To install only a specific SDK skill, pass its name with `--skill`:
 
 ```bash
-npx skills add upstash/skills/upstash-qstash-js
+npx skills add upstash/skills --skill upstash-qstash-js
 ```
+
+Add `--global` (`-g`) to make the skills available in every project instead of just the current one, and `--agent` (`-a`) to target a specific agent.
+
+## Per agent
+
+<AccordionGroup>
+  <Accordion title="Claude Code">
+    Install as a plugin from inside Claude Code. See the [Claude Code plugin docs](https://code.claude.com/docs/en/plugins) for more info.
+
+    ```
+    /plugin marketplace add upstash/skills
+    /plugin install upstash@upstash
+    ```
+  </Accordion>
+
+  <Accordion title="Cursor">
+    The plugin is pending review for the official [Cursor Marketplace](https://cursor.com/marketplace). Once listed, install it from **Customize** in the Cursor sidebar. Until then, use the Agent Skills CLI:
+
+    ```bash
+    npx skills add upstash/skills --agent cursor
+    ```
+  </Accordion>
+
+  <Accordion title="OpenAI Codex">
+    Install as a plugin with the Codex CLI. See the [Codex plugin docs](https://developers.openai.com/codex/plugins/build) for more info.
+
+    ```bash
+    codex plugin marketplace add upstash/skills
+    codex plugin add upstash@upstash
+    ```
+  </Accordion>
+
+  <Accordion title="OpenCode">
+    OpenCode loads [Agent Skills](https://opencode.ai/docs/skills) from `.agents/skills/` in a project and `~/.config/opencode/skills/` globally, which is where the Agent Skills CLI writes them for OpenCode:
+
+    ```bash
+    # Available in every project
+    npx skills add upstash/skills --agent opencode --global
+
+    # Or just this project
+    npx skills add upstash/skills --agent opencode
+    ```
+
+    OpenCode exposes the installed skills to the agent through its native `skill` tool, so only the sub-skill relevant to the task is loaded. For live access to your account, also add the [MCP server](/docs/agent-resources/mcp).
+  </Accordion>
+
+  <Accordion title="Zed">
+    Zed loads [Agent Skills](https://zed.dev/docs/ai/skills) from `.agents/skills/` in a project and `~/.agents/skills/` globally, which is where the Agent Skills CLI writes them for Zed:
+
+    ```bash
+    # Available in every project
+    npx skills add upstash/skills --agent zed --global
+
+    # Or just this project
+    npx skills add upstash/skills --agent zed
+    ```
+
+    The skills show up in Zed's Agent Panel, and the agent can load them on its own or via `/upstash`. Zed's extension marketplace has no channel for skills, so the CLI is the only way to install them; the Zed extension covers the [MCP server](/docs/agent-resources/mcp) instead.
+  </Accordion>
+
+  <Accordion title="Context7 CLI">
+    ```bash
+    npx ctx7 skills install upstash/skills
+    ```
+  </Accordion>
+
+  <Accordion title="DeepSeek Harness">
+    Installs the skills **and** the [MCP server](/docs/agent-resources/mcp) in one step. Requires `pnpm` on your `PATH`.
+
+    ```bash
+    # Install into a profile (`web` is the one `dsh web` boots)
+    dsh plugin --profile web add github:upstash/skills
+
+    # Start the harness
+    dsh web
+    ```
+
+    Then store your Upstash credentials from inside a session so the MCP server can connect. The skills work without them.
+
+    ```
+    /upstash-login YOUR_EMAIL YOUR_API_KEY
+    ```
+  </Accordion>
+</AccordionGroup>
 
 # Managing resources
 


### PR DESCRIPTION
- skills: list all 11 skills (add upstash-box-py, upstash-cli, upstash-redis-start) and document every install path (Claude Code, Cursor, Codex, OpenCode, Zed, Context7 CLI, DeepSeek Harness) alongside the Agent Skills CLI
- mcp: add Zed and DeepSeek Harness client sections