### PR TITLE
docs(qstash): document optional token and Client.fromEnv

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15592,6 +15592,29 @@ const client = new Client({
 });
 ```
 
+The token is optional. If you leave it out, the client reads `QSTASH_TOKEN`,
+`QSTASH_URL` and their [region-prefixed variants](/docs/qstash/howto/multi-region)
+from the environment, and only warns when it finds nothing:
+
+```typescript
+const client = new Client();
+```
+
+Use `Client.fromEnv()` if you would rather fail fast:
+
+```typescript
+const client = Client.fromEnv();
+// throws: [Upstash QStash] Unable to find environment variable: QSTASH_TOKEN.
+```
+
+<Note>
+  `fromEnv` reads `process.env`, so on runtimes where credentials only exist as
+  bindings (Cloudflare Workers) pass the token to `new Client()` instead.
+</Note>
+
+No credentials at all? You don't need any while developing — see
+[Local development](#local-development) below.
+
 #### RetryConfig
 
 You can configure the retry policy of the client by passing the configuration to the client constructor.

--- a/qstash/sdks/ts/gettingstarted.mdx
+++ b/qstash/sdks/ts/gettingstarted.mdx
@@ -24,6 +24,29 @@ const client = new Client({
 });
 ```
 
+The token is optional. If you leave it out, the client reads `QSTASH_TOKEN`,
+`QSTASH_URL` and their [region-prefixed variants](/qstash/howto/multi-region)
+from the environment, and only warns when it finds nothing:
+
+```typescript
+const client = new Client();
+```
+
+Use `Client.fromEnv()` if you would rather fail fast:
+
+```typescript
+const client = Client.fromEnv();
+// throws: [Upstash QStash] Unable to find environment variable: QSTASH_TOKEN.
+```
+
+<Note>
+  `fromEnv` reads `process.env`, so on runtimes where credentials only exist as
+  bindings (Cloudflare Workers) pass the token to `new Client()` instead.
+</Note>
+
+No credentials at all? You don't need any while developing — see
+[Local development](#local-development) below.
+
 #### RetryConfig
 
 You can configure the retry policy of the client by passing the configuration to the client constructor.


### PR DESCRIPTION
[DX-2923](https://linear.app/upstash/issue/DX-2923/qstash-js-add-dev-mode-message-to-no-credential-error)

Documents the QStash client's optional token, environment and regional credential fallback, and `Client.fromEnv()` for failing immediately when credentials are missing. Adds the Cloudflare Workers binding caveat and explains that Node.js/Bun development errors suggest local dev mode when `NODE_ENV=development`. Regenerates `llms-full.txt`.

Depends on https://github.com/upstash/qstash-js/pull/276. Keep this PR draft until the SDK change is merged and released; `Client.fromEnv()` is not available in the current published SDK.

Validation: all 1,373 documentation pages built with the current Docs7 renderer, and generated LLM files are synchronized. The fresh hosted Docs7 preview now passes, clearing the August 26 build failure. Mintlify deployment, link validation, and the generated-file check also pass.
