### PR TITLE
Remove dark prompt button fill

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2083,7 +2083,7 @@
             ]
           },
           {
-            "group": "Utility",
+            "group": "Utility Tools",
             "products": [
               {
                 "product": "Realtime",

--- a/style.css
+++ b/style.css
@@ -185,13 +185,13 @@ html[data-current-path="/introduction"] #content-area {
   color: #f4f4f5;
   background: transparent;
   border-color: rgba(255, 255, 255, 0.16);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 .dark .u-prompt-action .prompt button:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.24);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 .u-prompt-action {
   position: relative;

--- a/style.css
+++ b/style.css
@@ -158,6 +158,7 @@ html[data-current-path="/introduction"] #content-area {
   background: transparent;
 }
 .u-prompt-action .prompt button {
+  appearance: none;
   position: absolute;
   z-index: 2;
   inset: 0;
@@ -185,13 +186,13 @@ html[data-current-path="/introduction"] #content-area {
   color: #f4f4f5;
   background: transparent;
   border-color: rgba(255, 255, 255, 0.16);
-  box-shadow: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 .dark .u-prompt-action .prompt button:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.24);
-  box-shadow: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 .u-prompt-action {
   position: relative;

--- a/style.css
+++ b/style.css
@@ -157,8 +157,10 @@ html[data-current-path="/introduction"] #content-area {
   padding: 0;
   background: transparent;
 }
+.u-prompt-action .prompt > div + div {
+  display: none;
+}
 .u-prompt-action .prompt button {
-  appearance: none;
   position: absolute;
   z-index: 2;
   inset: 0;

--- a/style.css
+++ b/style.css
@@ -183,7 +183,7 @@ html[data-current-path="/introduction"] #content-area {
 }
 .dark .u-prompt-action .prompt button {
   color: #f4f4f5;
-  background: rgba(255, 255, 255, 0.04);
+  background: transparent;
   border-color: rgba(255, 255, 255, 0.16);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
## Summary

- remove the unintended dark-mode fill behind the homepage prompt action
- keep the border and hover feedback unchanged

## Validation

- verified the homepage prompt control in light and dark mode with the current Docs7 renderer
- confirmed that the dark resting background is transparent and the light resting background stays white
- ran `git diff --check`