### PR TITLE
docs: update homepage and product navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,675 +8,905 @@
     "dark": "#34D399"
   },
   "favicon": "/favicon.png",
+  "filterSidebar": false,
   "navigation": {
     "tabs": [
       {
-        "tab": "Overview",
+        "tab": "Documentation",
         "groups": [
           {
-            "group": "Introduction",
+            "group": "Get Started",
             "pages": [
-              "introduction"
-            ]
-          },
-          {
-            "group": "Concepts",
-            "pages": [
-              "common/concepts/serverless",
-              "common/concepts/scale-to-zero",
-              "common/concepts/global-replication",
-              "common/concepts/access-anywhere"
-            ]
-          },
-          {
-            "group": "Agent Resources",
-            "pages": [
-              "agent-resources/cli",
-              "agent-resources/skills",
-              "agent-resources/mcp",
-              "agent-resources/llms-txt"
-            ]
-          },
-          {
-            "group": "Help",
-            "pages": [
+              "introduction",
               {
-                "group": "Account & Teams",
+                "group": "Agent Setup",
                 "pages": [
-                  "common/account/createaccount",
-                  "common/account/teams",
-                  "common/account/developerapi",
-                  "common/account/add-payment-method",
-                  "common/account/awsmarketplace",
-                  "common/account/costexplorer",
-                  "common/account/paymenthistory",
-                  "common/account/auditlogs",
-                  "common/account/faq"
+                  "agent-resources/cli",
+                  "agent-resources/skills",
+                  "agent-resources/mcp",
+                  "agent-resources/llms-txt"
                 ]
               },
-              "common/help/support",
-              "common/help/prosupport",
-              "common/help/sla",
-              "common/help/uptime",
-              "common/help/legal",
-              "common/help/compliance"
+              {
+                "group": "Concepts",
+                "pages": [
+                  "common/concepts/serverless",
+                  "common/concepts/scale-to-zero",
+                  "common/concepts/global-replication",
+                  "common/concepts/access-anywhere"
+                ]
+              },
+              {
+                "group": "Support",
+                "pages": [
+                  {
+                    "group": "Account & Teams",
+                    "pages": [
+                      "common/account/createaccount",
+                      "common/account/teams",
+                      "common/account/developerapi",
+                      "common/account/add-payment-method",
+                      "common/account/awsmarketplace",
+                      "common/account/costexplorer",
+                      "common/account/paymenthistory",
+                      "common/account/auditlogs",
+                      "common/account/faq"
+                    ]
+                  },
+                  "common/help/support",
+                  "common/help/prosupport",
+                  "common/help/sla",
+                  "common/help/uptime",
+                  "common/help/legal",
+                  "common/help/compliance"
+                ]
+              }
             ]
           }
-        ]
-      },
-      {
-        "tab": "Redis",
-        "groups": [
+        ],
+        "productGroups": [
           {
-            "group": "Redis",
-            "pages": [
+            "group": "Products",
+            "products": [
               {
-                "group": "Overall",
-                "pages": [
-                  "redis/overall/getstarted",
-                  "redis/overall/pricing",
-                  "redis/overall/compatibility",
-                  "redis/overall/changelog",
-                  "redis/overall/usecases",
-                  "redis/overall/compare",
-                  "redis/overall/enterprise",
-                  "redis/overall/llms-txt"
-                ]
-              },
-              {
-                "group": "Quickstarts",
-                "pages": [
-                  "redis/quickstarts/aws-lambda",
+                "product": "Redis",
+                "icon": "/img/icons/redis.svg",
+                "groups": [
                   {
-                    "group": "Vercel Functions",
+                    "group": "Redis",
                     "pages": [
-                      "redis/quickstarts/vercel-functions-app-router",
-                      "redis/quickstarts/vercel-functions-pages-router"
-                    ]
-                  },
-                  {
-                    "group": "Next.js 16",
-                    "pages": [
-                      "redis/quickstarts/nextjs-app-router",
-                      "redis/quickstarts/nextjs-pages-router"
-                    ]
-                  },
-                  "redis/quickstarts/sst",
-                  {
-                    "group": "Python",
-                    "pages": [
-                      "redis/quickstarts/fastapi",
-                      "redis/quickstarts/flask",
-                      "redis/quickstarts/django",
-                      "redis/quickstarts/python-aws-lambda",
-                      "redis/quickstarts/vercel-python-runtime"
-                    ]
-                  },
-                  "redis/quickstarts/laravel",
-                  "redis/quickstarts/azure-functions",
-                  "redis/quickstarts/google-cloud-functions",
-                  "redis/quickstarts/elixir",
-                  "redis/quickstarts/fly",
-                  "redis/quickstarts/cloudflareworkers",
-                  "redis/quickstarts/fastlycompute",
-                  "redis/quickstarts/digitalocean",
-                  "redis/quickstarts/supabase",
-                  "redis/quickstarts/deno-deploy",
-                  "redis/quickstarts/koyeb"
-                ]
-              },
-              {
-                "group": "How To",
-                "pages": [
-                  "redis/howto/connect-client",
-                  "redis/howto/connect-with-upstash-redis",
-                  "redis/howto/redis-cli",
-                  "redis/howto/upgrade-database",
-                  "redis/howto/metrics-and-charts",
-                  "redis/howto/monitoryourusage",
-                  "redis/howto/importexport",
-                  "redis/howto/keyspacenotifications",
-                  "redis/howto/ipallowlist",
-                  "redis/howto/readyourwrites",
-                  "redis/howto/migratefromregionaltoglobal"
-                ]
-              },              {
-                "group": "SDKs",
-                "pages": [
-                  {
-                    "group": "Typescript",
-                    "pages": [
-                      "redis/sdks/ts/overview",
-                      "redis/sdks/ts/getstarted",
                       {
-                        "group": "Commands",
+                        "group": "Overall",
                         "pages": [
-                          "redis/sdks/ts/commands/overview",
-                          {
-                            "group": "Auth",
-                            "pages": [
-                              "redis/sdks/ts/commands/auth/echo",
-                              "redis/sdks/ts/commands/auth/ping"
-                            ]
-                          },
-                          {
-                            "group": "Connection",
-                            "pages": [
-                              "redis/sdks/ts/commands/connection/client_setinfo"
-                            ]
-                          },
-                          {
-                            "group": "Bitmap",
-                            "pages": [
-                              "redis/sdks/ts/commands/bitmap/bitcount",
-                              "redis/sdks/ts/commands/bitmap/bitop",
-                              "redis/sdks/ts/commands/bitmap/bitpos",
-                              "redis/sdks/ts/commands/bitmap/getbit",
-                              "redis/sdks/ts/commands/bitmap/setbit"
-                            ]
-                          },
-                          {
-                            "group": "Functions",
-                            "pages": [
-                              "redis/sdks/ts/commands/functions/call",
-                              "redis/sdks/ts/commands/functions/call_ro",
-                              "redis/sdks/ts/commands/functions/delete",
-                              "redis/sdks/ts/commands/functions/flush",
-                              "redis/sdks/ts/commands/functions/list",
-                              "redis/sdks/ts/commands/functions/load",
-                              "redis/sdks/ts/commands/functions/stats"
-                            ]
-                          },
-                          {
-                            "group": "Generic",
-                            "pages": [
-                              "redis/sdks/ts/commands/generic/del",
-                              "redis/sdks/ts/commands/generic/exists",
-                              "redis/sdks/ts/commands/generic/expire",
-                              "redis/sdks/ts/commands/generic/expireat",
-                              "redis/sdks/ts/commands/generic/keys",
-                              "redis/sdks/ts/commands/generic/persist",
-                              "redis/sdks/ts/commands/generic/pexpire",
-                              "redis/sdks/ts/commands/generic/pexpireat",
-                              "redis/sdks/ts/commands/generic/pttl",
-                              "redis/sdks/ts/commands/generic/randomkey",
-                              "redis/sdks/ts/commands/generic/rename",
-                              "redis/sdks/ts/commands/generic/renamenx",
-                              "redis/sdks/ts/commands/generic/scan",
-                              "redis/sdks/ts/commands/generic/touch",
-                              "redis/sdks/ts/commands/generic/ttl",
-                              "redis/sdks/ts/commands/generic/type",
-                              "redis/sdks/ts/commands/generic/unlink"
-                            ]
-                          },
-                          {
-                            "group": "Hash",
-                            "pages": [
-                              "redis/sdks/ts/commands/hash/hdel",
-                              "redis/sdks/ts/commands/hash/hexists",
-                              "redis/sdks/ts/commands/hash/hexpire",
-                              "redis/sdks/ts/commands/hash/hexpireat",
-                              "redis/sdks/ts/commands/hash/hexpiretime",
-                              "redis/sdks/ts/commands/hash/hget",
-                              "redis/sdks/ts/commands/hash/hgetall",
-                              "redis/sdks/ts/commands/hash/hgetdel",
-                              "redis/sdks/ts/commands/hash/hgetex",
-                              "redis/sdks/ts/commands/hash/hincrby",
-                              "redis/sdks/ts/commands/hash/hincrbyfloat",
-                              "redis/sdks/ts/commands/hash/hkeys",
-                              "redis/sdks/ts/commands/hash/hlen",
-                              "redis/sdks/ts/commands/hash/hmget",
-                              "redis/sdks/ts/commands/hash/hrandfield",
-                              "redis/sdks/ts/commands/hash/hscan",
-                              "redis/sdks/ts/commands/hash/hset",
-                              "redis/sdks/ts/commands/hash/hsetex",
-                              "redis/sdks/ts/commands/hash/hpersist",
-                              "redis/sdks/ts/commands/hash/hpexpire",
-                              "redis/sdks/ts/commands/hash/hpexpireat",
-                              "redis/sdks/ts/commands/hash/hpexpiretime",
-                              "redis/sdks/ts/commands/hash/hpttl",
-                              "redis/sdks/ts/commands/hash/hsetnx",
-                              "redis/sdks/ts/commands/hash/hstrlen",
-                              "redis/sdks/ts/commands/hash/httl",
-                              "redis/sdks/ts/commands/hash/hvals"
-                            ]
-                          },
-                          {
-                            "group": "Json",
-                            "pages": [
-                              "redis/sdks/ts/commands/json/arrappend",
-                              "redis/sdks/ts/commands/json/arrindex",
-                              "redis/sdks/ts/commands/json/arrinsert",
-                              "redis/sdks/ts/commands/json/arrlen",
-                              "redis/sdks/ts/commands/json/arrpop",
-                              "redis/sdks/ts/commands/json/arrtrim",
-                              "redis/sdks/ts/commands/json/clear",
-                              "redis/sdks/ts/commands/json/del",
-                              "redis/sdks/ts/commands/json/forget",
-                              "redis/sdks/ts/commands/json/get",
-                              "redis/sdks/ts/commands/json/merge",
-                              "redis/sdks/ts/commands/json/mget",
-                              "redis/sdks/ts/commands/json/mset",
-                              "redis/sdks/ts/commands/json/numincrby",
-                              "redis/sdks/ts/commands/json/nummultby",
-                              "redis/sdks/ts/commands/json/objkeys",
-                              "redis/sdks/ts/commands/json/objlen",
-                              "redis/sdks/ts/commands/json/set",
-                              "redis/sdks/ts/commands/json/strappend",
-                              "redis/sdks/ts/commands/json/strlen",
-                              "redis/sdks/ts/commands/json/toggle",
-                              "redis/sdks/ts/commands/json/type"
-                            ]
-                          },
-                          {
-                            "group": "List",
-                            "pages": [
-                              "redis/sdks/ts/commands/list/lindex",
-                              "redis/sdks/ts/commands/list/linsert",
-                              "redis/sdks/ts/commands/list/llen",
-                              "redis/sdks/ts/commands/list/lmove",
-                              "redis/sdks/ts/commands/list/lpop",
-                              "redis/sdks/ts/commands/list/lpos",
-                              "redis/sdks/ts/commands/list/lpush",
-                              "redis/sdks/ts/commands/list/lpushx",
-                              "redis/sdks/ts/commands/list/lrange",
-                              "redis/sdks/ts/commands/list/lrem",
-                              "redis/sdks/ts/commands/list/lset",
-                              "redis/sdks/ts/commands/list/ltrim",
-                              "redis/sdks/ts/commands/list/rpop",
-                              "redis/sdks/ts/commands/list/rpush",
-                              "redis/sdks/ts/commands/list/rpushx"
-                            ]
-                          },
-                          {
-                            "group": "PubSub",
-                            "pages": [
-                              "redis/sdks/ts/commands/pubsub/publish",
-                              "redis/sdks/ts/commands/pubsub/subscribe",
-                              "redis/sdks/ts/commands/pubsub/psubscribe"
-                            ]
-                          },
-                          {
-                            "group": "Scripts",
-                            "pages": [
-                              "redis/sdks/ts/commands/scripts/eval",
-                              "redis/sdks/ts/commands/scripts/eval_ro",
-                              "redis/sdks/ts/commands/scripts/evalsha",
-                              "redis/sdks/ts/commands/scripts/evalsha_ro",
-                              "redis/sdks/ts/commands/scripts/script_exists",
-                              "redis/sdks/ts/commands/scripts/script_flush",
-                              "redis/sdks/ts/commands/scripts/script_load"
-                            ]
-                          },
-                          {
-                            "group": "Server",
-                            "pages": [
-                              "redis/sdks/ts/commands/server/dbsize",
-                              "redis/sdks/ts/commands/server/flushall",
-                              "redis/sdks/ts/commands/server/flushdb"
-                            ]
-                          },
-                          {
-                            "group": "Set",
-                            "pages": [
-                              "redis/sdks/ts/commands/set/sadd",
-                              "redis/sdks/ts/commands/set/scard",
-                              "redis/sdks/ts/commands/set/sdiff",
-                              "redis/sdks/ts/commands/set/sdiffstore",
-                              "redis/sdks/ts/commands/set/sinter",
-                              "redis/sdks/ts/commands/set/sinterstore",
-                              "redis/sdks/ts/commands/set/sismember",
-                              "redis/sdks/ts/commands/set/smembers",
-                              "redis/sdks/ts/commands/set/smismember",
-                              "redis/sdks/ts/commands/set/smove",
-                              "redis/sdks/ts/commands/set/spop",
-                              "redis/sdks/ts/commands/set/srandmember",
-                              "redis/sdks/ts/commands/set/srem",
-                              "redis/sdks/ts/commands/set/sscan",
-                              "redis/sdks/ts/commands/set/sunion",
-                              "redis/sdks/ts/commands/set/sunionstore"
-                            ]
-                          },
-                          {
-                            "group": "Sorted Set",
-                            "pages": [
-                              "redis/sdks/ts/commands/zset/zadd",
-                              "redis/sdks/ts/commands/zset/zcard",
-                              "redis/sdks/ts/commands/zset/zcount",
-                              "redis/sdks/ts/commands/zset/zdiffstore",
-                              "redis/sdks/ts/commands/zset/zincrby",
-                              "redis/sdks/ts/commands/zset/zinterstore",
-                              "redis/sdks/ts/commands/zset/zlexcount",
-                              "redis/sdks/ts/commands/zset/zmscore",
-                              "redis/sdks/ts/commands/zset/zpopmax",
-                              "redis/sdks/ts/commands/zset/zpopmin",
-                              "redis/sdks/ts/commands/zset/zrange",
-                              "redis/sdks/ts/commands/zset/zrank",
-                              "redis/sdks/ts/commands/zset/zrem",
-                              "redis/sdks/ts/commands/zset/zremrangebylex",
-                              "redis/sdks/ts/commands/zset/zremrangebyrank",
-                              "redis/sdks/ts/commands/zset/zremrangebyscore",
-                              "redis/sdks/ts/commands/zset/zrevrank",
-                              "redis/sdks/ts/commands/zset/zscan",
-                              "redis/sdks/ts/commands/zset/zscore",
-                              "redis/sdks/ts/commands/zset/zunionstore"
-                            ]
-                          },
-                          {
-                            "group": "Stream",
-                            "pages": [
-                              "redis/sdks/ts/commands/stream/xack",
-                              "redis/sdks/ts/commands/stream/xackdel",
-                              "redis/sdks/ts/commands/stream/xadd",
-                              "redis/sdks/ts/commands/stream/xautoclaim",
-                              "redis/sdks/ts/commands/stream/xclaim",
-                              "redis/sdks/ts/commands/stream/xdel",
-                              "redis/sdks/ts/commands/stream/xdelex",
-                              "redis/sdks/ts/commands/stream/xgroup",
-                              "redis/sdks/ts/commands/stream/xinfo",
-                              "redis/sdks/ts/commands/stream/xlen",
-                              "redis/sdks/ts/commands/stream/xpending",
-                              "redis/sdks/ts/commands/stream/xrange",
-                              "redis/sdks/ts/commands/stream/xread",
-                              "redis/sdks/ts/commands/stream/xreadgroup",
-                              "redis/sdks/ts/commands/stream/xrevrange",
-                              "redis/sdks/ts/commands/stream/xtrim"
-                            ]
-                          },
-                          {
-                            "group": "String",
-                            "pages": [
-                              "redis/sdks/ts/commands/string/append",
-                              "redis/sdks/ts/commands/string/decr",
-                              "redis/sdks/ts/commands/string/decrby",
-                              "redis/sdks/ts/commands/string/get",
-                              "redis/sdks/ts/commands/string/getdel",
-                              "redis/sdks/ts/commands/string/getrange",
-                              "redis/sdks/ts/commands/string/getset",
-                              "redis/sdks/ts/commands/string/incr",
-                              "redis/sdks/ts/commands/string/incrby",
-                              "redis/sdks/ts/commands/string/incrbyfloat",
-                              "redis/sdks/ts/commands/string/mget",
-                              "redis/sdks/ts/commands/string/mset",
-                              "redis/sdks/ts/commands/string/msetnx",
-                              "redis/sdks/ts/commands/string/set",
-                              "redis/sdks/ts/commands/string/setrange",
-                              "redis/sdks/ts/commands/string/strlen"
-                            ]
-                          },
-                          "redis/sdks/ts/commands/transaction"
+                          "redis/overall/getstarted",
+                          "redis/overall/pricing",
+                          "redis/overall/compatibility",
+                          "redis/overall/changelog",
+                          "redis/overall/usecases",
+                          "redis/overall/compare",
+                          "redis/overall/enterprise",
+                          "redis/overall/llms-txt"
                         ]
                       },
-                      "redis/sdks/ts/deployment",
                       {
-                        "group": "Pipelining",
+                        "group": "Quickstarts",
                         "pages": [
-                          "redis/sdks/ts/pipelining/pipeline-transaction",
-                          "redis/sdks/ts/pipelining/auto-pipeline"
+                          "redis/quickstarts/aws-lambda",
+                          {
+                            "group": "Vercel Functions",
+                            "pages": [
+                              "redis/quickstarts/vercel-functions-app-router",
+                              "redis/quickstarts/vercel-functions-pages-router"
+                            ]
+                          },
+                          {
+                            "group": "Next.js 16",
+                            "pages": [
+                              "redis/quickstarts/nextjs-app-router",
+                              "redis/quickstarts/nextjs-pages-router"
+                            ]
+                          },
+                          "redis/quickstarts/sst",
+                          {
+                            "group": "Python",
+                            "pages": [
+                              "redis/quickstarts/fastapi",
+                              "redis/quickstarts/flask",
+                              "redis/quickstarts/django",
+                              "redis/quickstarts/python-aws-lambda",
+                              "redis/quickstarts/vercel-python-runtime"
+                            ]
+                          },
+                          "redis/quickstarts/laravel",
+                          "redis/quickstarts/azure-functions",
+                          "redis/quickstarts/google-cloud-functions",
+                          "redis/quickstarts/elixir",
+                          "redis/quickstarts/fly",
+                          "redis/quickstarts/cloudflareworkers",
+                          "redis/quickstarts/fastlycompute",
+                          "redis/quickstarts/digitalocean",
+                          "redis/quickstarts/supabase",
+                          "redis/quickstarts/deno-deploy",
+                          "redis/quickstarts/koyeb"
                         ]
                       },
-                      "redis/sdks/ts/advanced",
-                      "redis/sdks/ts/retries",
-                      "redis/sdks/ts/troubleshooting",
-                      "redis/sdks/ts/developing"
-                    ]
-                  },
-                  {
-                    "group": "Python",
-                    "pages": [
-                      "redis/sdks/py/overview",
-                      "redis/sdks/py/gettingstarted",
-                      "redis/sdks/py/features",
                       {
-                        "group": "Commands",
+                        "group": "How To",
                         "pages": [
-                          "redis/sdks/py/commands/overview",
+                          "redis/howto/connect-client",
+                          "redis/howto/connect-with-upstash-redis",
+                          "redis/howto/redis-cli",
+                          "redis/howto/upgrade-database",
+                          "redis/howto/metrics-and-charts",
+                          "redis/howto/monitoryourusage",
+                          "redis/howto/importexport",
+                          "redis/howto/keyspacenotifications",
+                          "redis/howto/ipallowlist",
+                          "redis/howto/readyourwrites",
+                          "redis/howto/migratefromregionaltoglobal"
+                        ]
+                      },
+                      {
+                        "group": "SDKs",
+                        "pages": [
                           {
-                            "group": "Auth",
+                            "group": "Typescript",
                             "pages": [
-                              "redis/sdks/py/commands/auth/echo",
-                              "redis/sdks/py/commands/auth/ping"
+                              "redis/sdks/ts/overview",
+                              "redis/sdks/ts/getstarted",
+                              {
+                                "group": "Commands",
+                                "pages": [
+                                  "redis/sdks/ts/commands/overview",
+                                  {
+                                    "group": "Auth",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/auth/echo",
+                                      "redis/sdks/ts/commands/auth/ping"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Connection",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/connection/client_setinfo"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Bitmap",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/bitmap/bitcount",
+                                      "redis/sdks/ts/commands/bitmap/bitop",
+                                      "redis/sdks/ts/commands/bitmap/bitpos",
+                                      "redis/sdks/ts/commands/bitmap/getbit",
+                                      "redis/sdks/ts/commands/bitmap/setbit"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Functions",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/functions/call",
+                                      "redis/sdks/ts/commands/functions/call_ro",
+                                      "redis/sdks/ts/commands/functions/delete",
+                                      "redis/sdks/ts/commands/functions/flush",
+                                      "redis/sdks/ts/commands/functions/list",
+                                      "redis/sdks/ts/commands/functions/load",
+                                      "redis/sdks/ts/commands/functions/stats"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Generic",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/generic/del",
+                                      "redis/sdks/ts/commands/generic/exists",
+                                      "redis/sdks/ts/commands/generic/expire",
+                                      "redis/sdks/ts/commands/generic/expireat",
+                                      "redis/sdks/ts/commands/generic/keys",
+                                      "redis/sdks/ts/commands/generic/persist",
+                                      "redis/sdks/ts/commands/generic/pexpire",
+                                      "redis/sdks/ts/commands/generic/pexpireat",
+                                      "redis/sdks/ts/commands/generic/pttl",
+                                      "redis/sdks/ts/commands/generic/randomkey",
+                                      "redis/sdks/ts/commands/generic/rename",
+                                      "redis/sdks/ts/commands/generic/renamenx",
+                                      "redis/sdks/ts/commands/generic/scan",
+                                      "redis/sdks/ts/commands/generic/touch",
+                                      "redis/sdks/ts/commands/generic/ttl",
+                                      "redis/sdks/ts/commands/generic/type",
+                                      "redis/sdks/ts/commands/generic/unlink"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Hash",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/hash/hdel",
+                                      "redis/sdks/ts/commands/hash/hexists",
+                                      "redis/sdks/ts/commands/hash/hexpire",
+                                      "redis/sdks/ts/commands/hash/hexpireat",
+                                      "redis/sdks/ts/commands/hash/hexpiretime",
+                                      "redis/sdks/ts/commands/hash/hget",
+                                      "redis/sdks/ts/commands/hash/hgetall",
+                                      "redis/sdks/ts/commands/hash/hgetdel",
+                                      "redis/sdks/ts/commands/hash/hgetex",
+                                      "redis/sdks/ts/commands/hash/hincrby",
+                                      "redis/sdks/ts/commands/hash/hincrbyfloat",
+                                      "redis/sdks/ts/commands/hash/hkeys",
+                                      "redis/sdks/ts/commands/hash/hlen",
+                                      "redis/sdks/ts/commands/hash/hmget",
+                                      "redis/sdks/ts/commands/hash/hrandfield",
+                                      "redis/sdks/ts/commands/hash/hscan",
+                                      "redis/sdks/ts/commands/hash/hset",
+                                      "redis/sdks/ts/commands/hash/hsetex",
+                                      "redis/sdks/ts/commands/hash/hpersist",
+                                      "redis/sdks/ts/commands/hash/hpexpire",
+                                      "redis/sdks/ts/commands/hash/hpexpireat",
+                                      "redis/sdks/ts/commands/hash/hpexpiretime",
+                                      "redis/sdks/ts/commands/hash/hpttl",
+                                      "redis/sdks/ts/commands/hash/hsetnx",
+                                      "redis/sdks/ts/commands/hash/hstrlen",
+                                      "redis/sdks/ts/commands/hash/httl",
+                                      "redis/sdks/ts/commands/hash/hvals"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Json",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/json/arrappend",
+                                      "redis/sdks/ts/commands/json/arrindex",
+                                      "redis/sdks/ts/commands/json/arrinsert",
+                                      "redis/sdks/ts/commands/json/arrlen",
+                                      "redis/sdks/ts/commands/json/arrpop",
+                                      "redis/sdks/ts/commands/json/arrtrim",
+                                      "redis/sdks/ts/commands/json/clear",
+                                      "redis/sdks/ts/commands/json/del",
+                                      "redis/sdks/ts/commands/json/forget",
+                                      "redis/sdks/ts/commands/json/get",
+                                      "redis/sdks/ts/commands/json/merge",
+                                      "redis/sdks/ts/commands/json/mget",
+                                      "redis/sdks/ts/commands/json/mset",
+                                      "redis/sdks/ts/commands/json/numincrby",
+                                      "redis/sdks/ts/commands/json/nummultby",
+                                      "redis/sdks/ts/commands/json/objkeys",
+                                      "redis/sdks/ts/commands/json/objlen",
+                                      "redis/sdks/ts/commands/json/set",
+                                      "redis/sdks/ts/commands/json/strappend",
+                                      "redis/sdks/ts/commands/json/strlen",
+                                      "redis/sdks/ts/commands/json/toggle",
+                                      "redis/sdks/ts/commands/json/type"
+                                    ]
+                                  },
+                                  {
+                                    "group": "List",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/list/lindex",
+                                      "redis/sdks/ts/commands/list/linsert",
+                                      "redis/sdks/ts/commands/list/llen",
+                                      "redis/sdks/ts/commands/list/lmove",
+                                      "redis/sdks/ts/commands/list/lpop",
+                                      "redis/sdks/ts/commands/list/lpos",
+                                      "redis/sdks/ts/commands/list/lpush",
+                                      "redis/sdks/ts/commands/list/lpushx",
+                                      "redis/sdks/ts/commands/list/lrange",
+                                      "redis/sdks/ts/commands/list/lrem",
+                                      "redis/sdks/ts/commands/list/lset",
+                                      "redis/sdks/ts/commands/list/ltrim",
+                                      "redis/sdks/ts/commands/list/rpop",
+                                      "redis/sdks/ts/commands/list/rpush",
+                                      "redis/sdks/ts/commands/list/rpushx"
+                                    ]
+                                  },
+                                  {
+                                    "group": "PubSub",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/pubsub/publish",
+                                      "redis/sdks/ts/commands/pubsub/subscribe",
+                                      "redis/sdks/ts/commands/pubsub/psubscribe"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Scripts",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/scripts/eval",
+                                      "redis/sdks/ts/commands/scripts/eval_ro",
+                                      "redis/sdks/ts/commands/scripts/evalsha",
+                                      "redis/sdks/ts/commands/scripts/evalsha_ro",
+                                      "redis/sdks/ts/commands/scripts/script_exists",
+                                      "redis/sdks/ts/commands/scripts/script_flush",
+                                      "redis/sdks/ts/commands/scripts/script_load"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Server",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/server/dbsize",
+                                      "redis/sdks/ts/commands/server/flushall",
+                                      "redis/sdks/ts/commands/server/flushdb"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Set",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/set/sadd",
+                                      "redis/sdks/ts/commands/set/scard",
+                                      "redis/sdks/ts/commands/set/sdiff",
+                                      "redis/sdks/ts/commands/set/sdiffstore",
+                                      "redis/sdks/ts/commands/set/sinter",
+                                      "redis/sdks/ts/commands/set/sinterstore",
+                                      "redis/sdks/ts/commands/set/sismember",
+                                      "redis/sdks/ts/commands/set/smembers",
+                                      "redis/sdks/ts/commands/set/smismember",
+                                      "redis/sdks/ts/commands/set/smove",
+                                      "redis/sdks/ts/commands/set/spop",
+                                      "redis/sdks/ts/commands/set/srandmember",
+                                      "redis/sdks/ts/commands/set/srem",
+                                      "redis/sdks/ts/commands/set/sscan",
+                                      "redis/sdks/ts/commands/set/sunion",
+                                      "redis/sdks/ts/commands/set/sunionstore"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Sorted Set",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/zset/zadd",
+                                      "redis/sdks/ts/commands/zset/zcard",
+                                      "redis/sdks/ts/commands/zset/zcount",
+                                      "redis/sdks/ts/commands/zset/zdiffstore",
+                                      "redis/sdks/ts/commands/zset/zincrby",
+                                      "redis/sdks/ts/commands/zset/zinterstore",
+                                      "redis/sdks/ts/commands/zset/zlexcount",
+                                      "redis/sdks/ts/commands/zset/zmscore",
+                                      "redis/sdks/ts/commands/zset/zpopmax",
+                                      "redis/sdks/ts/commands/zset/zpopmin",
+                                      "redis/sdks/ts/commands/zset/zrange",
+                                      "redis/sdks/ts/commands/zset/zrank",
+                                      "redis/sdks/ts/commands/zset/zrem",
+                                      "redis/sdks/ts/commands/zset/zremrangebylex",
+                                      "redis/sdks/ts/commands/zset/zremrangebyrank",
+                                      "redis/sdks/ts/commands/zset/zremrangebyscore",
+                                      "redis/sdks/ts/commands/zset/zrevrank",
+                                      "redis/sdks/ts/commands/zset/zscan",
+                                      "redis/sdks/ts/commands/zset/zscore",
+                                      "redis/sdks/ts/commands/zset/zunionstore"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Stream",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/stream/xack",
+                                      "redis/sdks/ts/commands/stream/xackdel",
+                                      "redis/sdks/ts/commands/stream/xadd",
+                                      "redis/sdks/ts/commands/stream/xautoclaim",
+                                      "redis/sdks/ts/commands/stream/xclaim",
+                                      "redis/sdks/ts/commands/stream/xdel",
+                                      "redis/sdks/ts/commands/stream/xdelex",
+                                      "redis/sdks/ts/commands/stream/xgroup",
+                                      "redis/sdks/ts/commands/stream/xinfo",
+                                      "redis/sdks/ts/commands/stream/xlen",
+                                      "redis/sdks/ts/commands/stream/xpending",
+                                      "redis/sdks/ts/commands/stream/xrange",
+                                      "redis/sdks/ts/commands/stream/xread",
+                                      "redis/sdks/ts/commands/stream/xreadgroup",
+                                      "redis/sdks/ts/commands/stream/xrevrange",
+                                      "redis/sdks/ts/commands/stream/xtrim"
+                                    ]
+                                  },
+                                  {
+                                    "group": "String",
+                                    "pages": [
+                                      "redis/sdks/ts/commands/string/append",
+                                      "redis/sdks/ts/commands/string/decr",
+                                      "redis/sdks/ts/commands/string/decrby",
+                                      "redis/sdks/ts/commands/string/get",
+                                      "redis/sdks/ts/commands/string/getdel",
+                                      "redis/sdks/ts/commands/string/getrange",
+                                      "redis/sdks/ts/commands/string/getset",
+                                      "redis/sdks/ts/commands/string/incr",
+                                      "redis/sdks/ts/commands/string/incrby",
+                                      "redis/sdks/ts/commands/string/incrbyfloat",
+                                      "redis/sdks/ts/commands/string/mget",
+                                      "redis/sdks/ts/commands/string/mset",
+                                      "redis/sdks/ts/commands/string/msetnx",
+                                      "redis/sdks/ts/commands/string/set",
+                                      "redis/sdks/ts/commands/string/setrange",
+                                      "redis/sdks/ts/commands/string/strlen"
+                                    ]
+                                  },
+                                  "redis/sdks/ts/commands/transaction"
+                                ]
+                              },
+                              "redis/sdks/ts/deployment",
+                              {
+                                "group": "Pipelining",
+                                "pages": [
+                                  "redis/sdks/ts/pipelining/pipeline-transaction",
+                                  "redis/sdks/ts/pipelining/auto-pipeline"
+                                ]
+                              },
+                              "redis/sdks/ts/advanced",
+                              "redis/sdks/ts/retries",
+                              "redis/sdks/ts/troubleshooting",
+                              "redis/sdks/ts/developing"
                             ]
                           },
                           {
-                            "group": "Connection",
+                            "group": "Python",
                             "pages": [
-                              "redis/sdks/py/commands/connection/client_setinfo"
+                              "redis/sdks/py/overview",
+                              "redis/sdks/py/gettingstarted",
+                              "redis/sdks/py/features",
+                              {
+                                "group": "Commands",
+                                "pages": [
+                                  "redis/sdks/py/commands/overview",
+                                  {
+                                    "group": "Auth",
+                                    "pages": [
+                                      "redis/sdks/py/commands/auth/echo",
+                                      "redis/sdks/py/commands/auth/ping"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Connection",
+                                    "pages": [
+                                      "redis/sdks/py/commands/connection/client_setinfo"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Bitmap",
+                                    "pages": [
+                                      "redis/sdks/py/commands/bitmap/bitcount",
+                                      "redis/sdks/py/commands/bitmap/bitfield",
+                                      "redis/sdks/py/commands/bitmap/bitop",
+                                      "redis/sdks/py/commands/bitmap/bitpos",
+                                      "redis/sdks/py/commands/bitmap/getbit"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Generic",
+                                    "pages": [
+                                      "redis/sdks/py/commands/generic/del",
+                                      "redis/sdks/py/commands/generic/exists",
+                                      "redis/sdks/py/commands/generic/expire",
+                                      "redis/sdks/py/commands/generic/expireat",
+                                      "redis/sdks/py/commands/generic/keys",
+                                      "redis/sdks/py/commands/generic/persist",
+                                      "redis/sdks/py/commands/generic/pexpire",
+                                      "redis/sdks/py/commands/generic/pexpireat",
+                                      "redis/sdks/py/commands/generic/pttl",
+                                      "redis/sdks/py/commands/generic/randomkey",
+                                      "redis/sdks/py/commands/generic/rename",
+                                      "redis/sdks/py/commands/generic/renamenx",
+                                      "redis/sdks/py/commands/generic/scan",
+                                      "redis/sdks/py/commands/generic/touch",
+                                      "redis/sdks/py/commands/generic/ttl",
+                                      "redis/sdks/py/commands/generic/type",
+                                      "redis/sdks/py/commands/generic/unlink"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Hash",
+                                    "pages": [
+                                      "redis/sdks/py/commands/hash/hdel",
+                                      "redis/sdks/py/commands/hash/hexists",
+                                      "redis/sdks/py/commands/hash/hexpire",
+                                      "redis/sdks/py/commands/hash/hexpireat",
+                                      "redis/sdks/py/commands/hash/hexpiretime",
+                                      "redis/sdks/py/commands/hash/hget",
+                                      "redis/sdks/py/commands/hash/hgetall",
+                                      "redis/sdks/py/commands/hash/hgetdel",
+                                      "redis/sdks/py/commands/hash/hgetex",
+                                      "redis/sdks/py/commands/hash/hincrby",
+                                      "redis/sdks/py/commands/hash/hincrbyfloat",
+                                      "redis/sdks/py/commands/hash/hkeys",
+                                      "redis/sdks/py/commands/hash/hlen",
+                                      "redis/sdks/py/commands/hash/hmget",
+                                      "redis/sdks/py/commands/hash/hrandfield",
+                                      "redis/sdks/py/commands/hash/hscan",
+                                      "redis/sdks/py/commands/hash/hset",
+                                      "redis/sdks/py/commands/hash/hpersist",
+                                      "redis/sdks/py/commands/hash/hpexpire",
+                                      "redis/sdks/py/commands/hash/hpexpireat",
+                                      "redis/sdks/py/commands/hash/hpexpiretime",
+                                      "redis/sdks/py/commands/hash/hpttl",
+                                      "redis/sdks/py/commands/hash/hmset",
+                                      "redis/sdks/py/commands/hash/hsetex",
+                                      "redis/sdks/py/commands/hash/hsetnx",
+                                      "redis/sdks/py/commands/hash/hstrlen",
+                                      "redis/sdks/py/commands/hash/httl",
+                                      "redis/sdks/py/commands/hash/hvals"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Json",
+                                    "pages": [
+                                      "redis/sdks/py/commands/json/arrappend",
+                                      "redis/sdks/py/commands/json/arrindex",
+                                      "redis/sdks/py/commands/json/arrinsert",
+                                      "redis/sdks/py/commands/json/arrlen",
+                                      "redis/sdks/py/commands/json/arrpop",
+                                      "redis/sdks/py/commands/json/arrtrim",
+                                      "redis/sdks/py/commands/json/clear",
+                                      "redis/sdks/py/commands/json/del",
+                                      "redis/sdks/py/commands/json/forget",
+                                      "redis/sdks/py/commands/json/get",
+                                      "redis/sdks/py/commands/json/merge",
+                                      "redis/sdks/py/commands/json/mget",
+                                      "redis/sdks/py/commands/json/mset",
+                                      "redis/sdks/py/commands/json/numincrby",
+                                      "redis/sdks/py/commands/json/nummultby",
+                                      "redis/sdks/py/commands/json/objkeys",
+                                      "redis/sdks/py/commands/json/objlen",
+                                      "redis/sdks/py/commands/json/resp",
+                                      "redis/sdks/py/commands/json/set",
+                                      "redis/sdks/py/commands/json/strappend",
+                                      "redis/sdks/py/commands/json/strlen",
+                                      "redis/sdks/py/commands/json/toggle",
+                                      "redis/sdks/py/commands/json/type"
+                                    ]
+                                  },
+                                  {
+                                    "group": "List",
+                                    "pages": [
+                                      "redis/sdks/py/commands/list/lindex",
+                                      "redis/sdks/py/commands/list/linsert",
+                                      "redis/sdks/py/commands/list/llen",
+                                      "redis/sdks/py/commands/list/lmove",
+                                      "redis/sdks/py/commands/list/lpop",
+                                      "redis/sdks/py/commands/list/lpos",
+                                      "redis/sdks/py/commands/list/lpush",
+                                      "redis/sdks/py/commands/list/lpushx",
+                                      "redis/sdks/py/commands/list/lrange",
+                                      "redis/sdks/py/commands/list/lrem",
+                                      "redis/sdks/py/commands/list/lset",
+                                      "redis/sdks/py/commands/list/ltrim",
+                                      "redis/sdks/py/commands/list/rpop",
+                                      "redis/sdks/py/commands/list/rpush",
+                                      "redis/sdks/py/commands/list/rpushx"
+                                    ]
+                                  },
+                                  {
+                                    "group": "PubSub",
+                                    "pages": [
+                                      "redis/sdks/py/commands/pubsub/publish"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Scripts",
+                                    "pages": [
+                                      "redis/sdks/py/commands/scripts/eval",
+                                      "redis/sdks/py/commands/scripts/eval_ro",
+                                      "redis/sdks/py/commands/scripts/evalsha",
+                                      "redis/sdks/py/commands/scripts/evalsha_ro",
+                                      "redis/sdks/py/commands/scripts/script_exists",
+                                      "redis/sdks/py/commands/scripts/script_flush",
+                                      "redis/sdks/py/commands/scripts/script_load"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Server",
+                                    "pages": [
+                                      "redis/sdks/py/commands/server/dbsize",
+                                      "redis/sdks/py/commands/server/flushall",
+                                      "redis/sdks/py/commands/server/flushdb"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Set",
+                                    "pages": [
+                                      "redis/sdks/py/commands/set/sadd",
+                                      "redis/sdks/py/commands/set/scard",
+                                      "redis/sdks/py/commands/set/sdiff",
+                                      "redis/sdks/py/commands/set/sdiffstore",
+                                      "redis/sdks/py/commands/set/sinter",
+                                      "redis/sdks/py/commands/set/sinterstore",
+                                      "redis/sdks/py/commands/set/sismember",
+                                      "redis/sdks/py/commands/set/smembers",
+                                      "redis/sdks/py/commands/set/smismember",
+                                      "redis/sdks/py/commands/set/smove",
+                                      "redis/sdks/py/commands/set/spop",
+                                      "redis/sdks/py/commands/set/srandmember",
+                                      "redis/sdks/py/commands/set/srem",
+                                      "redis/sdks/py/commands/set/sscan",
+                                      "redis/sdks/py/commands/set/sunion",
+                                      "redis/sdks/py/commands/set/sunionstore"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Sorted Set",
+                                    "pages": [
+                                      "redis/sdks/py/commands/zset/zadd",
+                                      "redis/sdks/py/commands/zset/zcard",
+                                      "redis/sdks/py/commands/zset/zcount",
+                                      "redis/sdks/py/commands/zset/zdiff",
+                                      "redis/sdks/py/commands/zset/zdiffstore",
+                                      "redis/sdks/py/commands/zset/zincrby",
+                                      "redis/sdks/py/commands/zset/zinter",
+                                      "redis/sdks/py/commands/zset/zinterstore",
+                                      "redis/sdks/py/commands/zset/zlexcount",
+                                      "redis/sdks/py/commands/zset/zmscore",
+                                      "redis/sdks/py/commands/zset/zpopmax",
+                                      "redis/sdks/py/commands/zset/zpopmin",
+                                      "redis/sdks/py/commands/zset/zrandmember",
+                                      "redis/sdks/py/commands/zset/zrange",
+                                      "redis/sdks/py/commands/zset/zrank",
+                                      "redis/sdks/py/commands/zset/zrem",
+                                      "redis/sdks/py/commands/zset/zremrangebylex",
+                                      "redis/sdks/py/commands/zset/zremrangebyrank",
+                                      "redis/sdks/py/commands/zset/zremrangebyscore",
+                                      "redis/sdks/py/commands/zset/zrevrank",
+                                      "redis/sdks/py/commands/zset/zscan",
+                                      "redis/sdks/py/commands/zset/zscore",
+                                      "redis/sdks/py/commands/zset/zunion",
+                                      "redis/sdks/py/commands/zset/zunionstore"
+                                    ]
+                                  },
+                                  {
+                                    "group": "Stream",
+                                    "pages": [
+                                      "redis/sdks/py/commands/stream/xack",
+                                      "redis/sdks/py/commands/stream/xackdel",
+                                      "redis/sdks/py/commands/stream/xadd",
+                                      "redis/sdks/py/commands/stream/xautoclaim",
+                                      "redis/sdks/py/commands/stream/xclaim",
+                                      "redis/sdks/py/commands/stream/xdel",
+                                      "redis/sdks/py/commands/stream/xdelex",
+                                      "redis/sdks/py/commands/stream/xgroup_create",
+                                      "redis/sdks/py/commands/stream/xgroup_createconsumer",
+                                      "redis/sdks/py/commands/stream/xgroup_delconsumer",
+                                      "redis/sdks/py/commands/stream/xgroup_destroy",
+                                      "redis/sdks/py/commands/stream/xgroup_setid",
+                                      "redis/sdks/py/commands/stream/xinfo_consumers",
+                                      "redis/sdks/py/commands/stream/xinfo_groups",
+                                      "redis/sdks/py/commands/stream/xlen",
+                                      "redis/sdks/py/commands/stream/xpending",
+                                      "redis/sdks/py/commands/stream/xrange",
+                                      "redis/sdks/py/commands/stream/xread",
+                                      "redis/sdks/py/commands/stream/xreadgroup",
+                                      "redis/sdks/py/commands/stream/xrevrange",
+                                      "redis/sdks/py/commands/stream/xtrim"
+                                    ]
+                                  },
+                                  {
+                                    "group": "String",
+                                    "pages": [
+                                      "redis/sdks/py/commands/string/append",
+                                      "redis/sdks/py/commands/string/decr",
+                                      "redis/sdks/py/commands/string/decrby",
+                                      "redis/sdks/py/commands/string/get",
+                                      "redis/sdks/py/commands/string/getdel",
+                                      "redis/sdks/py/commands/string/getrange",
+                                      "redis/sdks/py/commands/string/getset",
+                                      "redis/sdks/py/commands/string/incr",
+                                      "redis/sdks/py/commands/string/incrbyfloat",
+                                      "redis/sdks/py/commands/string/mget",
+                                      "redis/sdks/py/commands/string/mset",
+                                      "redis/sdks/py/commands/string/msetnx",
+                                      "redis/sdks/py/commands/string/set",
+                                      "redis/sdks/py/commands/string/setrange",
+                                      "redis/sdks/py/commands/string/strlen"
+                                    ]
+                                  }
+                                ]
+                              }
                             ]
                           },
                           {
-                            "group": "Bitmap",
+                            "group": "AgentKit",
                             "pages": [
-                              "redis/sdks/py/commands/bitmap/bitcount",
-                              "redis/sdks/py/commands/bitmap/bitfield",
-                              "redis/sdks/py/commands/bitmap/bitop",
-                              "redis/sdks/py/commands/bitmap/bitpos",
-                              "redis/sdks/py/commands/bitmap/getbit"
+                              "redis/sdks/agentkit/ai-sdk",
+                              "redis/sdks/agentkit/eve"
+                            ]
+                          },
+                          "redis/sdks/mcp",
+                          "redis/sdks/realtime",
+                          "redis/sdks/agent-analytics",
+                          "redis/sdks/redis-analytics"
+                        ]
+                      },
+                      {
+                        "group": "Features",
+                        "pages": [
+                          "redis/features/globaldatabase",
+                          "redis/features/restapi",
+                          "redis/features/backup",
+                          "redis/features/durability",
+                          "redis/features/replication",
+                          "redis/features/key-locking",
+                          "redis/features/eviction",
+                          "redis/features/security",
+                          "redis/features/credential-protection",
+                          "redis/features/consistency",
+                          "redis/features/auto-upgrade"
+                        ]
+                      },
+                      {
+                        "group": "Search",
+                        "pages": [
+                          "redis/search/introduction",
+                          "redis/search/getting-started",
+                          "redis/search/index-management",
+                          "redis/search/document-updates",
+                          "redis/search/schema-definition",
+                          "redis/search/querying",
+                          "redis/search/aggregations",
+                          "redis/search/counting",
+                          "redis/search/aliases",
+                          "redis/search/command-reference",
+                          "redis/search/troubleshooting",
+                          {
+                            "group": "Adapters",
+                            "pages": [
+                              "redis/search/adapters/ioredis",
+                              "redis/search/adapters/node-redis"
                             ]
                           },
                           {
-                            "group": "Generic",
+                            "group": "Query Operators",
                             "pages": [
-                              "redis/sdks/py/commands/generic/del",
-                              "redis/sdks/py/commands/generic/exists",
-                              "redis/sdks/py/commands/generic/expire",
-                              "redis/sdks/py/commands/generic/expireat",
-                              "redis/sdks/py/commands/generic/keys",
-                              "redis/sdks/py/commands/generic/persist",
-                              "redis/sdks/py/commands/generic/pexpire",
-                              "redis/sdks/py/commands/generic/pexpireat",
-                              "redis/sdks/py/commands/generic/pttl",
-                              "redis/sdks/py/commands/generic/randomkey",
-                              "redis/sdks/py/commands/generic/rename",
-                              "redis/sdks/py/commands/generic/renamenx",
-                              "redis/sdks/py/commands/generic/scan",
-                              "redis/sdks/py/commands/generic/touch",
-                              "redis/sdks/py/commands/generic/ttl",
-                              "redis/sdks/py/commands/generic/type",
-                              "redis/sdks/py/commands/generic/unlink"
+                              {
+                                "group": "Boolean Operators",
+                                "pages": [
+                                  "redis/search/query-operators/boolean-operators/overview",
+                                  "redis/search/query-operators/boolean-operators/must",
+                                  "redis/search/query-operators/boolean-operators/should",
+                                  "redis/search/query-operators/boolean-operators/must-not",
+                                  "redis/search/query-operators/boolean-operators/boost"
+                                ]
+                              },
+                              {
+                                "group": "Field Operators",
+                                "pages": [
+                                  "redis/search/query-operators/field-operators/overview",
+                                  "redis/search/query-operators/field-operators/smart-matching",
+                                  "redis/search/query-operators/field-operators/eq",
+                                  "redis/search/query-operators/field-operators/in",
+                                  "redis/search/query-operators/field-operators/range-operators",
+                                  "redis/search/query-operators/field-operators/phrase",
+                                  "redis/search/query-operators/field-operators/fuzzy",
+                                  "redis/search/query-operators/field-operators/regex",
+                                  "redis/search/query-operators/field-operators/boost"
+                                ]
+                              }
                             ]
                           },
                           {
-                            "group": "Hash",
+                            "group": "Aggregation Operators",
                             "pages": [
-                              "redis/sdks/py/commands/hash/hdel",
-                              "redis/sdks/py/commands/hash/hexists",
-                              "redis/sdks/py/commands/hash/hexpire",
-                              "redis/sdks/py/commands/hash/hexpireat",
-                              "redis/sdks/py/commands/hash/hexpiretime",
-                              "redis/sdks/py/commands/hash/hget",
-                              "redis/sdks/py/commands/hash/hgetall",
-                              "redis/sdks/py/commands/hash/hgetdel",
-                              "redis/sdks/py/commands/hash/hgetex",
-                              "redis/sdks/py/commands/hash/hincrby",
-                              "redis/sdks/py/commands/hash/hincrbyfloat",
-                              "redis/sdks/py/commands/hash/hkeys",
-                              "redis/sdks/py/commands/hash/hlen",
-                              "redis/sdks/py/commands/hash/hmget",
-                              "redis/sdks/py/commands/hash/hrandfield",
-                              "redis/sdks/py/commands/hash/hscan",
-                              "redis/sdks/py/commands/hash/hset",
-                              "redis/sdks/py/commands/hash/hpersist",
-                              "redis/sdks/py/commands/hash/hpexpire",
-                              "redis/sdks/py/commands/hash/hpexpireat",
-                              "redis/sdks/py/commands/hash/hpexpiretime",
-                              "redis/sdks/py/commands/hash/hpttl",
-                              "redis/sdks/py/commands/hash/hmset",
-                              "redis/sdks/py/commands/hash/hsetex",
-                              "redis/sdks/py/commands/hash/hsetnx",
-                              "redis/sdks/py/commands/hash/hstrlen",
-                              "redis/sdks/py/commands/hash/httl",
-                              "redis/sdks/py/commands/hash/hvals"
+                              {
+                                "group": "Metric Aggregations",
+                                "pages": [
+                                  "redis/search/aggregation-operators/metric-aggregations/overview",
+                                  "redis/search/aggregation-operators/metric-aggregations/avg",
+                                  "redis/search/aggregation-operators/metric-aggregations/sum",
+                                  "redis/search/aggregation-operators/metric-aggregations/min",
+                                  "redis/search/aggregation-operators/metric-aggregations/max",
+                                  "redis/search/aggregation-operators/metric-aggregations/count",
+                                  "redis/search/aggregation-operators/metric-aggregations/cardinality",
+                                  "redis/search/aggregation-operators/metric-aggregations/stats",
+                                  "redis/search/aggregation-operators/metric-aggregations/extended-stats",
+                                  "redis/search/aggregation-operators/metric-aggregations/percentiles"
+                                ]
+                              },
+                              {
+                                "group": "Bucket Aggregations",
+                                "pages": [
+                                  "redis/search/aggregation-operators/bucket-aggregations/overview",
+                                  "redis/search/aggregation-operators/bucket-aggregations/terms",
+                                  "redis/search/aggregation-operators/bucket-aggregations/range",
+                                  "redis/search/aggregation-operators/bucket-aggregations/histogram",
+                                  "redis/search/aggregation-operators/bucket-aggregations/date-histogram",
+                                  "redis/search/aggregation-operators/bucket-aggregations/facet"
+                                ]
+                              }
                             ]
                           },
                           {
-                            "group": "Json",
+                            "group": "Recipes",
                             "pages": [
-                              "redis/sdks/py/commands/json/arrappend",
-                              "redis/sdks/py/commands/json/arrindex",
-                              "redis/sdks/py/commands/json/arrinsert",
-                              "redis/sdks/py/commands/json/arrlen",
-                              "redis/sdks/py/commands/json/arrpop",
-                              "redis/sdks/py/commands/json/arrtrim",
-                              "redis/sdks/py/commands/json/clear",
-                              "redis/sdks/py/commands/json/del",
-                              "redis/sdks/py/commands/json/forget",
-                              "redis/sdks/py/commands/json/get",
-                              "redis/sdks/py/commands/json/merge",
-                              "redis/sdks/py/commands/json/mget",
-                              "redis/sdks/py/commands/json/mset",
-                              "redis/sdks/py/commands/json/numincrby",
-                              "redis/sdks/py/commands/json/nummultby",
-                              "redis/sdks/py/commands/json/objkeys",
-                              "redis/sdks/py/commands/json/objlen",
-                              "redis/sdks/py/commands/json/resp",
-                              "redis/sdks/py/commands/json/set",
-                              "redis/sdks/py/commands/json/strappend",
-                              "redis/sdks/py/commands/json/strlen",
-                              "redis/sdks/py/commands/json/toggle",
-                              "redis/sdks/py/commands/json/type"
+                              "redis/search/recipes/overview",
+                              "redis/search/recipes/e-commerce-search",
+                              "redis/search/recipes/blog-search",
+                              "redis/search/recipes/user-directory"
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Security & Compliance",
+                        "pages": [
+                          "redis/help/production-checklist",
+                          "redis/help/shared-responsibility-model",
+                          "redis/help/managing-healthcare-data"
+                        ]
+                      },
+                      {
+                        "group": "Integrations",
+                        "pages": [
+                          "redis/integrations/drizzle",
+                          "redis/howto/datadog",
+                          "redis/integrations/prometheus",
+                          "redis/integrations/bullmq",
+                          "redis/integrations/effect-mq",
+                          "redis/integrations/sidekiq",
+                          "redis/howto/vercelintegration",
+                          "redis/integrations/replit-templates",
+                          "redis/howto/emqxintegration",
+                          "redis/integrations/celery",
+                          "redis/integrations/n8n",
                           {
-                            "group": "List",
+                            "group": "AgentKit",
                             "pages": [
-                              "redis/sdks/py/commands/list/lindex",
-                              "redis/sdks/py/commands/list/linsert",
-                              "redis/sdks/py/commands/list/llen",
-                              "redis/sdks/py/commands/list/lmove",
-                              "redis/sdks/py/commands/list/lpop",
-                              "redis/sdks/py/commands/list/lpos",
-                              "redis/sdks/py/commands/list/lpush",
-                              "redis/sdks/py/commands/list/lpushx",
-                              "redis/sdks/py/commands/list/lrange",
-                              "redis/sdks/py/commands/list/lrem",
-                              "redis/sdks/py/commands/list/lset",
-                              "redis/sdks/py/commands/list/ltrim",
-                              "redis/sdks/py/commands/list/rpop",
-                              "redis/sdks/py/commands/list/rpush",
-                              "redis/sdks/py/commands/list/rpushx"
+                              "redis/sdks/agentkit/ai-sdk",
+                              "redis/sdks/agentkit/eve"
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Tutorials",
+                        "pages": [
+                          "redis/tutorials/laravel_caching",
+                          "redis/tutorials/python_realtime_chat",
+                          "redis/tutorials/python_session",
+                          "redis/tutorials/python_rate_limiting",
+                          "redis/tutorials/python_multithreading",
+                          "redis/tutorials/python_fastapi_caching",
+                          "redis/tutorials/python_url_shortener",
+                          "redis/tutorials/api_with_cdk",
+                          "redis/tutorials/agent_memory",
+                          "redis/tutorials/tanstack_chat_persistence",
+                          "redis/tutorials/auto_complete_with_serverless_redis",
+                          "redis/tutorials/aws_app_runner_with_redis",
+                          "redis/tutorials/cloud_run_sessions",
+                          "redis/tutorials/cloudflare_workers_with_redis",
+                          "redis/tutorials/cloudflare_websockets_redis",
+                          "redis/tutorials/edge_leaderboard",
+                          "redis/tutorials/express_session",
+                          "redis/tutorials/goapi",
+                          "redis/tutorials/histogram",
+                          "redis/tutorials/job_processing",
+                          "redis/tutorials/redis_queue",
+                          "redis/tutorials/nextjs_with_redis",
+                          "redis/tutorials/notification",
+                          "redis/tutorials/nuxtjs_with_redis",
+                          "redis/tutorials/pythonapi",
+                          "redis/tutorials/rate-limiting",
+                          "redis/tutorials/redisson",
+                          "redis/tutorials/roadmapvotingapp",
+                          "redis/tutorials/serverless_java_redis",
+                          "redis/tutorials/using_aws_sam",
+                          "redis/tutorials/using_google_cloud_functions",
+                          "redis/tutorials/using_serverless_framework"
+                        ]
+                      },
+                      {
+                        "group": "Troubleshooting",
+                        "pages": [
+                          "redis/troubleshooting/command_count_increases_unexpectedly",
+                          "redis/troubleshooting/readonly_connection",
+                          "redis/troubleshooting/no_auth",
+                          "redis/troubleshooting/http_unauthorized",
+                          "redis/troubleshooting/econn_reset",
+                          "redis/troubleshooting/max_concurrent_connections",
+                          "redis/troubleshooting/max_request_size_exceeded",
+                          "redis/troubleshooting/max_record_size_exceeded",
+                          "redis/troubleshooting/max_key_size_exceeded",
+                          "redis/troubleshooting/db_capacity_quota_exceeded",
+                          "redis/troubleshooting/max_requests_limit",
+                          "redis/troubleshooting/stream_pel_limit"
+                        ]
+                      },
+                      {
+                        "group": "Help",
+                        "pages": [
+                          "redis/help/faq",
                           {
-                            "group": "PubSub",
+                            "group": "Support",
                             "pages": [
-                              "redis/sdks/py/commands/pubsub/publish"
-                            ]
-                          },
-                          {
-                            "group": "Scripts",
-                            "pages": [
-                              "redis/sdks/py/commands/scripts/eval",
-                              "redis/sdks/py/commands/scripts/eval_ro",
-                              "redis/sdks/py/commands/scripts/evalsha",
-                              "redis/sdks/py/commands/scripts/evalsha_ro",
-                              "redis/sdks/py/commands/scripts/script_exists",
-                              "redis/sdks/py/commands/scripts/script_flush",
-                              "redis/sdks/py/commands/scripts/script_load"
-                            ]
-                          },
-                          {
-                            "group": "Server",
-                            "pages": [
-                              "redis/sdks/py/commands/server/dbsize",
-                              "redis/sdks/py/commands/server/flushall",
-                              "redis/sdks/py/commands/server/flushdb"
-                            ]
-                          },
-                          {
-                            "group": "Set",
-                            "pages": [
-                              "redis/sdks/py/commands/set/sadd",
-                              "redis/sdks/py/commands/set/scard",
-                              "redis/sdks/py/commands/set/sdiff",
-                              "redis/sdks/py/commands/set/sdiffstore",
-                              "redis/sdks/py/commands/set/sinter",
-                              "redis/sdks/py/commands/set/sinterstore",
-                              "redis/sdks/py/commands/set/sismember",
-                              "redis/sdks/py/commands/set/smembers",
-                              "redis/sdks/py/commands/set/smismember",
-                              "redis/sdks/py/commands/set/smove",
-                              "redis/sdks/py/commands/set/spop",
-                              "redis/sdks/py/commands/set/srandmember",
-                              "redis/sdks/py/commands/set/srem",
-                              "redis/sdks/py/commands/set/sscan",
-                              "redis/sdks/py/commands/set/sunion",
-                              "redis/sdks/py/commands/set/sunionstore"
-                            ]
-                          },
-                          {
-                            "group": "Sorted Set",
-                            "pages": [
-                              "redis/sdks/py/commands/zset/zadd",
-                              "redis/sdks/py/commands/zset/zcard",
-                              "redis/sdks/py/commands/zset/zcount",
-                              "redis/sdks/py/commands/zset/zdiff",
-                              "redis/sdks/py/commands/zset/zdiffstore",
-                              "redis/sdks/py/commands/zset/zincrby",
-                              "redis/sdks/py/commands/zset/zinter",
-                              "redis/sdks/py/commands/zset/zinterstore",
-                              "redis/sdks/py/commands/zset/zlexcount",
-                              "redis/sdks/py/commands/zset/zmscore",
-                              "redis/sdks/py/commands/zset/zpopmax",
-                              "redis/sdks/py/commands/zset/zpopmin",
-                              "redis/sdks/py/commands/zset/zrandmember",
-                              "redis/sdks/py/commands/zset/zrange",
-                              "redis/sdks/py/commands/zset/zrank",
-                              "redis/sdks/py/commands/zset/zrem",
-                              "redis/sdks/py/commands/zset/zremrangebylex",
-                              "redis/sdks/py/commands/zset/zremrangebyrank",
-                              "redis/sdks/py/commands/zset/zremrangebyscore",
-                              "redis/sdks/py/commands/zset/zrevrank",
-                              "redis/sdks/py/commands/zset/zscan",
-                              "redis/sdks/py/commands/zset/zscore",
-                              "redis/sdks/py/commands/zset/zunion",
-                              "redis/sdks/py/commands/zset/zunionstore"
-                            ]
-                          },
-                          {
-                            "group": "Stream",
-                            "pages": [
-                              "redis/sdks/py/commands/stream/xack",
-                              "redis/sdks/py/commands/stream/xackdel",
-                              "redis/sdks/py/commands/stream/xadd",
-                              "redis/sdks/py/commands/stream/xautoclaim",
-                              "redis/sdks/py/commands/stream/xclaim",
-                              "redis/sdks/py/commands/stream/xdel",
-                              "redis/sdks/py/commands/stream/xdelex",
-                              "redis/sdks/py/commands/stream/xgroup_create",
-                              "redis/sdks/py/commands/stream/xgroup_createconsumer",
-                              "redis/sdks/py/commands/stream/xgroup_delconsumer",
-                              "redis/sdks/py/commands/stream/xgroup_destroy",
-                              "redis/sdks/py/commands/stream/xgroup_setid",
-                              "redis/sdks/py/commands/stream/xinfo_consumers",
-                              "redis/sdks/py/commands/stream/xinfo_groups",
-                              "redis/sdks/py/commands/stream/xlen",
-                              "redis/sdks/py/commands/stream/xpending",
-                              "redis/sdks/py/commands/stream/xrange",
-                              "redis/sdks/py/commands/stream/xread",
-                              "redis/sdks/py/commands/stream/xreadgroup",
-                              "redis/sdks/py/commands/stream/xrevrange",
-                              "redis/sdks/py/commands/stream/xtrim"
-                            ]
-                          },
-                          {
-                            "group": "String",
-                            "pages": [
-                              "redis/sdks/py/commands/string/append",
-                              "redis/sdks/py/commands/string/decr",
-                              "redis/sdks/py/commands/string/decrby",
-                              "redis/sdks/py/commands/string/get",
-                              "redis/sdks/py/commands/string/getdel",
-                              "redis/sdks/py/commands/string/getrange",
-                              "redis/sdks/py/commands/string/getset",
-                              "redis/sdks/py/commands/string/incr",
-                              "redis/sdks/py/commands/string/incrbyfloat",
-                              "redis/sdks/py/commands/string/mget",
-                              "redis/sdks/py/commands/string/mset",
-                              "redis/sdks/py/commands/string/msetnx",
-                              "redis/sdks/py/commands/string/set",
-                              "redis/sdks/py/commands/string/setrange",
-                              "redis/sdks/py/commands/string/strlen"
+                              "redis/help/support",
+                              "redis/help/uptime",
+                              "redis/help/legal",
+                              "redis/help/compliance",
+                              "redis/help/integration"
                             ]
                           }
                         ]
@@ -684,7 +914,1200 @@
                     ]
                   },
                   {
-                    "group": "Ratelimit (TS)",
+                    "group": "Command Reference",
+                    "pages": [
+                      "redis/commands/overview",
+                      {
+                        "group": "Bitmap",
+                        "pages": [
+                          "redis/commands/bitmap/overview",
+                          "redis/commands/bitmap/bitcount",
+                          "redis/commands/bitmap/bitfield",
+                          "redis/commands/bitmap/bitfield-ro",
+                          "redis/commands/bitmap/bitop",
+                          "redis/commands/bitmap/bitpos",
+                          "redis/commands/bitmap/getbit",
+                          "redis/commands/bitmap/setbit"
+                        ]
+                      },
+                      {
+                        "group": "Connection",
+                        "pages": [
+                          "redis/commands/connection/overview",
+                          "redis/commands/connection/auth",
+                          "redis/commands/connection/client-getname",
+                          "redis/commands/connection/client-id",
+                          "redis/commands/connection/client-info",
+                          "redis/commands/connection/client-list",
+                          "redis/commands/connection/client-setinfo",
+                          "redis/commands/connection/client-setname",
+                          "redis/commands/connection/echo",
+                          "redis/commands/connection/hello",
+                          "redis/commands/connection/ping",
+                          "redis/commands/connection/quit",
+                          "redis/commands/connection/reset",
+                          "redis/commands/connection/select"
+                        ]
+                      },
+                      {
+                        "group": "Functions",
+                        "pages": [
+                          "redis/commands/functions/overview",
+                          "redis/commands/functions/fcall",
+                          "redis/commands/functions/fcall-ro",
+                          "redis/commands/functions/function-delete",
+                          "redis/commands/functions/function-flush",
+                          "redis/commands/functions/function-kill",
+                          "redis/commands/functions/function-list",
+                          "redis/commands/functions/function-load",
+                          "redis/commands/functions/function-stats"
+                        ]
+                      },
+                      {
+                        "group": "Generic",
+                        "pages": [
+                          "redis/commands/generic/overview",
+                          "redis/commands/generic/copy",
+                          "redis/commands/generic/del",
+                          "redis/commands/generic/dump",
+                          "redis/commands/generic/exists",
+                          "redis/commands/generic/expire",
+                          "redis/commands/generic/expireat",
+                          "redis/commands/generic/expiretime",
+                          "redis/commands/generic/keys",
+                          "redis/commands/generic/memory-usage",
+                          "redis/commands/generic/persist",
+                          "redis/commands/generic/pexpire",
+                          "redis/commands/generic/pexpireat",
+                          "redis/commands/generic/pexpiretime",
+                          "redis/commands/generic/pttl",
+                          "redis/commands/generic/randomkey",
+                          "redis/commands/generic/rename",
+                          "redis/commands/generic/renamenx",
+                          "redis/commands/generic/restore",
+                          "redis/commands/generic/scan",
+                          "redis/commands/generic/touch",
+                          "redis/commands/generic/ttl",
+                          "redis/commands/generic/type",
+                          "redis/commands/generic/unlink",
+                          "redis/commands/generic/wait",
+                          "redis/commands/generic/waitaof"
+                        ]
+                      },
+                      {
+                        "group": "Geo",
+                        "pages": [
+                          "redis/commands/geo/overview",
+                          "redis/commands/geo/geoadd",
+                          "redis/commands/geo/geodist",
+                          "redis/commands/geo/geohash",
+                          "redis/commands/geo/geopos",
+                          "redis/commands/geo/georadius",
+                          "redis/commands/geo/georadius-ro",
+                          "redis/commands/geo/georadiusbymember",
+                          "redis/commands/geo/georadiusbymember-ro",
+                          "redis/commands/geo/geosearch",
+                          "redis/commands/geo/geosearchstore"
+                        ]
+                      },
+                      {
+                        "group": "Hash",
+                        "pages": [
+                          "redis/commands/hash/overview",
+                          "redis/commands/hash/hdel",
+                          "redis/commands/hash/hexists",
+                          "redis/commands/hash/hexpire",
+                          "redis/commands/hash/hexpireat",
+                          "redis/commands/hash/hexpiretime",
+                          "redis/commands/hash/hget",
+                          "redis/commands/hash/hgetall",
+                          "redis/commands/hash/hgetdel",
+                          "redis/commands/hash/hgetex",
+                          "redis/commands/hash/hincrby",
+                          "redis/commands/hash/hincrbyfloat",
+                          "redis/commands/hash/hkeys",
+                          "redis/commands/hash/hlen",
+                          "redis/commands/hash/hmget",
+                          "redis/commands/hash/hmset",
+                          "redis/commands/hash/hpersist",
+                          "redis/commands/hash/hpexpire",
+                          "redis/commands/hash/hpexpireat",
+                          "redis/commands/hash/hpexpiretime",
+                          "redis/commands/hash/hpttl",
+                          "redis/commands/hash/hrandfield",
+                          "redis/commands/hash/hscan",
+                          "redis/commands/hash/hset",
+                          "redis/commands/hash/hsetex",
+                          "redis/commands/hash/hsetnx",
+                          "redis/commands/hash/hstrlen",
+                          "redis/commands/hash/httl",
+                          "redis/commands/hash/hvals"
+                        ]
+                      },
+                      {
+                        "group": "HyperLogLog",
+                        "pages": [
+                          "redis/commands/hyperloglog/overview",
+                          "redis/commands/hyperloglog/pfadd",
+                          "redis/commands/hyperloglog/pfcount",
+                          "redis/commands/hyperloglog/pfmerge"
+                        ]
+                      },
+                      {
+                        "group": "JSON",
+                        "pages": [
+                          "redis/commands/json/overview",
+                          "redis/commands/json/json-arrappend",
+                          "redis/commands/json/json-arrindex",
+                          "redis/commands/json/json-arrinsert",
+                          "redis/commands/json/json-arrlen",
+                          "redis/commands/json/json-arrpop",
+                          "redis/commands/json/json-arrtrim",
+                          "redis/commands/json/json-clear",
+                          "redis/commands/json/json-del",
+                          "redis/commands/json/json-debug",
+                          "redis/commands/json/json-forget",
+                          "redis/commands/json/json-get",
+                          "redis/commands/json/json-merge",
+                          "redis/commands/json/json-mget",
+                          "redis/commands/json/json-mset",
+                          "redis/commands/json/json-numincrby",
+                          "redis/commands/json/json-nummultby",
+                          "redis/commands/json/json-objkeys",
+                          "redis/commands/json/json-objlen",
+                          "redis/commands/json/json-resp",
+                          "redis/commands/json/json-set",
+                          "redis/commands/json/json-strappend",
+                          "redis/commands/json/json-strlen",
+                          "redis/commands/json/json-toggle",
+                          "redis/commands/json/json-type"
+                        ]
+                      },
+                      {
+                        "group": "List",
+                        "pages": [
+                          "redis/commands/list/overview",
+                          "redis/commands/list/blmove",
+                          "redis/commands/list/blmpop",
+                          "redis/commands/list/blpop",
+                          "redis/commands/list/brpop",
+                          "redis/commands/list/brpoplpush",
+                          "redis/commands/list/lindex",
+                          "redis/commands/list/linsert",
+                          "redis/commands/list/llen",
+                          "redis/commands/list/lmove",
+                          "redis/commands/list/lmpop",
+                          "redis/commands/list/lpop",
+                          "redis/commands/list/lpos",
+                          "redis/commands/list/lpush",
+                          "redis/commands/list/lpushx",
+                          "redis/commands/list/lrange",
+                          "redis/commands/list/lrem",
+                          "redis/commands/list/lset",
+                          "redis/commands/list/ltrim",
+                          "redis/commands/list/rpop",
+                          "redis/commands/list/rpoplpush",
+                          "redis/commands/list/rpush",
+                          "redis/commands/list/rpushx"
+                        ]
+                      },
+                      {
+                        "group": "Pub/Sub",
+                        "pages": [
+                          "redis/commands/pub-sub/overview",
+                          "redis/commands/pub-sub/psubscribe",
+                          "redis/commands/pub-sub/publish",
+                          "redis/commands/pub-sub/pubsub",
+                          "redis/commands/pub-sub/punsubscribe",
+                          "redis/commands/pub-sub/subscribe",
+                          "redis/commands/pub-sub/unsubscribe"
+                        ]
+                      },
+                      {
+                        "group": "Scripting",
+                        "pages": [
+                          "redis/commands/scripting/overview",
+                          "redis/commands/scripting/eval",
+                          "redis/commands/scripting/eval-ro",
+                          "redis/commands/scripting/evalsha",
+                          "redis/commands/scripting/evalsha-ro",
+                          "redis/commands/scripting/script-exists",
+                          "redis/commands/scripting/script-flush",
+                          "redis/commands/scripting/script-kill",
+                          "redis/commands/scripting/script-load"
+                        ]
+                      },
+                      {
+                        "group": "Search",
+                        "pages": [
+                          "redis/commands/search/overview",
+                          "redis/commands/search/search-create",
+                          "redis/commands/search/search-reindex",
+                          "redis/commands/search/search-drop",
+                          "redis/commands/search/search-describe",
+                          "redis/commands/search/search-waitindexing",
+                          "redis/commands/search/search-listindexes",
+                          "redis/commands/search/search-query",
+                          "redis/commands/search/search-count",
+                          "redis/commands/search/search-aggregate",
+                          "redis/commands/search/search-aliasadd",
+                          "redis/commands/search/search-aliasdel",
+                          "redis/commands/search/search-listaliases"
+                        ]
+                      },
+                      {
+                        "group": "Server",
+                        "pages": [
+                          "redis/commands/server/overview",
+                          "redis/commands/server/acl-cat",
+                          "redis/commands/server/acl-deluser",
+                          "redis/commands/server/acl-genpass",
+                          "redis/commands/server/acl-gentoken",
+                          "redis/commands/server/acl-getuser",
+                          "redis/commands/server/acl-list",
+                          "redis/commands/server/acl-load",
+                          "redis/commands/server/acl-log",
+                          "redis/commands/server/acl-resttoken",
+                          "redis/commands/server/acl-save",
+                          "redis/commands/server/acl-setuser",
+                          "redis/commands/server/acl-users",
+                          "redis/commands/server/acl-whoami",
+                          "redis/commands/server/command",
+                          "redis/commands/server/config-get",
+                          "redis/commands/server/config-set",
+                          "redis/commands/server/dbsize",
+                          "redis/commands/server/flushall",
+                          "redis/commands/server/flushdb",
+                          "redis/commands/server/info",
+                          "redis/commands/server/monitor",
+                          "redis/commands/server/time"
+                        ]
+                      },
+                      {
+                        "group": "Set",
+                        "pages": [
+                          "redis/commands/set/overview",
+                          "redis/commands/set/sadd",
+                          "redis/commands/set/scard",
+                          "redis/commands/set/sdiff",
+                          "redis/commands/set/sdiffstore",
+                          "redis/commands/set/sinter",
+                          "redis/commands/set/sintercard",
+                          "redis/commands/set/sinterstore",
+                          "redis/commands/set/sismember",
+                          "redis/commands/set/smembers",
+                          "redis/commands/set/smismember",
+                          "redis/commands/set/smove",
+                          "redis/commands/set/spop",
+                          "redis/commands/set/srandmember",
+                          "redis/commands/set/srem",
+                          "redis/commands/set/sscan",
+                          "redis/commands/set/sunion",
+                          "redis/commands/set/sunionstore"
+                        ]
+                      },
+                      {
+                        "group": "Sorted Set",
+                        "pages": [
+                          "redis/commands/sorted-set/overview",
+                          "redis/commands/sorted-set/bzmpop",
+                          "redis/commands/sorted-set/bzpopmax",
+                          "redis/commands/sorted-set/bzpopmin",
+                          "redis/commands/sorted-set/zadd",
+                          "redis/commands/sorted-set/zcard",
+                          "redis/commands/sorted-set/zcount",
+                          "redis/commands/sorted-set/zdiff",
+                          "redis/commands/sorted-set/zdiffstore",
+                          "redis/commands/sorted-set/zincrby",
+                          "redis/commands/sorted-set/zinter",
+                          "redis/commands/sorted-set/zintercard",
+                          "redis/commands/sorted-set/zinterstore",
+                          "redis/commands/sorted-set/zlexcount",
+                          "redis/commands/sorted-set/zmpop",
+                          "redis/commands/sorted-set/zmscore",
+                          "redis/commands/sorted-set/zpopmax",
+                          "redis/commands/sorted-set/zpopmin",
+                          "redis/commands/sorted-set/zrandmember",
+                          "redis/commands/sorted-set/zrange",
+                          "redis/commands/sorted-set/zrangebylex",
+                          "redis/commands/sorted-set/zrangebyscore",
+                          "redis/commands/sorted-set/zrangestore",
+                          "redis/commands/sorted-set/zrank",
+                          "redis/commands/sorted-set/zrem",
+                          "redis/commands/sorted-set/zremrangebylex",
+                          "redis/commands/sorted-set/zremrangebyrank",
+                          "redis/commands/sorted-set/zremrangebyscore",
+                          "redis/commands/sorted-set/zrevrange",
+                          "redis/commands/sorted-set/zrevrangebylex",
+                          "redis/commands/sorted-set/zrevrangebyscore",
+                          "redis/commands/sorted-set/zrevrank",
+                          "redis/commands/sorted-set/zscan",
+                          "redis/commands/sorted-set/zscore",
+                          "redis/commands/sorted-set/zunion",
+                          "redis/commands/sorted-set/zunionstore"
+                        ]
+                      },
+                      {
+                        "group": "Streams",
+                        "pages": [
+                          "redis/commands/streams/overview",
+                          "redis/commands/streams/xack",
+                          "redis/commands/streams/xackdel",
+                          "redis/commands/streams/xadd",
+                          "redis/commands/streams/xautoclaim",
+                          "redis/commands/streams/xclaim",
+                          "redis/commands/streams/xdel",
+                          "redis/commands/streams/xdelex",
+                          "redis/commands/streams/xgroup",
+                          "redis/commands/streams/xinfo-consumers",
+                          "redis/commands/streams/xinfo-groups",
+                          "redis/commands/streams/xinfo-stream",
+                          "redis/commands/streams/xlen",
+                          "redis/commands/streams/xpending",
+                          "redis/commands/streams/xrange",
+                          "redis/commands/streams/xread",
+                          "redis/commands/streams/xreadgroup",
+                          "redis/commands/streams/xrevrange",
+                          "redis/commands/streams/xtrim"
+                        ]
+                      },
+                      {
+                        "group": "String",
+                        "pages": [
+                          "redis/commands/string/overview",
+                          "redis/commands/string/append",
+                          "redis/commands/string/decr",
+                          "redis/commands/string/decrby",
+                          "redis/commands/string/delex",
+                          "redis/commands/string/digest",
+                          "redis/commands/string/get",
+                          "redis/commands/string/getdel",
+                          "redis/commands/string/getex",
+                          "redis/commands/string/getrange",
+                          "redis/commands/string/getset",
+                          "redis/commands/string/incr",
+                          "redis/commands/string/incrby",
+                          "redis/commands/string/incrbyfloat",
+                          "redis/commands/string/mget",
+                          "redis/commands/string/mset",
+                          "redis/commands/string/msetnx",
+                          "redis/commands/string/psetex",
+                          "redis/commands/string/set",
+                          "redis/commands/string/setex",
+                          "redis/commands/string/setnx",
+                          "redis/commands/string/setrange",
+                          "redis/commands/string/strlen"
+                        ]
+                      },
+                      {
+                        "group": "Transactions",
+                        "pages": [
+                          "redis/commands/transactions/overview",
+                          "redis/commands/transactions/discard",
+                          "redis/commands/transactions/exec",
+                          "redis/commands/transactions/multi",
+                          "redis/commands/transactions/unwatch",
+                          "redis/commands/transactions/watch"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "product": "Vector",
+                "icon": "/img/icons/vector.svg",
+                "groups": [
+                  {
+                    "group": "Vector",
+                    "pages": [
+                      {
+                        "group": "Overall",
+                        "pages": [
+                          "vector/overall/getstarted",
+                          "vector/overall/whatisvector",
+                          "vector/overall/pricing",
+                          "vector/overall/changelog",
+                          "vector/overall/llms-txt"
+                        ]
+                      },
+                      {
+                        "group": "Features",
+                        "pages": [
+                          "vector/features/algorithm",
+                          "vector/features/similarityfunctions",
+                          "vector/features/hybridindexes",
+                          "vector/features/sparseindexes",
+                          "vector/features/metadata",
+                          "vector/features/filtering",
+                          "vector/features/embeddingmodels",
+                          "vector/features/namespaces",
+                          "vector/features/resumablequery"
+                        ]
+                      },
+                      {
+                        "group": "REST API",
+                        "pages": [
+                          "vector/api/get-started",
+                          {
+                            "group": "Endpoints",
+                            "pages": [
+                              "vector/api/endpoints/upsert",
+                              "vector/api/endpoints/upsert-data",
+                              "vector/api/endpoints/query",
+                              "vector/api/endpoints/query-data",
+                              {
+                                "group": "Resumable Query",
+                                "pages": [
+                                  "vector/api/endpoints/resumable-query/start-with-vector",
+                                  "vector/api/endpoints/resumable-query/start-with-data",
+                                  "vector/api/endpoints/resumable-query/resume",
+                                  "vector/api/endpoints/resumable-query/stop"
+                                ]
+                              },
+                              "vector/api/endpoints/fetch",
+                              "vector/api/endpoints/fetch-random",
+                              "vector/api/endpoints/range",
+                              "vector/api/endpoints/delete",
+                              "vector/api/endpoints/update",
+                              "vector/api/endpoints/reset",
+                              "vector/api/endpoints/info",
+                              "vector/api/endpoints/list-namespaces",
+                              "vector/api/endpoints/delete-namespace",
+                              "vector/api/endpoints/rename-namespace"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "SDKs",
+                        "pages": [
+                          {
+                            "group": "Typescript",
+                            "pages": [
+                              "vector/sdks/ts/getting-started",
+                              {
+                                "group": "Commands",
+                                "pages": [
+                                  "vector/sdks/ts/commands/upsert",
+                                  "vector/sdks/ts/commands/query",
+                                  "vector/sdks/ts/commands/resumable-query",
+                                  "vector/sdks/ts/commands/fetch",
+                                  "vector/sdks/ts/commands/delete",
+                                  "vector/sdks/ts/commands/range",
+                                  "vector/sdks/ts/commands/reset",
+                                  "vector/sdks/ts/commands/info"
+                                ]
+                              },
+                              "vector/sdks/ts/advanced",
+                              "vector/sdks/ts/contributing"
+                            ]
+                          },
+                          {
+                            "group": "Python",
+                            "pages": [
+                              "vector/sdks/py/gettingstarted",
+                              "vector/sdks/py/features",
+                              {
+                                "group": "Example Calls",
+                                "pages": [
+                                  "vector/sdks/py/example_calls/upsert",
+                                  "vector/sdks/py/example_calls/query",
+                                  "vector/sdks/py/example_calls/resumable-query",
+                                  "vector/sdks/py/example_calls/range",
+                                  "vector/sdks/py/example_calls/fetch",
+                                  "vector/sdks/py/example_calls/delete",
+                                  "vector/sdks/py/example_calls/update",
+                                  "vector/sdks/py/example_calls/reset",
+                                  "vector/sdks/py/example_calls/info"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "PHP",
+                            "pages": [
+                              "vector/sdks/php/getting-started",
+                              "vector/sdks/php/laravel",
+                              {
+                                "group": "Guides",
+                                "pages": [
+                                  "vector/sdks/php/commands/upsert-vectors",
+                                  "vector/sdks/php/commands/upsert-data",
+                                  "vector/sdks/php/commands/query",
+                                  "vector/sdks/php/commands/fetch",
+                                  "vector/sdks/php/commands/delete-vectors",
+                                  "vector/sdks/php/commands/reset",
+                                  "vector/sdks/php/commands/info"
+                                ]
+                              }
+                            ]
+                          },
+                          "vector/sdk/semantic-cache-js",
+                          "vector/sdk/semantic-cache-py",
+                          "vector/sdk/gosdk"
+                        ]
+                      },
+                      {
+                        "group": "Integrations",
+                        "pages": [
+                          "vector/integrations/ai-sdk",
+                          "vector/integrations/langchain",
+                          "vector/integrations/llamaindex",
+                          "vector/integrations/llamaparse",
+                          "vector/integrations/flowise",
+                          "vector/integrations/langflow"
+                        ]
+                      },
+                      {
+                        "group": "Tutorials",
+                        "pages": [
+                          "vector/tutorials/semantic_search",
+                          "vector/tutorials/langchain",
+                          "vector/tutorials/llamaindex",
+                          "vector/tutorials/llamaparse",
+                          "vector/tutorials/huggingface-embeddings",
+                          "vector/tutorials/gradio-application"
+                        ]
+                      },
+                      "vector/examples",
+                      {
+                        "group": "Help",
+                        "pages": [
+                          "vector/help/faq"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "product": "QStash",
+                "icon": "/img/icons/qstash.svg",
+                "groups": [
+                  {
+                    "group": "QStash",
+                    "pages": [
+                      {
+                        "group": "Overall",
+                        "pages": [
+                          "qstash/overall/getstarted",
+                          "qstash/overall/usecases",
+                          "qstash/overall/pricing",
+                          "qstash/overall/enterprise",
+                          "qstash/overall/apiexamples",
+                          "qstash/overall/compare",
+                          "qstash/overall/changelog",
+                          "qstash/overall/roadmap",
+                          "qstash/overall/llms-txt"
+                        ]
+                      },
+                      {
+                        "group": "Quickstarts",
+                        "pages": [
+                          "qstash/quickstarts/vercel-nextjs",
+                          "qstash/quickstarts/python-vercel",
+                          "qstash/quickstarts/cloudflare-workers",
+                          "qstash/quickstarts/aws-lambda/nodejs",
+                          "qstash/quickstarts/aws-lambda/python",
+                          "qstash/quickstarts/deno-deploy",
+                          "qstash/quickstarts/fly-io/go"
+                        ]
+                      },
+                      {
+                        "group": "Features",
+                        "pages": [
+                          "qstash/features/background-jobs",
+                          "qstash/features/retry",
+                          "qstash/features/schedules",
+                          "qstash/features/queues",
+                          "qstash/features/flowcontrol",
+                          "qstash/features/delay",
+                          "qstash/features/url-groups",
+                          "qstash/features/batch",
+                          "qstash/features/callbacks",
+                          "qstash/features/dlq",
+                          "qstash/features/at-least-once",
+                          "qstash/features/deduplication",
+                          "qstash/features/security"
+                        ]
+                      },
+                      {
+                        "group": "Integrations",
+                        "pages": [
+                          "qstash/integrations/llm",
+                          "qstash/integrations/anthropic",
+                          "qstash/integrations/datadog",
+                          "qstash/integrations/prometheus",
+                          "qstash/integrations/resend",
+                          "qstash/integrations/pipedream",
+                          "qstash/integrations/n8n"
+                        ]
+                      },
+                      {
+                        "group": "How To",
+                        "pages": [
+                          "qstash/howto/publishing",
+                          "qstash/howto/url-group-endpoint",
+                          "qstash/howto/handling-failures",
+                          "qstash/howto/receiving",
+                          "qstash/howto/webhook",
+                          "qstash/howto/multi-region",
+                          "qstash/howto/local-development",
+                          "qstash/howto/local-tunnel",
+                          "qstash/howto/readonly-token",
+                          "qstash/howto/redact-fields",
+                          "qstash/howto/signature",
+                          "qstash/howto/delete-schedule",
+                          "qstash/howto/reset-token",
+                          "qstash/howto/roll-signing-keys",
+                          "qstash/howto/debug-logs",
+                          "qstash/recipes/periodic-data-updates"
+                        ]
+                      },
+                      {
+                        "group": "REST",
+                        "pages": [
+                          "qstash/api/authentication",
+                          "qstash/api/api-ratelimiting",
+                          {
+                            "group": "API",
+                            "openapi": {
+                              "source": "qstash/openapi.yaml",
+                              "directory": "qstash/api-reference"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "group": "SDKs",
+                        "pages": [
+                          {
+                            "group": "Typescript",
+                            "pages": [
+                              "qstash/sdks/ts/overview",
+                              "qstash/sdks/ts/gettingstarted",
+                              {
+                                "group": "Examples",
+                                "pages": [
+                                  "qstash/sdks/ts/examples/overview",
+                                  "qstash/sdks/ts/examples/publish",
+                                  "qstash/sdks/ts/examples/schedules",
+                                  "qstash/sdks/ts/examples/url-groups",
+                                  "qstash/sdks/ts/examples/dlq",
+                                  "qstash/sdks/ts/examples/logs",
+                                  "qstash/sdks/ts/examples/messages",
+                                  "qstash/sdks/ts/examples/receiver",
+                                  "qstash/sdks/ts/examples/queues",
+                                  "qstash/sdks/ts/examples/flow-control"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "Python",
+                            "pages": [
+                              "qstash/sdks/py/overview",
+                              "qstash/sdks/py/gettingstarted",
+                              {
+                                "group": "Examples",
+                                "pages": [
+                                  "qstash/sdks/py/examples/overview",
+                                  "qstash/sdks/py/examples/publish",
+                                  "qstash/sdks/py/examples/schedules",
+                                  "qstash/sdks/py/examples/url-groups",
+                                  "qstash/sdks/py/examples/dlq",
+                                  "qstash/sdks/py/examples/events",
+                                  "qstash/sdks/py/examples/messages",
+                                  "qstash/sdks/py/examples/keys",
+                                  "qstash/sdks/py/examples/receiver",
+                                  "qstash/sdks/py/examples/queues",
+                                  "qstash/sdks/py/examples/flow-control"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "product": "Workflow",
+                "icon": "/img/icons/workflow.svg",
+                "groups": [
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "workflow/getstarted",
+                      {
+                        "group": "Quickstarts",
+                        "pages": [
+                          "workflow/quickstarts/platforms",
+                          {
+                            "group": "TypeScript",
+                            "pages": [
+                              "workflow/quickstarts/vercel-nextjs",
+                              "workflow/quickstarts/cloudflare-workers",
+                              "workflow/quickstarts/nuxt",
+                              "workflow/quickstarts/solidjs",
+                              "workflow/quickstarts/svelte",
+                              "workflow/quickstarts/hono",
+                              "workflow/quickstarts/express",
+                              "workflow/quickstarts/astro",
+                              "workflow/quickstarts/tanstack-start"
+                            ]
+                          },
+                          {
+                            "group": "Python",
+                            "pages": [
+                              "workflow/quickstarts/fastapi",
+                              "workflow/quickstarts/nextjs-fastapi",
+                              "workflow/quickstarts/flask",
+                              "workflow/quickstarts/nextjs-flask"
+                            ]
+                          }
+                        ]
+                      },
+                      "workflow/basics/how",
+                      "workflow/basics/caveats"
+                    ]
+                  },
+                  {
+                    "group": "Core Concepts",
+                    "pages": [
+                      {
+                        "group": "Create Workflow Endpoint",
+                        "pages": [
+                          "workflow/basics/serve",
+                          "workflow/basics/serve/advanced"
+                        ]
+                      },
+                      {
+                        "group": "Local Development",
+                        "pages": [
+                          "workflow/howto/local-development/development-server",
+                          "workflow/howto/local-development/local-tunnel"
+                        ]
+                      },
+                      {
+                        "group": "Steps",
+                        "pages": [
+                          "workflow/steps",
+                          "workflow/steps/run",
+                          "workflow/steps/sleep",
+                          "workflow/steps/sleepUntil",
+                          "workflow/steps/call",
+                          "workflow/steps/waitForEvent",
+                          "workflow/steps/createWebhook",
+                          "workflow/steps/waitForWebhook",
+                          "workflow/steps/notify",
+                          "workflow/steps/invoke",
+                          "workflow/steps/api",
+                          "workflow/steps/cancel"
+                        ]
+                      },
+                      {
+                        "group": "Workflow Client",
+                        "pages": [
+                          "workflow/basics/client",
+                          {
+                            "group": "Functions",
+                            "pages": [
+                              "workflow/basics/client/trigger",
+                              "workflow/basics/client/cancel",
+                              "workflow/basics/client/logs",
+                              {
+                                "group": "client.dlq",
+                                "pages": [
+                                  "workflow/basics/client/dlq/list",
+                                  "workflow/basics/client/dlq/restart",
+                                  "workflow/basics/client/dlq/resume",
+                                  "workflow/basics/client/dlq/delete",
+                                  "workflow/basics/client/dlq/callback"
+                                ]
+                              },
+                              "workflow/basics/client/notify",
+                              "workflow/basics/client/waiters"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "How To",
+                        "pages": [
+                          "workflow/howto/start",
+                          "workflow/howto/configure",
+                          "workflow/howto/cancel",
+                          "workflow/howto/security",
+                          "workflow/howto/get-token",
+                          "workflow/howto/readonly-token",
+                          "workflow/howto/redact-fields",
+                          "workflow/howto/changes",
+                          "workflow/howto/schedule",
+                          "workflow/howto/use-webhooks",
+                          "workflow/howto/middlewares",
+                          "workflow/howto/migrations",
+                          "workflow/howto/multi-region",
+                          {
+                            "group": "Realtime",
+                            "pages": [
+                              "workflow/howto/realtime/basic",
+                              "workflow/howto/realtime/human-in-the-loop"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Features",
+                    "pages": [
+                      {
+                        "group": "Retries",
+                        "pages": [
+                          "workflow/features/retries",
+                          "workflow/features/retries/prevent-retries"
+                        ]
+                      },
+                      "workflow/features/parallel-steps",
+                      {
+                        "group": "Failure Function",
+                        "pages": [
+                          "workflow/features/failure-callback",
+                          "workflow/features/failureFunction/reliability",
+                          "workflow/features/failureFunction/advanced"
+                        ]
+                      },
+                      {
+                        "group": "Dead Letter Queue",
+                        "pages": [
+                          "workflow/features/dlq",
+                          "workflow/features/dlq/restart",
+                          "workflow/features/dlq/resume",
+                          "workflow/features/dlq/delete",
+                          "workflow/features/dlq/callback"
+                        ]
+                      },
+                      {
+                        "group": "Flow Control",
+                        "pages": [
+                          "workflow/features/flow-control",
+                          "workflow/features/flow-control/rate-period",
+                          "workflow/features/flow-control/parallelism",
+                          "workflow/features/flow-control/monitor"
+                        ]
+                      },
+                      {
+                        "group": "Wait For Event",
+                        "pages": [
+                          "workflow/features/wait-for-event",
+                          "workflow/features/wait",
+                          "workflow/features/notify"
+                        ]
+                      },
+                      "workflow/features/webhooks",
+                      {
+                        "group": "Invoke",
+                        "pages": [
+                          "workflow/features/invoke",
+                          "workflow/features/invoke/serveMany"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Agents",
+                    "pages": [
+                      "workflow/agents/overview",
+                      "workflow/agents/getting-started",
+                      "workflow/agents/features",
+                      {
+                        "group": "Patterns",
+                        "pages": [
+                          "workflow/agents/patterns/prompt-chaining",
+                          "workflow/agents/patterns/evaluator-optimizer",
+                          "workflow/agents/patterns/parallelization",
+                          "workflow/agents/patterns/orchestrator-workers"
+                        ]
+                      },
+                      "workflow/agents/examples"
+                    ]
+                  },
+                  {
+                    "group": "API Reference",
+                    "pages": [
+                      {
+                        "group": "REST API",
+                        "openapi": {
+                          "source": "workflow/openapi.yaml",
+                          "directory": "workflow/api-reference"
+                        }
+                      },
+                      "workflow/sdk/workflow-js",
+                      "workflow/sdk/workflow-py"
+                    ]
+                  },
+                  {
+                    "group": "Resources",
+                    "pages": [
+                      {
+                        "group": "Integrations",
+                        "pages": [
+                          "workflow/integrations/openai",
+                          "workflow/integrations/anthropic",
+                          "workflow/integrations/aisdk",
+                          "workflow/integrations/resend",
+                          "workflow/integrations/datadog",
+                          "workflow/integrations/prometheus"
+                        ]
+                      },
+                      {
+                        "group": "Examples",
+                        "pages": [
+                          "workflow/examples/allInOne",
+                          "workflow/examples/waitForEvent",
+                          "workflow/examples/customerOnboarding",
+                          "workflow/examples/authWebhook",
+                          "workflow/examples/paymentRetry",
+                          "workflow/examples/eCommerceOrderFulfillment",
+                          "workflow/examples/imageProcessing",
+                          "workflow/examples/customRetry",
+                          "workflow/examples/dynamicWorkflow"
+                        ]
+                      },
+                      "workflow/pricing",
+                      {
+                        "group": "Troubleshooting",
+                        "pages": [
+                          "workflow/troubleshooting/general",
+                          "workflow/troubleshooting/vercel"
+                        ]
+                      },
+                      "workflow/changelog",
+                      "workflow/roadmap",
+                      "workflow/llms-txt"
+                    ]
+                  }
+                ]
+              },
+              {
+                "product": "Search",
+                "icon": "/img/icons/search.svg",
+                "groups": [
+                  {
+                    "group": "Search",
+                    "pages": [
+                      {
+                        "group": "Overall",
+                        "pages": [
+                          "search/overall/getstarted",
+                          "search/overall/whatisupstashsearch",
+                          "search/overall/pricing"
+                        ]
+                      },
+                      {
+                        "group": "Quickstarts",
+                        "pages": [
+                          "search/tutorials/nextjs",
+                          "search/tutorials/buildsearchbar"
+                        ]
+                      },
+                      {
+                        "group": "Search UI",
+                        "pages": [
+                          "search/ui/search-bar"
+                        ]
+                      },
+                      {
+                        "group": "Features",
+                        "pages": [
+                          "search/features/algorithm",
+                          "search/features/indexes",
+                          "search/features/content-and-metadata",
+                          "search/features/filtering",
+                          "search/features/reranking",
+                          "search/features/advanced-settings"
+                        ]
+                      },
+                      {
+                        "group": "SDKs",
+                        "pages": [
+                          {
+                            "group": "Typescript",
+                            "pages": [
+                              "search/sdks/ts/getting-started",
+                              "search/sdks/ts/contributing",
+                              {
+                                "group": "Commands",
+                                "pages": [
+                                  "search/sdks/ts/commands/search",
+                                  "search/sdks/ts/commands/upsert",
+                                  "search/sdks/ts/commands/fetch",
+                                  "search/sdks/ts/commands/delete",
+                                  "search/sdks/ts/commands/range",
+                                  "search/sdks/ts/commands/reset",
+                                  "search/sdks/ts/commands/info"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "Python",
+                            "pages": [
+                              "search/sdks/py/gettingstarted",
+                              {
+                                "group": "Commands",
+                                "pages": [
+                                  "search/sdks/py/commands/search",
+                                  "search/sdks/py/commands/upsert",
+                                  "search/sdks/py/commands/fetch",
+                                  "search/sdks/py/commands/delete",
+                                  "search/sdks/py/commands/range",
+                                  "search/sdks/py/commands/reset",
+                                  "search/sdks/py/commands/info"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Integrations",
+                        "pages": [
+                          "search/integrations/docusaurus"
+                        ]
+                      },
+                      {
+                        "group": "Tools",
+                        "pages": [
+                          "search/tools/databasemigrator",
+                          "search/tools/documentationcrawler"
+                        ]
+                      },
+                      {
+                        "group": "Help",
+                        "pages": [
+                          "search/help/faq"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "product": "Box",
+                "icon": "/img/icons/box.svg",
+                "groups": [
+                  {
+                    "group": "Introduction",
+                    "pages": [
+                      "box/overall/quickstart",
+                      "box/overall/how-it-works",
+                      "box/overall/use-cases",
+                      "box/overall/pricing"
+                    ]
+                  },
+                  {
+                    "group": "Basics",
+                    "pages": [
+                      "box/overall/agent",
+                      {
+                        "group": "Custom Agents",
+                        "pages": [
+                          "box/overall/custom-agent",
+                          "box/overall/custom-harness/pi",
+                          "box/overall/custom-harness/gemini",
+                          "box/overall/custom-harness/aider",
+                          "box/overall/custom-harness/goose",
+                          "box/overall/custom-harness/crewai",
+                          "box/overall/custom-harness/pydantic-ai"
+                        ]
+                      },
+                      "box/overall/git",
+                      "box/overall/shell",
+                      "box/overall/live-sessions",
+                      "box/overall/files",
+                      "box/overall/snapshots"
+                    ]
+                  },
+                  {
+                    "group": "Lifecycle",
+                    "pages": [
+                      "box/overall/preview",
+                      "box/overall/schedules",
+                      "box/overall/keep-alive",
+                      "box/overall/ephemeral-box"
+                    ]
+                  },
+                  {
+                    "group": "Security",
+                    "pages": [
+                      "box/overall/security",
+                      "box/overall/network-policy",
+                      "box/overall/attach-headers"
+                    ]
+                  },
+                  {
+                    "group": "Browser",
+                    "pages": [
+                      "box/overall/browser/overview",
+                      "box/overall/browser/tabs",
+                      "box/overall/browser/reading-pages",
+                      "box/overall/browser/ai-actions",
+                      "box/overall/browser/live-view",
+                      "box/overall/browser/recordings",
+                      "box/overall/browser/connect",
+                      "box/overall/browser/cookbook"
+                    ]
+                  },
+                  {
+                    "group": "Guides",
+                    "pages": [
+                      "box/guides/remote-development",
+                      "box/guides/nextjs-setup",
+                      "box/guides/code-review-agent",
+                      "box/guides/langchain-deep-agents",
+                      "box/guides/web-scraping-playwright",
+                      "box/guides/ai-sdk-code-interpreter",
+                      "box/guides/tanstack-ai-file-editor",
+                      "box/guides/pi-setup",
+                      "box/guides/openclaw-setup",
+                      "box/guides/hermes-setup",
+                      "box/guides/crabbox-setup"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Utility",
+            "products": [
+              {
+                "product": "Realtime",
+                "groups": [
+                  {
+                    "group": "Realtime",
+                    "pages": [
+                      "realtime/overall/quickstart",
+                      "realtime/features/client-side",
+                      "realtime/features/server-side",
+                      "realtime/features/channels",
+                      "realtime/features/middleware",
+                      "realtime/features/history",
+                      "realtime/features/serverless",
+                      "realtime/overall/pricing"
+                    ]
+                  }
+                ]
+              },
+              {
+                "product": "Rate Limit",
+                "groups": [
+                  {
+                    "group": "TypeScript",
                     "pages": [
                       "redis/sdks/ratelimit-ts/overview",
                       "redis/sdks/ratelimit-ts/gettingstarted",
@@ -708,950 +2131,13 @@
                     ]
                   },
                   {
-                    "group": "Ratelimit (PY)",
+                    "group": "Python",
                     "pages": [
                       "redis/sdks/ratelimit-py/overview",
                       "redis/sdks/ratelimit-py/gettingstarted",
                       "redis/sdks/ratelimit-py/features",
                       "redis/sdks/ratelimit-py/algorithms"
                     ]
-                  },
-                  {
-                    "group": "AgentKit",
-                    "pages": [
-                      "redis/sdks/agentkit/ai-sdk",
-                      "redis/sdks/agentkit/eve"
-                    ]
-                  },
-                  "redis/sdks/mcp",
-                  "redis/sdks/realtime",
-                  "redis/sdks/agent-analytics",
-                  "redis/sdks/redis-analytics"
-                ]
-              },
-              {
-                "group": "Features",
-                "pages": [
-                  "redis/features/globaldatabase",
-                  "redis/features/restapi",
-                  "redis/features/backup",
-                  "redis/features/durability",
-                  "redis/features/replication",
-                  "redis/features/key-locking",
-                  "redis/features/eviction",
-                  "redis/features/security",
-                  "redis/features/credential-protection",
-                  "redis/features/consistency",
-                  "redis/features/auto-upgrade"
-                ]
-              },
-              {
-                "group": "Search",
-                "pages": [
-                  "redis/search/introduction",
-                  "redis/search/getting-started",
-                  "redis/search/index-management",
-                  "redis/search/document-updates",
-                  "redis/search/schema-definition",
-                  "redis/search/querying",
-                  "redis/search/aggregations",
-                  "redis/search/counting",
-                  "redis/search/aliases",
-                  "redis/search/command-reference",
-                  "redis/search/troubleshooting",
-                  {
-                    "group": "Adapters",
-                    "pages": [
-                      "redis/search/adapters/ioredis",
-                      "redis/search/adapters/node-redis"
-                    ]
-                  },
-                  {
-                    "group": "Query Operators",
-                    "pages": [
-                      {
-                        "group": "Boolean Operators",
-                        "pages": [
-                          "redis/search/query-operators/boolean-operators/overview",
-                          "redis/search/query-operators/boolean-operators/must",
-                          "redis/search/query-operators/boolean-operators/should",
-                          "redis/search/query-operators/boolean-operators/must-not",
-                          "redis/search/query-operators/boolean-operators/boost"
-                        ]
-                      },
-                      {
-                        "group": "Field Operators",
-                        "pages": [
-                          "redis/search/query-operators/field-operators/overview",
-                          "redis/search/query-operators/field-operators/smart-matching",
-                          "redis/search/query-operators/field-operators/eq",
-                          "redis/search/query-operators/field-operators/in",
-                          "redis/search/query-operators/field-operators/range-operators",
-                          "redis/search/query-operators/field-operators/phrase",
-                          "redis/search/query-operators/field-operators/fuzzy",
-                          "redis/search/query-operators/field-operators/regex",
-                          "redis/search/query-operators/field-operators/boost"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Aggregation Operators",
-                    "pages": [
-                      {
-                        "group": "Metric Aggregations",
-                        "pages": [
-                          "redis/search/aggregation-operators/metric-aggregations/overview",
-                          "redis/search/aggregation-operators/metric-aggregations/avg",
-                          "redis/search/aggregation-operators/metric-aggregations/sum",
-                          "redis/search/aggregation-operators/metric-aggregations/min",
-                          "redis/search/aggregation-operators/metric-aggregations/max",
-                          "redis/search/aggregation-operators/metric-aggregations/count",
-                          "redis/search/aggregation-operators/metric-aggregations/cardinality",
-                          "redis/search/aggregation-operators/metric-aggregations/stats",
-                          "redis/search/aggregation-operators/metric-aggregations/extended-stats",
-                          "redis/search/aggregation-operators/metric-aggregations/percentiles"
-                        ]
-                      },
-                      {
-                        "group": "Bucket Aggregations",
-                        "pages": [
-                          "redis/search/aggregation-operators/bucket-aggregations/overview",
-                          "redis/search/aggregation-operators/bucket-aggregations/terms",
-                          "redis/search/aggregation-operators/bucket-aggregations/range",
-                          "redis/search/aggregation-operators/bucket-aggregations/histogram",
-                          "redis/search/aggregation-operators/bucket-aggregations/date-histogram",
-                          "redis/search/aggregation-operators/bucket-aggregations/facet"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Recipes",
-                    "pages": [
-                      "redis/search/recipes/overview",
-                      "redis/search/recipes/e-commerce-search",
-                      "redis/search/recipes/blog-search",
-                      "redis/search/recipes/user-directory"
-                    ]
-                  }
-                ]
-              },
-
-              {
-                "group": "Security & Compliance",
-                "pages": [
-                  "redis/help/production-checklist",
-                  "redis/help/shared-responsibility-model",
-                  "redis/help/managing-healthcare-data"
-                ]
-              },
-              {
-                "group": "Integrations",
-                "pages": [
-                  "redis/integrations/drizzle",
-                  "redis/howto/datadog",
-                  "redis/integrations/prometheus",
-                  "redis/integrations/bullmq",
-                  "redis/integrations/effect-mq",
-                  "redis/integrations/sidekiq",
-                  "redis/howto/vercelintegration",
-                  "redis/integrations/replit-templates",
-                  "redis/howto/emqxintegration",
-                  "redis/integrations/celery",
-                  "redis/integrations/n8n",
-                  {
-                    "group": "AgentKit",
-                    "pages": [
-                      "redis/sdks/agentkit/ai-sdk",
-                      "redis/sdks/agentkit/eve"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Tutorials",
-                "pages": [
-                  "redis/tutorials/laravel_caching",
-                  "redis/tutorials/python_realtime_chat",
-                  "redis/tutorials/python_session",
-                  "redis/tutorials/python_rate_limiting",
-                  "redis/tutorials/python_multithreading",
-                  "redis/tutorials/python_fastapi_caching",
-                  "redis/tutorials/python_url_shortener",
-                  "redis/tutorials/api_with_cdk",
-                  "redis/tutorials/agent_memory",
-                  "redis/tutorials/tanstack_chat_persistence",
-                  "redis/tutorials/auto_complete_with_serverless_redis",
-                  "redis/tutorials/aws_app_runner_with_redis",
-                  "redis/tutorials/cloud_run_sessions",
-                  "redis/tutorials/cloudflare_workers_with_redis",
-                  "redis/tutorials/cloudflare_websockets_redis",
-                  "redis/tutorials/edge_leaderboard",
-                  "redis/tutorials/express_session",
-                  "redis/tutorials/goapi",
-                  "redis/tutorials/histogram",
-                  "redis/tutorials/job_processing",
-                  "redis/tutorials/redis_queue",
-                  "redis/tutorials/nextjs_with_redis",
-                  "redis/tutorials/notification",
-                  "redis/tutorials/nuxtjs_with_redis",
-                  "redis/tutorials/pythonapi",
-                  "redis/tutorials/rate-limiting",
-                  "redis/tutorials/redisson",
-                  "redis/tutorials/roadmapvotingapp",
-                  "redis/tutorials/serverless_java_redis",
-                  "redis/tutorials/using_aws_sam",
-                  "redis/tutorials/using_google_cloud_functions",
-                  "redis/tutorials/using_serverless_framework"
-                ]
-              },
-              {
-                "group": "Troubleshooting",
-                "pages": [
-                  "redis/troubleshooting/command_count_increases_unexpectedly",
-                  "redis/troubleshooting/readonly_connection",
-                  "redis/troubleshooting/no_auth",
-                  "redis/troubleshooting/http_unauthorized",
-                  "redis/troubleshooting/econn_reset",
-                  "redis/troubleshooting/max_concurrent_connections",
-                  "redis/troubleshooting/max_request_size_exceeded",
-                  "redis/troubleshooting/max_record_size_exceeded",
-                  "redis/troubleshooting/max_key_size_exceeded",
-                  "redis/troubleshooting/db_capacity_quota_exceeded",
-                  "redis/troubleshooting/max_requests_limit",
-                  "redis/troubleshooting/stream_pel_limit"
-                ]
-              },
-              {
-                "group": "Help",
-                "pages": [
-                  "redis/help/faq",
-                  {
-                    "group": "Support",
-                    "pages": [
-                      "redis/help/support",
-                      "redis/help/uptime",
-                      "redis/help/legal",
-                      "redis/help/compliance",
-                      "redis/help/integration"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Command Reference",
-            "pages": [
-              "redis/commands/overview",
-              {
-                "group": "Bitmap",
-                "pages": [
-                  "redis/commands/bitmap/overview",
-                  "redis/commands/bitmap/bitcount",
-                  "redis/commands/bitmap/bitfield",
-                  "redis/commands/bitmap/bitfield-ro",
-                  "redis/commands/bitmap/bitop",
-                  "redis/commands/bitmap/bitpos",
-                  "redis/commands/bitmap/getbit",
-                  "redis/commands/bitmap/setbit"
-                ]
-              },
-              {
-                "group": "Connection",
-                "pages": [
-                  "redis/commands/connection/overview",
-                  "redis/commands/connection/auth",
-                  "redis/commands/connection/client-getname",
-                  "redis/commands/connection/client-id",
-                  "redis/commands/connection/client-info",
-                  "redis/commands/connection/client-list",
-                  "redis/commands/connection/client-setinfo",
-                  "redis/commands/connection/client-setname",
-                  "redis/commands/connection/echo",
-                  "redis/commands/connection/hello",
-                  "redis/commands/connection/ping",
-                  "redis/commands/connection/quit",
-                  "redis/commands/connection/reset",
-                  "redis/commands/connection/select"
-                ]
-              },
-              {
-                "group": "Functions",
-                "pages": [
-                  "redis/commands/functions/overview",
-                  "redis/commands/functions/fcall",
-                  "redis/commands/functions/fcall-ro",
-                  "redis/commands/functions/function-delete",
-                  "redis/commands/functions/function-flush",
-                  "redis/commands/functions/function-kill",
-                  "redis/commands/functions/function-list",
-                  "redis/commands/functions/function-load",
-                  "redis/commands/functions/function-stats"
-                ]
-              },
-              {
-                "group": "Generic",
-                "pages": [
-                  "redis/commands/generic/overview",
-                  "redis/commands/generic/copy",
-                  "redis/commands/generic/del",
-                  "redis/commands/generic/dump",
-                  "redis/commands/generic/exists",
-                  "redis/commands/generic/expire",
-                  "redis/commands/generic/expireat",
-                  "redis/commands/generic/expiretime",
-                  "redis/commands/generic/keys",
-                  "redis/commands/generic/memory-usage",
-                  "redis/commands/generic/persist",
-                  "redis/commands/generic/pexpire",
-                  "redis/commands/generic/pexpireat",
-                  "redis/commands/generic/pexpiretime",
-                  "redis/commands/generic/pttl",
-                  "redis/commands/generic/randomkey",
-                  "redis/commands/generic/rename",
-                  "redis/commands/generic/renamenx",
-                  "redis/commands/generic/restore",
-                  "redis/commands/generic/scan",
-                  "redis/commands/generic/touch",
-                  "redis/commands/generic/ttl",
-                  "redis/commands/generic/type",
-                  "redis/commands/generic/unlink",
-                  "redis/commands/generic/wait",
-                  "redis/commands/generic/waitaof"
-                ]
-              },
-              {
-                "group": "Geo",
-                "pages": [
-                  "redis/commands/geo/overview",
-                  "redis/commands/geo/geoadd",
-                  "redis/commands/geo/geodist",
-                  "redis/commands/geo/geohash",
-                  "redis/commands/geo/geopos",
-                  "redis/commands/geo/georadius",
-                  "redis/commands/geo/georadius-ro",
-                  "redis/commands/geo/georadiusbymember",
-                  "redis/commands/geo/georadiusbymember-ro",
-                  "redis/commands/geo/geosearch",
-                  "redis/commands/geo/geosearchstore"
-                ]
-              },
-              {
-                "group": "Hash",
-                "pages": [
-                  "redis/commands/hash/overview",
-                  "redis/commands/hash/hdel",
-                  "redis/commands/hash/hexists",
-                  "redis/commands/hash/hexpire",
-                  "redis/commands/hash/hexpireat",
-                  "redis/commands/hash/hexpiretime",
-                  "redis/commands/hash/hget",
-                  "redis/commands/hash/hgetall",
-                  "redis/commands/hash/hgetdel",
-                  "redis/commands/hash/hgetex",
-                  "redis/commands/hash/hincrby",
-                  "redis/commands/hash/hincrbyfloat",
-                  "redis/commands/hash/hkeys",
-                  "redis/commands/hash/hlen",
-                  "redis/commands/hash/hmget",
-                  "redis/commands/hash/hmset",
-                  "redis/commands/hash/hpersist",
-                  "redis/commands/hash/hpexpire",
-                  "redis/commands/hash/hpexpireat",
-                  "redis/commands/hash/hpexpiretime",
-                  "redis/commands/hash/hpttl",
-                  "redis/commands/hash/hrandfield",
-                  "redis/commands/hash/hscan",
-                  "redis/commands/hash/hset",
-                  "redis/commands/hash/hsetex",
-                  "redis/commands/hash/hsetnx",
-                  "redis/commands/hash/hstrlen",
-                  "redis/commands/hash/httl",
-                  "redis/commands/hash/hvals"
-                ]
-              },
-              {
-                "group": "HyperLogLog",
-                "pages": [
-                  "redis/commands/hyperloglog/overview",
-                  "redis/commands/hyperloglog/pfadd",
-                  "redis/commands/hyperloglog/pfcount",
-                  "redis/commands/hyperloglog/pfmerge"
-                ]
-              },
-              {
-                "group": "JSON",
-                "pages": [
-                  "redis/commands/json/overview",
-                  "redis/commands/json/json-arrappend",
-                  "redis/commands/json/json-arrindex",
-                  "redis/commands/json/json-arrinsert",
-                  "redis/commands/json/json-arrlen",
-                  "redis/commands/json/json-arrpop",
-                  "redis/commands/json/json-arrtrim",
-                  "redis/commands/json/json-clear",
-                  "redis/commands/json/json-del",
-                  "redis/commands/json/json-debug",
-                  "redis/commands/json/json-forget",
-                  "redis/commands/json/json-get",
-                  "redis/commands/json/json-merge",
-                  "redis/commands/json/json-mget",
-                  "redis/commands/json/json-mset",
-                  "redis/commands/json/json-numincrby",
-                  "redis/commands/json/json-nummultby",
-                  "redis/commands/json/json-objkeys",
-                  "redis/commands/json/json-objlen",
-                  "redis/commands/json/json-resp",
-                  "redis/commands/json/json-set",
-                  "redis/commands/json/json-strappend",
-                  "redis/commands/json/json-strlen",
-                  "redis/commands/json/json-toggle",
-                  "redis/commands/json/json-type"
-                ]
-              },
-              {
-                "group": "List",
-                "pages": [
-                  "redis/commands/list/overview",
-                  "redis/commands/list/blmove",
-                  "redis/commands/list/blmpop",
-                  "redis/commands/list/blpop",
-                  "redis/commands/list/brpop",
-                  "redis/commands/list/brpoplpush",
-                  "redis/commands/list/lindex",
-                  "redis/commands/list/linsert",
-                  "redis/commands/list/llen",
-                  "redis/commands/list/lmove",
-                  "redis/commands/list/lmpop",
-                  "redis/commands/list/lpop",
-                  "redis/commands/list/lpos",
-                  "redis/commands/list/lpush",
-                  "redis/commands/list/lpushx",
-                  "redis/commands/list/lrange",
-                  "redis/commands/list/lrem",
-                  "redis/commands/list/lset",
-                  "redis/commands/list/ltrim",
-                  "redis/commands/list/rpop",
-                  "redis/commands/list/rpoplpush",
-                  "redis/commands/list/rpush",
-                  "redis/commands/list/rpushx"
-                ]
-              },
-              {
-                "group": "Pub/Sub",
-                "pages": [
-                  "redis/commands/pub-sub/overview",
-                  "redis/commands/pub-sub/psubscribe",
-                  "redis/commands/pub-sub/publish",
-                  "redis/commands/pub-sub/pubsub",
-                  "redis/commands/pub-sub/punsubscribe",
-                  "redis/commands/pub-sub/subscribe",
-                  "redis/commands/pub-sub/unsubscribe"
-                ]
-              },
-              {
-                "group": "Scripting",
-                "pages": [
-                  "redis/commands/scripting/overview",
-                  "redis/commands/scripting/eval",
-                  "redis/commands/scripting/eval-ro",
-                  "redis/commands/scripting/evalsha",
-                  "redis/commands/scripting/evalsha-ro",
-                  "redis/commands/scripting/script-exists",
-                  "redis/commands/scripting/script-flush",
-                  "redis/commands/scripting/script-kill",
-                  "redis/commands/scripting/script-load"
-                ]
-              },
-              {
-                "group": "Search",
-                "pages": [
-                  "redis/commands/search/overview",
-                  "redis/commands/search/search-create",
-                  "redis/commands/search/search-reindex",
-                  "redis/commands/search/search-drop",
-                  "redis/commands/search/search-describe",
-                  "redis/commands/search/search-waitindexing",
-                  "redis/commands/search/search-listindexes",
-                  "redis/commands/search/search-query",
-                  "redis/commands/search/search-count",
-                  "redis/commands/search/search-aggregate",
-                  "redis/commands/search/search-aliasadd",
-                  "redis/commands/search/search-aliasdel",
-                  "redis/commands/search/search-listaliases"
-                ]
-              },
-              {
-                "group": "Server",
-                "pages": [
-                  "redis/commands/server/overview",
-                  "redis/commands/server/acl-cat",
-                  "redis/commands/server/acl-deluser",
-                  "redis/commands/server/acl-genpass",
-                  "redis/commands/server/acl-gentoken",
-                  "redis/commands/server/acl-getuser",
-                  "redis/commands/server/acl-list",
-                  "redis/commands/server/acl-load",
-                  "redis/commands/server/acl-log",
-                  "redis/commands/server/acl-resttoken",
-                  "redis/commands/server/acl-save",
-                  "redis/commands/server/acl-setuser",
-                  "redis/commands/server/acl-users",
-                  "redis/commands/server/acl-whoami",
-                  "redis/commands/server/command",
-                  "redis/commands/server/config-get",
-                  "redis/commands/server/config-set",
-                  "redis/commands/server/dbsize",
-                  "redis/commands/server/flushall",
-                  "redis/commands/server/flushdb",
-                  "redis/commands/server/info",
-                  "redis/commands/server/monitor",
-                  "redis/commands/server/time"
-                ]
-              },
-              {
-                "group": "Set",
-                "pages": [
-                  "redis/commands/set/overview",
-                  "redis/commands/set/sadd",
-                  "redis/commands/set/scard",
-                  "redis/commands/set/sdiff",
-                  "redis/commands/set/sdiffstore",
-                  "redis/commands/set/sinter",
-                  "redis/commands/set/sintercard",
-                  "redis/commands/set/sinterstore",
-                  "redis/commands/set/sismember",
-                  "redis/commands/set/smembers",
-                  "redis/commands/set/smismember",
-                  "redis/commands/set/smove",
-                  "redis/commands/set/spop",
-                  "redis/commands/set/srandmember",
-                  "redis/commands/set/srem",
-                  "redis/commands/set/sscan",
-                  "redis/commands/set/sunion",
-                  "redis/commands/set/sunionstore"
-                ]
-              },
-              {
-                "group": "Sorted Set",
-                "pages": [
-                  "redis/commands/sorted-set/overview",
-                  "redis/commands/sorted-set/bzmpop",
-                  "redis/commands/sorted-set/bzpopmax",
-                  "redis/commands/sorted-set/bzpopmin",
-                  "redis/commands/sorted-set/zadd",
-                  "redis/commands/sorted-set/zcard",
-                  "redis/commands/sorted-set/zcount",
-                  "redis/commands/sorted-set/zdiff",
-                  "redis/commands/sorted-set/zdiffstore",
-                  "redis/commands/sorted-set/zincrby",
-                  "redis/commands/sorted-set/zinter",
-                  "redis/commands/sorted-set/zintercard",
-                  "redis/commands/sorted-set/zinterstore",
-                  "redis/commands/sorted-set/zlexcount",
-                  "redis/commands/sorted-set/zmpop",
-                  "redis/commands/sorted-set/zmscore",
-                  "redis/commands/sorted-set/zpopmax",
-                  "redis/commands/sorted-set/zpopmin",
-                  "redis/commands/sorted-set/zrandmember",
-                  "redis/commands/sorted-set/zrange",
-                  "redis/commands/sorted-set/zrangebylex",
-                  "redis/commands/sorted-set/zrangebyscore",
-                  "redis/commands/sorted-set/zrangestore",
-                  "redis/commands/sorted-set/zrank",
-                  "redis/commands/sorted-set/zrem",
-                  "redis/commands/sorted-set/zremrangebylex",
-                  "redis/commands/sorted-set/zremrangebyrank",
-                  "redis/commands/sorted-set/zremrangebyscore",
-                  "redis/commands/sorted-set/zrevrange",
-                  "redis/commands/sorted-set/zrevrangebylex",
-                  "redis/commands/sorted-set/zrevrangebyscore",
-                  "redis/commands/sorted-set/zrevrank",
-                  "redis/commands/sorted-set/zscan",
-                  "redis/commands/sorted-set/zscore",
-                  "redis/commands/sorted-set/zunion",
-                  "redis/commands/sorted-set/zunionstore"
-                ]
-              },
-              {
-                "group": "Streams",
-                "pages": [
-                  "redis/commands/streams/overview",
-                  "redis/commands/streams/xack",
-                  "redis/commands/streams/xackdel",
-                  "redis/commands/streams/xadd",
-                  "redis/commands/streams/xautoclaim",
-                  "redis/commands/streams/xclaim",
-                  "redis/commands/streams/xdel",
-                  "redis/commands/streams/xdelex",
-                  "redis/commands/streams/xgroup",
-                  "redis/commands/streams/xinfo-consumers",
-                  "redis/commands/streams/xinfo-groups",
-                  "redis/commands/streams/xinfo-stream",
-                  "redis/commands/streams/xlen",
-                  "redis/commands/streams/xpending",
-                  "redis/commands/streams/xrange",
-                  "redis/commands/streams/xread",
-                  "redis/commands/streams/xreadgroup",
-                  "redis/commands/streams/xrevrange",
-                  "redis/commands/streams/xtrim"
-                ]
-              },
-              {
-                "group": "String",
-                "pages": [
-                  "redis/commands/string/overview",
-                  "redis/commands/string/append",
-                  "redis/commands/string/decr",
-                  "redis/commands/string/decrby",
-                  "redis/commands/string/delex",
-                  "redis/commands/string/digest",
-                  "redis/commands/string/get",
-                  "redis/commands/string/getdel",
-                  "redis/commands/string/getex",
-                  "redis/commands/string/getrange",
-                  "redis/commands/string/getset",
-                  "redis/commands/string/incr",
-                  "redis/commands/string/incrby",
-                  "redis/commands/string/incrbyfloat",
-                  "redis/commands/string/mget",
-                  "redis/commands/string/mset",
-                  "redis/commands/string/msetnx",
-                  "redis/commands/string/psetex",
-                  "redis/commands/string/set",
-                  "redis/commands/string/setex",
-                  "redis/commands/string/setnx",
-                  "redis/commands/string/setrange",
-                  "redis/commands/string/strlen"
-                ]
-              },
-              {
-                "group": "Transactions",
-                "pages": [
-                  "redis/commands/transactions/overview",
-                  "redis/commands/transactions/discard",
-                  "redis/commands/transactions/exec",
-                  "redis/commands/transactions/multi",
-                  "redis/commands/transactions/unwatch",
-                  "redis/commands/transactions/watch"
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Vector",
-        "groups": [
-          {
-            "group": "Vector",
-            "pages": [
-              {
-                "group": "Overall",
-                "pages": [
-                  "vector/overall/getstarted",
-                  "vector/overall/whatisvector",
-                  "vector/overall/pricing",
-                  "vector/overall/changelog",
-                  "vector/overall/llms-txt"
-                ]
-              },
-              {
-                "group": "Features",
-                "pages": [
-                  "vector/features/algorithm",
-                  "vector/features/similarityfunctions",
-                  "vector/features/hybridindexes",
-                  "vector/features/sparseindexes",
-                  "vector/features/metadata",
-                  "vector/features/filtering",
-                  "vector/features/embeddingmodels",
-                  "vector/features/namespaces",
-                  "vector/features/resumablequery"
-                ]
-              },
-              {
-                "group": "REST API",
-                "pages": [
-                  "vector/api/get-started",
-                  {
-                    "group": "Endpoints",
-                    "pages": [
-                      "vector/api/endpoints/upsert",
-                      "vector/api/endpoints/upsert-data",
-                      "vector/api/endpoints/query",
-                      "vector/api/endpoints/query-data",
-                      {
-                        "group": "Resumable Query",
-                        "pages": [
-                          "vector/api/endpoints/resumable-query/start-with-vector",
-                          "vector/api/endpoints/resumable-query/start-with-data",
-                          "vector/api/endpoints/resumable-query/resume",
-                          "vector/api/endpoints/resumable-query/stop"
-                        ]
-                      },
-                      "vector/api/endpoints/fetch",
-                      "vector/api/endpoints/fetch-random",
-                      "vector/api/endpoints/range",
-                      "vector/api/endpoints/delete",
-                      "vector/api/endpoints/update",
-                      "vector/api/endpoints/reset",
-                      "vector/api/endpoints/info",
-                      "vector/api/endpoints/list-namespaces",
-                      "vector/api/endpoints/delete-namespace",
-                      "vector/api/endpoints/rename-namespace"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "SDKs",
-                "pages": [
-                  {
-                    "group": "Typescript",
-                    "pages": [
-                      "vector/sdks/ts/getting-started",
-                      {
-                        "group": "Commands",
-                        "pages": [
-                          "vector/sdks/ts/commands/upsert",
-                          "vector/sdks/ts/commands/query",
-                          "vector/sdks/ts/commands/resumable-query",
-                          "vector/sdks/ts/commands/fetch",
-                          "vector/sdks/ts/commands/delete",
-                          "vector/sdks/ts/commands/range",
-                          "vector/sdks/ts/commands/reset",
-                          "vector/sdks/ts/commands/info"
-                        ]
-                      },
-                      "vector/sdks/ts/advanced",
-                      "vector/sdks/ts/contributing"
-                    ]
-                  },
-                  {
-                    "group": "Python",
-                    "pages": [
-                      "vector/sdks/py/gettingstarted",
-                      "vector/sdks/py/features",
-                      {
-                        "group": "Example Calls",
-                        "pages": [
-                          "vector/sdks/py/example_calls/upsert",
-                          "vector/sdks/py/example_calls/query",
-                          "vector/sdks/py/example_calls/resumable-query",
-                          "vector/sdks/py/example_calls/range",
-                          "vector/sdks/py/example_calls/fetch",
-                          "vector/sdks/py/example_calls/delete",
-                          "vector/sdks/py/example_calls/update",
-                          "vector/sdks/py/example_calls/reset",
-                          "vector/sdks/py/example_calls/info"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "PHP",
-                    "pages": [
-                      "vector/sdks/php/getting-started",
-                      "vector/sdks/php/laravel",
-                      {
-                        "group": "Guides",
-                        "pages": [
-                          "vector/sdks/php/commands/upsert-vectors",
-                          "vector/sdks/php/commands/upsert-data",
-                          "vector/sdks/php/commands/query",
-                          "vector/sdks/php/commands/fetch",
-                          "vector/sdks/php/commands/delete-vectors",
-                          "vector/sdks/php/commands/reset",
-                          "vector/sdks/php/commands/info"
-                        ]
-                      }
-                    ]
-                  },
-                  "vector/sdk/semantic-cache-js",
-                  "vector/sdk/semantic-cache-py",
-                  "vector/sdk/gosdk"
-                ]
-              },
-              {
-                "group": "Integrations",
-                "pages": [
-                  "vector/integrations/ai-sdk",
-                  "vector/integrations/langchain",
-                  "vector/integrations/llamaindex",
-                  "vector/integrations/llamaparse",
-                  "vector/integrations/flowise",
-                  "vector/integrations/langflow"
-                ]
-              },
-              {
-                "group": "Tutorials",
-                "pages": [
-                  "vector/tutorials/semantic_search",
-                  "vector/tutorials/langchain",
-                  "vector/tutorials/llamaindex",
-                  "vector/tutorials/llamaparse",
-                  "vector/tutorials/huggingface-embeddings",
-                  "vector/tutorials/gradio-application"
-                ]
-              },
-              "vector/examples",
-              {
-                "group": "Help",
-                "pages": [
-                  "vector/help/faq"
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "QStash",
-        "groups": [
-          {
-            "group": "QStash",
-            "pages": [
-              {
-                "group": "Overall",
-                "pages": [
-                  "qstash/overall/getstarted",
-                  "qstash/overall/usecases",
-                  "qstash/overall/pricing",
-                  "qstash/overall/enterprise",
-                  "qstash/overall/apiexamples",
-                  "qstash/overall/compare",
-                  "qstash/overall/changelog",
-                  "qstash/overall/roadmap",
-                  "qstash/overall/llms-txt"
-                ]
-              },
-              {
-                "group": "Quickstarts",
-                "pages": [
-                  "qstash/quickstarts/vercel-nextjs",
-                  "qstash/quickstarts/python-vercel",
-                  "qstash/quickstarts/cloudflare-workers",
-                  "qstash/quickstarts/aws-lambda/nodejs",
-                  "qstash/quickstarts/aws-lambda/python",
-                  "qstash/quickstarts/deno-deploy",
-                  "qstash/quickstarts/fly-io/go"
-                ]
-              },
-              {
-                "group": "Features",
-                "pages": [
-                  "qstash/features/background-jobs",
-                  "qstash/features/retry",
-                  "qstash/features/schedules",
-                  "qstash/features/queues",
-                  "qstash/features/flowcontrol",
-                  "qstash/features/delay",
-                  "qstash/features/url-groups",
-                  "qstash/features/batch",
-                  "qstash/features/callbacks",
-                  "qstash/features/dlq",
-                  "qstash/features/at-least-once",
-                  "qstash/features/deduplication",
-                  "qstash/features/security"
-                ]
-              },
-              {
-                "group": "Integrations",
-                "pages": [
-                  "qstash/integrations/llm",
-                  "qstash/integrations/anthropic",
-                  "qstash/integrations/datadog",
-                  "qstash/integrations/prometheus",
-                  "qstash/integrations/resend",
-                  "qstash/integrations/pipedream",
-                  "qstash/integrations/n8n"
-                ]
-              },
-              {
-                "group": "How To",
-                "pages": [
-                  "qstash/howto/publishing",
-                  "qstash/howto/url-group-endpoint",
-                  "qstash/howto/handling-failures",
-                  "qstash/howto/receiving",
-                  "qstash/howto/webhook",
-                  "qstash/howto/multi-region",
-                  "qstash/howto/local-development",
-                  "qstash/howto/local-tunnel",
-                  "qstash/howto/readonly-token",
-                  "qstash/howto/redact-fields",
-                  "qstash/howto/signature",
-                  "qstash/howto/delete-schedule",
-                  "qstash/howto/reset-token",
-                  "qstash/howto/roll-signing-keys",
-                  "qstash/howto/debug-logs",
-                  "qstash/recipes/periodic-data-updates"
-                ]
-              },
-              {
-                "group": "REST",
-                "pages": [
-                  "qstash/api/authentication",
-                  "qstash/api/api-ratelimiting",
-                  {
-                    "group": "API",
-                    "openapi": {
-                      "source": "qstash/openapi.yaml",
-                      "directory": "qstash/api-reference"
-                    }
-                  }
-                ]
-              },
-              {
-                "group": "SDKs",
-                "pages": [
-                  {
-                    "group": "Typescript",
-                    "pages": [
-                      "qstash/sdks/ts/overview",
-                      "qstash/sdks/ts/gettingstarted",
-                      {
-                        "group": "Examples",
-                        "pages": [
-                          "qstash/sdks/ts/examples/overview",
-                          "qstash/sdks/ts/examples/publish",
-                          "qstash/sdks/ts/examples/schedules",
-                          "qstash/sdks/ts/examples/url-groups",
-                          "qstash/sdks/ts/examples/dlq",
-                          "qstash/sdks/ts/examples/logs",
-                          "qstash/sdks/ts/examples/messages",
-                          "qstash/sdks/ts/examples/receiver",
-                          "qstash/sdks/ts/examples/queues",
-                          "qstash/sdks/ts/examples/flow-control"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Python",
-                    "pages": [
-                      "qstash/sdks/py/overview",
-                      "qstash/sdks/py/gettingstarted",
-                      {
-                        "group": "Examples",
-                        "pages": [
-                          "qstash/sdks/py/examples/overview",
-                          "qstash/sdks/py/examples/publish",
-                          "qstash/sdks/py/examples/schedules",
-                          "qstash/sdks/py/examples/url-groups",
-                          "qstash/sdks/py/examples/dlq",
-                          "qstash/sdks/py/examples/events",
-                          "qstash/sdks/py/examples/messages",
-                          "qstash/sdks/py/examples/keys",
-                          "qstash/sdks/py/examples/receiver",
-                          "qstash/sdks/py/examples/queues",
-                          "qstash/sdks/py/examples/flow-control"
-                        ]
-                      }
-                    ]
                   }
                 ]
               }
@@ -1660,457 +2146,7 @@
         ]
       },
       {
-        "tab": "Workflow",
-        "groups": [
-          {
-            "group": "Getting Started",
-            "pages": [
-              "workflow/getstarted",
-              {
-                "group": "Quickstarts",
-                "pages": [
-                  "workflow/quickstarts/platforms",
-                  {
-                    "group": "TypeScript",
-                    "pages": [
-                      "workflow/quickstarts/vercel-nextjs",
-                      "workflow/quickstarts/cloudflare-workers",
-                      "workflow/quickstarts/nuxt",
-                      "workflow/quickstarts/solidjs",
-                      "workflow/quickstarts/svelte",
-                      "workflow/quickstarts/hono",
-                      "workflow/quickstarts/express",
-                      "workflow/quickstarts/astro",
-                      "workflow/quickstarts/tanstack-start"
-                    ]
-                  },
-                  {
-                    "group": "Python",
-                    "pages": [
-                      "workflow/quickstarts/fastapi",
-                      "workflow/quickstarts/nextjs-fastapi",
-                      "workflow/quickstarts/flask",
-                      "workflow/quickstarts/nextjs-flask"
-                    ]
-                  }
-                ]
-              },
-              "workflow/basics/how",
-              "workflow/basics/caveats"
-            ]
-          },
-          {
-            "group": "Core Concepts",
-            "pages": [
-              {
-                "group": "Create Workflow Endpoint",
-                "pages": [
-                  "workflow/basics/serve",
-                  "workflow/basics/serve/advanced"
-                ]
-              },
-              {
-                "group": "Local Development",
-                "pages": [
-                  "workflow/howto/local-development/development-server",
-                  "workflow/howto/local-development/local-tunnel"
-                ]
-              },
-              {
-                "group": "Steps",
-                "pages": [
-                  "workflow/steps",
-                  "workflow/steps/run",
-                  "workflow/steps/sleep",
-                  "workflow/steps/sleepUntil",
-                  "workflow/steps/call",
-                  "workflow/steps/waitForEvent",
-                  "workflow/steps/createWebhook",
-                  "workflow/steps/waitForWebhook",
-                  "workflow/steps/notify",
-                  "workflow/steps/invoke",
-                  "workflow/steps/api",
-                  "workflow/steps/cancel"
-                ]
-              },
-              {
-                "group": "Workflow Client",
-                "pages": [
-                  "workflow/basics/client",
-                  {
-                    "group": "Functions",
-                    "pages": [
-                      "workflow/basics/client/trigger",
-                      "workflow/basics/client/cancel",
-                      "workflow/basics/client/logs",
-                      {
-                        "group": "client.dlq",
-                        "pages": [
-                          "workflow/basics/client/dlq/list",
-                          "workflow/basics/client/dlq/restart",
-                          "workflow/basics/client/dlq/resume",
-                          "workflow/basics/client/dlq/delete",
-                          "workflow/basics/client/dlq/callback"
-                        ]
-                      },
-                      "workflow/basics/client/notify",
-                      "workflow/basics/client/waiters"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "How To",
-                "pages": [
-                  "workflow/howto/start",
-                  "workflow/howto/configure",
-                  "workflow/howto/cancel",
-                  "workflow/howto/security",
-                  "workflow/howto/get-token",
-                  "workflow/howto/readonly-token",
-                  "workflow/howto/redact-fields",
-                  "workflow/howto/changes",
-                  "workflow/howto/schedule",
-                  "workflow/howto/use-webhooks",
-                  "workflow/howto/middlewares",
-                  "workflow/howto/migrations",
-                  "workflow/howto/multi-region",
-                  {
-                    "group": "Realtime",
-                    "pages": [
-                      "workflow/howto/realtime/basic",
-                      "workflow/howto/realtime/human-in-the-loop"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Features",
-            "pages": [
-              {
-                "group": "Retries",
-                "pages": [
-                  "workflow/features/retries",
-                  "workflow/features/retries/prevent-retries"
-                ]
-              },
-              "workflow/features/parallel-steps",
-              {
-                "group": "Failure Function",
-                "pages": [
-                  "workflow/features/failure-callback",
-                  "workflow/features/failureFunction/reliability",
-                  "workflow/features/failureFunction/advanced"
-                ]
-              },
-              {
-                "group": "Dead Letter Queue",
-                "pages": [
-                  "workflow/features/dlq",
-                  "workflow/features/dlq/restart",
-                  "workflow/features/dlq/resume",
-                  "workflow/features/dlq/delete",
-                  "workflow/features/dlq/callback"
-                ]
-              },
-              {
-                "group": "Flow Control",
-                "pages": [
-                  "workflow/features/flow-control",
-                  "workflow/features/flow-control/rate-period",
-                  "workflow/features/flow-control/parallelism",
-                  "workflow/features/flow-control/monitor"
-                ]
-              },
-              {
-                "group": "Wait For Event",
-                "pages": [
-                  "workflow/features/wait-for-event",
-                  "workflow/features/wait",
-                  "workflow/features/notify"
-                ]
-              },
-              "workflow/features/webhooks",
-              {
-                "group": "Invoke",
-                "pages": [
-                  "workflow/features/invoke",
-                  "workflow/features/invoke/serveMany"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Agents",
-            "pages": [
-              "workflow/agents/overview",
-              "workflow/agents/getting-started",
-              "workflow/agents/features",
-              {
-                "group": "Patterns",
-                "pages": [
-                  "workflow/agents/patterns/prompt-chaining",
-                  "workflow/agents/patterns/evaluator-optimizer",
-                  "workflow/agents/patterns/parallelization",
-                  "workflow/agents/patterns/orchestrator-workers"
-                ]
-              },
-              "workflow/agents/examples"
-            ]
-          },
-          {
-            "group": "API Reference",
-            "pages": [
-              {
-                "group": "REST API",
-                "openapi": {
-                  "source": "workflow/openapi.yaml",
-                  "directory": "workflow/api-reference"
-                }
-              },
-              "workflow/sdk/workflow-js",
-              "workflow/sdk/workflow-py"
-            ]
-          },
-          {
-            "group": "Resources",
-            "pages": [
-              {
-                "group": "Integrations",
-                "pages": [
-                  "workflow/integrations/openai",
-                  "workflow/integrations/anthropic",
-                  "workflow/integrations/aisdk",
-                  "workflow/integrations/resend",
-                  "workflow/integrations/datadog",
-                  "workflow/integrations/prometheus"
-                ]
-              },
-              {
-                "group": "Examples",
-                "pages": [
-                  "workflow/examples/allInOne",
-                  "workflow/examples/waitForEvent",
-                  "workflow/examples/customerOnboarding",
-                  "workflow/examples/authWebhook",
-                  "workflow/examples/paymentRetry",
-                  "workflow/examples/eCommerceOrderFulfillment",
-                  "workflow/examples/imageProcessing",
-                  "workflow/examples/customRetry",
-                  "workflow/examples/dynamicWorkflow"
-                ]
-              },
-              "workflow/pricing",
-              {
-                "group": "Troubleshooting",
-                "pages": [
-                  "workflow/troubleshooting/general",
-                  "workflow/troubleshooting/vercel"
-                ]
-              },
-              "workflow/changelog",
-              "workflow/roadmap",
-              "workflow/llms-txt"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Search",
-        "groups": [
-          {
-            "group": "Search",
-            "pages": [
-              {
-                "group": "Overall",
-                "pages": [
-                  "search/overall/getstarted",
-                  "search/overall/whatisupstashsearch",
-                  "search/overall/pricing"
-                ]
-              },
-              {
-                "group": "Quickstarts",
-                "pages": [
-                  "search/tutorials/nextjs",
-                  "search/tutorials/buildsearchbar"
-                ]
-              },
-              {
-                "group": "Search UI",
-                "pages": [
-                  "search/ui/search-bar"
-                ]
-              },
-              {
-                "group": "Features",
-                "pages": [
-                  "search/features/algorithm",
-                  "search/features/indexes",
-                  "search/features/content-and-metadata",
-                  "search/features/filtering",
-                  "search/features/reranking",
-                  "search/features/advanced-settings"
-                ]
-              },
-              {
-                "group": "SDKs",
-                "pages": [
-                  {
-                    "group": "Typescript",
-                    "pages": [
-                      "search/sdks/ts/getting-started",
-                      "search/sdks/ts/contributing",
-                      {
-                        "group": "Commands",
-                        "pages": [
-                          "search/sdks/ts/commands/search",
-                          "search/sdks/ts/commands/upsert",
-                          "search/sdks/ts/commands/fetch",
-                          "search/sdks/ts/commands/delete",
-                          "search/sdks/ts/commands/range",
-                          "search/sdks/ts/commands/reset",
-                          "search/sdks/ts/commands/info"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Python",
-                    "pages": [
-                      "search/sdks/py/gettingstarted",
-                      {
-                        "group": "Commands",
-                        "pages": [
-                          "search/sdks/py/commands/search",
-                          "search/sdks/py/commands/upsert",
-                          "search/sdks/py/commands/fetch",
-                          "search/sdks/py/commands/delete",
-                          "search/sdks/py/commands/range",
-                          "search/sdks/py/commands/reset",
-                          "search/sdks/py/commands/info"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Integrations",
-                "pages": [
-                  "search/integrations/docusaurus"
-                ]
-              },
-              {
-                "group": "Tools",
-                "pages": [
-                  "search/tools/databasemigrator",
-                  "search/tools/documentationcrawler"
-                ]
-              },
-              {
-                "group": "Help",
-                "pages": [
-                  "search/help/faq"
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Box",
-        "groups": [
-          {
-            "group": "Introduction",
-            "pages": [
-              "box/overall/quickstart",
-              "box/overall/how-it-works",
-              "box/overall/use-cases",
-              "box/overall/pricing"
-            ]
-          },
-          {
-            "group": "Basics",
-            "pages": [
-              "box/overall/agent",
-              {
-                "group": "Custom Agents",
-                "pages": [
-                  "box/overall/custom-agent",
-                  "box/overall/custom-harness/pi",
-                  "box/overall/custom-harness/gemini",
-                  "box/overall/custom-harness/aider",
-                  "box/overall/custom-harness/goose",
-                  "box/overall/custom-harness/crewai",
-                  "box/overall/custom-harness/pydantic-ai"
-                ]
-              },
-              "box/overall/git",
-              "box/overall/shell",
-              "box/overall/live-sessions",
-              "box/overall/files",
-              "box/overall/snapshots"
-            ]
-          },
-          {
-            "group": "Lifecycle",
-            "pages": [
-              "box/overall/preview",
-              "box/overall/schedules",
-              "box/overall/keep-alive",
-              "box/overall/ephemeral-box"
-            ]
-          },
-          {
-            "group": "Security",
-            "pages": [
-              "box/overall/security",
-              "box/overall/network-policy",
-              "box/overall/attach-headers"
-            ]
-          },
-          {
-            "group": "Browser",
-            "pages": [
-              "box/overall/browser/overview",
-              "box/overall/browser/tabs",
-              "box/overall/browser/reading-pages",
-              "box/overall/browser/ai-actions",
-              "box/overall/browser/live-view",
-              "box/overall/browser/recordings",
-              "box/overall/browser/connect",
-              "box/overall/browser/cookbook"
-            ]
-          },
-          {
-            "group": "Guides",
-            "pages": ["box/guides/remote-development", "box/guides/nextjs-setup", "box/guides/code-review-agent", "box/guides/langchain-deep-agents", "box/guides/web-scraping-playwright", "box/guides/ai-sdk-code-interpreter", "box/guides/tanstack-ai-file-editor", "box/guides/pi-setup", "box/guides/openclaw-setup", "box/guides/hermes-setup", "box/guides/crabbox-setup"]
-          }
-        ]
-      },
-      {
-        "tab": "Realtime",
-        "groups": [
-          {
-            "group": "Realtime",
-            "pages": [
-              "realtime/overall/quickstart",
-              "realtime/features/client-side",
-              "realtime/features/server-side",
-              "realtime/features/channels",
-              "realtime/features/middleware",
-              "realtime/features/history",
-              "realtime/features/serverless",
-              "realtime/overall/pricing"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Developer API",
+        "tab": "API Reference",
         "openapi": "devops/developer-api/openapi.yaml",
         "groups": [
           {

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,24 +1,27 @@
 ---
-title: Get Started
+title: Overview
 description: "Serverless data and messaging for developers: Redis, Vector, QStash, Workflow, Search, and Box, with SDKs, integrations, and a full-featured console."
 mode: frame
 ---
 
-import { Hero, SectionHead, ProductGrid, AgentResources, Concepts, Community } from "/snippets/landing.jsx";
-
-<Hero />
+import { Hero, PromptToolIcons, SectionHead, ProductGrid, UtilityGrid, Community } from "/snippets/landing.jsx";
 
 <div className="u-wrap">
-  <div id="products" />
-  <SectionHead eyebrow="Products" title="Pick a product and start building" sub={<>See <a href="https://upstash.com/pricing">pricing</a> for each product's plans, billing, and limits.</>} />
+  <Hero>
+    <div className="u-prompt-action">
+      <PromptToolIcons />
+      <Prompt actions={["copy"]}>
+        Help me add the right Upstash product to this project. Review the project first, then choose Redis, Vector, QStash, Workflow, Search, Box, Realtime, or Rate Limit based on its needs. Use the current Upstash documentation at https://upstash.com/docs. Implement the smallest working setup, list the required environment variables, and add a quick verification step.
+      </Prompt>
+    </div>
+  </Hero>
+
+  <SectionHead divider title="Pick a product and start building" sub={<>See <a href="https://upstash.com/pricing">pricing</a> for each product's plans, billing, and limits.</>} />
   <ProductGrid />
 
-  <SectionHead eyebrow="Agent Resources" title="Build with AI agents" sub="Tools to manage and build on Upstash from coding agents and LLMs." />
-  <AgentResources />
+  <SectionHead title="Developer utility tools" sub="Useful tools to build with or alongside our core products." />
+  <UtilityGrid />
 
-  <SectionHead eyebrow="Concepts" title="How Upstash works" />
-  <Concepts />
-
-  <SectionHead eyebrow="Community" title="Get in touch" />
+  <SectionHead divider title="Connect with Upstash" sub="Join the community, read our blog, and follow us." />
   <Community />
 </div>

--- a/snippets/landing.jsx
+++ b/snippets/landing.jsx
@@ -1,20 +1,41 @@
-// Full-custom landing components (used by introduction.mdx with `mode: frame`).
-// Styling lives in style.css (.u-* classes). Each component keeps its own data
-// locally (Mintlify compiles exports in isolation, no cross-references).
-
-export const Hero = () => (
+export const Hero = ({ children }) => (
   <div className="u-hero">
     <h1>Build with Upstash</h1>
     <p>
       Serverless data, messaging, and AI infrastructure for developers. Scale to
       zero, pay per request.
     </p>
+    <div className="u-actions">
+      <a className="u-action u-action--primary" href="/agent-resources/mcp">
+        Agent Setup
+      </a>
+      {children}
+    </div>
   </div>
 );
 
-export const SectionHead = ({ eyebrow, title, sub }) => (
-  <div className="u-section">
-    {eyebrow ? <div className="u-eyebrow">{eyebrow}</div> : null}
+export const PromptToolIcons = () => (
+  <span className="u-prompt-tools" aria-hidden="true">
+    <span className="u-prompt-tool">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
+      </svg>
+    </span>
+    <span className="u-prompt-tool">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z" />
+      </svg>
+    </span>
+    <span className="u-prompt-tool">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M22.106 5.68L12.5.135a.998.998 0 00-.998 0L1.893 5.68a.84.84 0 00-.419.726v11.186c0 .3.16.577.42.727l9.607 5.547a.999.999 0 00.998 0l9.608-5.547a.84.84 0 00.42-.727V6.407a.84.84 0 00-.42-.726zm-.603 1.176L12.228 22.92c-.063.108-.228.064-.228-.061V12.34a.59.59 0 00-.295-.51l-9.11-5.26c-.107-.062-.063-.228.062-.228h18.55c.264 0 .428.286.296.514z" />
+      </svg>
+    </span>
+  </span>
+);
+
+export const SectionHead = ({ title, sub, divider = false }) => (
+  <div className={`u-section${divider ? " u-section--divider" : ""}`}>
     <h2>{title}</h2>
     {sub ? <p className="u-sub">{sub}</p> : null}
   </div>
@@ -29,100 +50,64 @@ export const ProductGrid = () => {
     { name: "Vector", desc: "Vector database for AI and LLM apps.", href: "/vector/overall/getstarted", icon: "vector" },
     { name: "Search", desc: "Full-text and semantic search.", href: "/search/overall/getstarted", icon: "search" },
   ];
+
+  return (
+    <div className="u-grid u-grid--fixed2">
+      {products.map((product) => (
+        <a key={product.href} href={product.href} className="u-card u-product">
+          <img
+            className="u-card__icon"
+            src={`/docs-assets/img/icons/${product.icon}.svg`}
+            alt=""
+          />
+          <div className="u-card__body">
+            <div className="u-card__title">{product.name}</div>
+            <div className="u-card__desc">{product.desc}</div>
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+};
+
+export const UtilityGrid = () => {
+  const tools = [
+    { name: "RateLimit", desc: "Protect your APIs from abuse.", href: "/redis/sdks/ratelimit-ts/overview" },
+    { name: "RealTime", desc: "The easiest way to add realtime.", href: "/realtime/overall/quickstart" },
+    { name: "AI Tracking", desc: "AI agent traffic analytics for Next.js.", href: "https://github.com/upstash/agent-analytics" },
+  ];
+
+  return (
+    <div className="u-grid u-grid--fixed2">
+      {tools.map((tool) => (
+        <a key={tool.href} href={tool.href} className="u-card u-tool">
+          <div className="u-card__body">
+            <div className="u-card__title">{tool.name}</div>
+            <div className="u-card__desc">{tool.desc}</div>
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+};
+
+export const Community = () => {
+  const links = [
+    { name: "Discord", desc: "Ask questions and meet other developers.", href: "https://upstash.com/discord" },
+    { name: "Blog", desc: "Read product news and engineering stories.", href: "https://upstash.com/blog" },
+    { name: "X / Twitter", desc: "Follow the latest Upstash updates.", href: "https://x.com/upstash" },
+  ];
+
   return (
     <div className="u-grid u-grid--fixed3">
-      {products.map((p) => (
-        <a key={p.href} href={p.href} className="u-card u-product">
-          {/* absolute URL: Mintlify only rewrites literal src attrs to its CDN, and
-              the raw /img path 404s under the upstash.com/docs base path */}
-          <img className="u-card__icon" src={`https://upstash.com/docs/img/icons/${p.icon}.svg`} alt="" />
+      {links.map((link) => (
+        <a key={link.href} href={link.href} className="u-card u-community">
           <div className="u-card__body">
-            <div className="u-card__title">{p.name}</div>
-            <div className="u-card__desc">{p.desc}</div>
+            <div className="u-card__title">{link.name}</div>
+            <div className="u-card__desc">{link.desc}</div>
           </div>
         </a>
       ))}
     </div>
   );
 };
-
-export const AgentResources = () => {
-  // Tabler icons (MIT) from https://tabler.io/icons
-  const items = [
-    { name: "MCP Server", desc: "Manage Upstash from AI agents over MCP.", href: "/agent-resources/mcp", paths: ["M7 12l5 5l-1.5 1.5a3.536 3.536 0 1 1 -5 -5l1.5 -1.5", "M17 12l-5 -5l1.5 -1.5a3.536 3.536 0 1 1 5 5l-1.5 1.5", "M3 21l2.5 -2.5", "M18.5 5.5l2.5 -2.5", "M10 11l-2 2", "M13 14l-2 2"] },
-    { name: "Skills", desc: "Ready-made skills for coding agents.", href: "/agent-resources/skills", paths: ["M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2m0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2m-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6"] },
-    { name: "CLI", desc: "Manage Upstash from your terminal.", href: "/agent-resources/cli", paths: ["M8 9l3 3l-3 3", "M13 15l3 0", "M3 6a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2l0 -12"] },
-    { name: "Context7", desc: "Up-to-date code docs for LLMs and agents.", href: "https://context7.com", icon: "https://upstash.com/docs/img/icons/context7.svg" },
-  ];
-  return (
-    <div className="u-grid u-grid--fixed2">
-      {items.map((it) => (
-        <a key={it.href} href={it.href} className="u-card">
-          {it.icon ? (
-            <img className="u-card__icon" src={it.icon} alt="" />
-          ) : (
-            <div className="u-card__icon u-card__icon--muted">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                {it.paths.map((d, i) => (
-                  <path key={i} d={d} />
-                ))}
-              </svg>
-            </div>
-          )}
-          <div className="u-card__body">
-            <div className="u-card__title">{it.name}</div>
-            <div className="u-card__desc">{it.desc}</div>
-          </div>
-        </a>
-      ))}
-    </div>
-  );
-};
-
-export const Concepts = () => {
-  // Tabler icons (MIT) from https://tabler.io/icons
-  const items = [
-    { name: "Serverless", desc: "No infrastructure to provision. Just create and use.", href: "/common/concepts/serverless", paths: ["M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878"] },
-    { name: "Scale to Zero", desc: "Pay only for what you use, nothing for idle resources.", href: "/common/concepts/scale-to-zero", paths: ["M12 5l0 14", "M18 13l-6 6", "M6 13l6 6"] },
-    { name: "Global Replication", desc: "Low latency worldwide with multi-region replication.", href: "/common/concepts/global-replication", paths: ["M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0", "M3.6 9h16.8", "M3.6 15h16.8", "M11.5 3a17 17 0 0 0 0 18", "M12.5 3a17 17 0 0 1 0 18"] },
-    { name: "Access Anywhere", desc: "REST APIs for edge and serverless runtimes.", href: "/common/concepts/access-anywhere", paths: ["M4 13h5", "M12 16v-8h3a2 2 0 0 1 2 2v1a2 2 0 0 1 -2 2h-3", "M20 8v8", "M9 16v-5.5a2.5 2.5 0 0 0 -5 0v5.5"] },
-  ];
-  return (
-    <div className="u-grid u-grid--fixed2">
-      {items.map((it) => (
-        <a key={it.href} href={it.href} className="u-card">
-          <div className="u-card__icon u-card__icon--muted">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              {it.paths.map((d, i) => (
-                <path key={i} d={d} />
-              ))}
-            </svg>
-          </div>
-          <div className="u-card__body">
-            <div className="u-card__title">{it.name}</div>
-            <div className="u-card__desc">{it.desc}</div>
-          </div>
-        </a>
-      ))}
-    </div>
-  );
-};
-
-export const Community = () => (
-  <div className="u-grid u-grid--2">
-    <a className="u-card" href="https://x.com/upstash">
-      <div className="u-card__body">
-        <div className="u-card__title">X / Twitter</div>
-        <div className="u-card__desc">Latest news and product updates.</div>
-      </div>
-    </a>
-    <a className="u-card" href="https://upstash.com/discord">
-      <div className="u-card__body">
-        <div className="u-card__title">Discord</div>
-        <div className="u-card__desc">
-          Ask the team and other developers your questions.
-        </div>
-      </div>
-    </a>
-  </div>
-);

--- a/style.css
+++ b/style.css
@@ -15,12 +15,12 @@
 }
 
 /* ============================================================
-   Custom landing page (mode: custom)
-   Upstash green: #10B981 / #34D399. Class-based dark mode (.dark).
+   Custom landing page (mode: frame)
    ============================================================ */
 
 .u-wrap {
-  max-width: 78rem;
+  width: 100%;
+  max-width: 66.75rem;
   margin: 0 auto;
   padding: 0 1.5rem 6rem;
 }
@@ -68,46 +68,24 @@ html[data-current-path="/introduction"] #content-area {
 
 /* ---- Hero ---- */
 .u-hero {
-  position: relative;
-  text-align: center;
-  padding: 3.5rem 1rem 3rem;
-  overflow: hidden;
-}
-.u-hero::before {
-  content: "";
-  position: absolute;
-  top: -12rem;
-  left: 50%;
-  width: 64rem;
-  height: 24rem;
-  transform: translateX(-50%);
-  background: radial-gradient(
-    closest-side,
-    rgba(52, 211, 153, 0.22),
-    rgba(52, 211, 153, 0)
-  );
-  pointer-events: none;
-  z-index: 0;
-}
-.u-hero > * {
-  position: relative;
-  z-index: 1;
+  padding: 3.125rem 0 0;
 }
 .u-hero h1 {
-  font-size: clamp(2.25rem, 5vw, 3.5rem);
-  line-height: 1.05;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-size: 2.5rem;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: 0;
   margin: 0;
 }
 .u-hero p {
-  margin: 1.1rem auto 0;
-  max-width: 40rem;
+  margin: 0.5rem 0 0;
+  max-width: 34.5rem;
   font-size: 1.125rem;
-  color: #52606d;
+  line-height: 1.5;
+  color: #737373;
 }
 .dark .u-hero p {
-  color: #b3bcc7;
+  color: #a3a3a3;
 }
 
 /* Strong heading/title color. Mintlify's base content text is a muted gray
@@ -116,7 +94,7 @@ html[data-current-path="/introduction"] #content-area {
 .u-hero h1,
 .u-section h2,
 .u-card__title {
-  color: #0d1526;
+  color: #262626;
 }
 .dark .u-hero h1,
 .dark .u-section h2,
@@ -124,84 +102,173 @@ html[data-current-path="/introduction"] #content-area {
   color: #f4f5f6;
 }
 
-.u-cta {
+.u-actions {
   display: flex;
-  gap: 0.75rem;
-  justify-content: center;
+  gap: 0.5rem;
   flex-wrap: wrap;
-  margin-top: 2rem;
+  margin-top: 1.5rem;
 }
-.u-btn {
+.u-action {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 1.25rem;
-  border-radius: 0.65rem;
-  font-weight: 600;
-  font-size: 0.95rem;
+  justify-content: center;
+  gap: 0.625rem;
+  height: 2.625rem;
+  min-height: 2.625rem;
+  padding: 0 1.25rem;
+  border: 1px solid transparent;
+  border-radius: 2.5rem;
+  font-family: inherit;
+  font-weight: 400;
+  font-size: 0.9375rem;
+  line-height: 1;
   text-decoration: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   transition:
-    transform 0.15s ease,
     background 0.15s ease,
-    border-color 0.15s ease;
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
-.u-btn--primary {
-  background: #10b981;
-  color: #05231a;
+.u-action:focus-visible {
+  outline: 2px solid #10b981;
+  outline-offset: 2px;
 }
-.u-btn--primary:hover {
-  background: #34d399;
-  transform: translateY(-1px);
+.u-action--primary {
+  background: #262626;
+  color: #fff;
 }
-.u-btn--ghost {
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  color: inherit;
+.u-action--primary:hover {
+  background: #27272a;
 }
-.dark .u-btn--ghost {
+.dark .u-action--primary {
+  background: #f4f4f5;
+  color: #18181b;
+}
+.dark .u-action--primary:hover {
+  background: #e4e4e7;
+}
+.u-prompt-action .prompt {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+.u-prompt-action .prompt button {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  justify-content: flex-end;
+  width: 13.125rem;
+  height: 2.625rem;
+  min-height: 2.625rem;
+  padding: 0 1.25rem 0 6rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 2.5rem;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #262626;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.u-prompt-action .prompt button:hover {
+  color: #262626;
+  background: #fafafa;
+  border-color: #d4d4d4;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.dark .u-prompt-action .prompt button {
+  color: #f4f4f5;
+  background: rgba(255, 255, 255, 0.04);
   border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
-.u-btn--ghost:hover {
-  border-color: #10b981;
-  transform: translateY(-1px);
+.dark .u-prompt-action .prompt button:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.24);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+.u-prompt-action {
+  position: relative;
+  width: 13.125rem;
+  height: 2.625rem;
+}
+.u-prompt-action .prompt button > span:has(svg) {
+  display: none;
+}
+.u-prompt-tools {
+  position: absolute;
+  z-index: 3;
+  top: 0.3125rem;
+  left: 0.375rem;
+  display: flex;
+  width: 5rem;
+  height: 2rem;
+  pointer-events: none;
+}
+.u-prompt-tool {
+  display: grid;
+  flex: none;
+  width: 2rem;
+  height: 2rem;
+  padding: 0.25rem;
+  place-items: center;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 9999px;
+  color: #262626;
+  background: #fff;
+}
+.u-prompt-tool + .u-prompt-tool {
+  margin-left: -0.5rem;
+}
+.u-prompt-tool svg {
+  width: 1.375rem;
+  height: 1.375rem;
+}
+.dark .u-prompt-tool {
+  border-color: rgba(255, 255, 255, 0.16);
+  color: #f4f4f5;
+  background: #18181b;
 }
 
 /* ---- Section headings ---- */
 .u-section {
   margin-top: 4rem;
 }
-/* tighter gap between the hero and the first section */
-.u-wrap > .u-section:first-of-type {
-  margin-top: 2rem;
+.u-section--divider {
+  padding-top: 4rem;
+  border-top: 1px solid #e5e5e5;
 }
-.u-eyebrow {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #059669;
-}
-.dark .u-eyebrow {
-  color: #34d399;
+.dark .u-section--divider {
+  border-top-color: #27272a;
 }
 .u-section h2 {
-  font-size: 1.6rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  margin: 0.35rem 0 0;
+  font-size: 1.5rem;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: 0;
+  margin: 0;
 }
 /* Mintlify renders the sub as <p> or <span> depending on content, so target
    the class only and force block display. */
 .u-section .u-sub {
   display: block;
-  margin: 0.5rem 0 0;
-  color: #52606d;
-  font-size: 1rem;
+  margin: 0.25rem 0 0;
+  color: #737373;
+  font-size: 0.9375rem;
+  line-height: 1.7;
 }
 .dark .u-section .u-sub {
-  color: #b3bcc7;
+  color: #a3a3a3;
 }
 .u-section .u-sub a {
   color: inherit;
+  font-weight: 500;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -324,12 +391,60 @@ html[data-current-path="/introduction"] #content-area {
 
 /* ---- Product cards (larger) ---- */
 .u-product .u-card__icon {
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 0.7rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0;
+  align-self: center;
 }
-.u-product .u-card__title {
-  font-size: 1.05rem;
+.u-product,
+.u-tool,
+.u-community {
+  min-height: 5.125rem;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 1.25rem;
+  background: #fafafa;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.u-product:hover,
+.u-tool:hover,
+.u-community:hover {
+  border-color: #d4d4d4;
+  transform: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.u-product .u-card__title,
+.u-tool .u-card__title,
+.u-community .u-card__title {
+  font-size: 1.0625rem;
+  line-height: 1.3;
+  font-weight: 600;
+}
+.u-product .u-card__desc,
+.u-tool .u-card__desc,
+.u-community .u-card__desc {
+  margin-top: 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: #737373;
+}
+.dark .u-product,
+.dark .u-tool,
+.dark .u-community {
+  border-color: #3f3f46;
+  background: rgba(255, 255, 255, 0.04);
+}
+.dark .u-product:hover,
+.dark .u-tool:hover,
+.dark .u-community:hover {
+  border-color: #52525b;
+}
+.dark .u-product .u-card__desc,
+.dark .u-tool .u-card__desc,
+.dark .u-community .u-card__desc {
+  color: #a3a3a3;
 }
 
 /* ---- Console showcase ---- */


### PR DESCRIPTION
## Summary

- match the documentation homepage to the new Figma design
- move product navigation into the Documentation tab with product groups
- keep Documentation and API Reference as global tabs
- keep the upstream change limited to the homepage and docs.json

This PR depends on https://github.com/upstash/docs7/pull/268.

The docs.json diff is large because existing navigation trees move into the new product group structure.

## Files

- docs.json
- introduction.mdx
- snippets/landing.jsx
- style.css

The LLMS generator, README, and generated LLMS files are intentionally not included.

## Validation

- docs.json parses as valid JSON
- git diff --check
- Docs7 preview passed for the same homepage and docs.json state in enesgules/docs PR #10