### PR TITLE
docs: match utility tool names to their documentation

### DIFF
--- a/snippets/landing.jsx
+++ b/snippets/landing.jsx
@@ -72,8 +72,8 @@ export const ProductGrid = () => {
 
 export const UtilityGrid = () => {
   const tools = [
-    { name: "RateLimit", desc: "Protect your APIs from abuse.", href: "/redis/sdks/ratelimit-ts/overview" },
-    { name: "RealTime", desc: "The easiest way to add realtime.", href: "/realtime/overall/quickstart" },
+    { name: "Rate Limit", desc: "Protect your APIs from abuse.", href: "/redis/sdks/ratelimit-ts/overview" },
+    { name: "Realtime", desc: "The easiest way to add realtime.", href: "/realtime/overall/quickstart" },
     { name: "AI Tracking", desc: "AI agent traffic analytics for Next.js.", href: "https://github.com/upstash/agent-analytics" },
   ];
 


### PR DESCRIPTION
The landing page utility grid rendered "RateLimit" and "RealTime", while the sidebar and the products' own pages use "Rate Limit" and "Realtime".

Claude-Session: https://claude.ai/code/session_01WvAQH9mzynz28vYzg17wVA