### PR TITLE
Rename Utility Tools labels

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2083,7 +2083,7 @@
             ]
           },
           {
-            "group": "Utility Tools",
+            "group": "Dev Tools",
             "products": [
               {
                 "product": "Realtime",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -19,7 +19,7 @@ import { Hero, PromptToolIcons, SectionHead, ProductGrid, UtilityGrid, Community
   <SectionHead divider title="Pick a product and start building" sub={<>See <a href="https://upstash.com/pricing">pricing</a> for each product's plans, billing, and limits.</>} />
   <ProductGrid />
 
-  <SectionHead title="Developer utility tools" sub="Useful tools to build with or alongside our core products." />
+  <SectionHead title="Developer Tools" sub="Useful tools to build with or alongside our core products." />
   <UtilityGrid />
 
   <SectionHead divider title="Connect with Upstash" sub="Join the community, read our blog, and follow us." />

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10480,7 +10480,7 @@ import { Hero, PromptToolIcons, SectionHead, ProductGrid, UtilityGrid, Community
   <SectionHead divider title="Pick a product and start building" sub={<>See <a href="https://upstash.com/pricing">pricing</a> for each product's plans, billing, and limits.</>} />
   <ProductGrid />
 
-  <SectionHead title="Developer utility tools" sub="Useful tools to build with or alongside our core products." />
+  <SectionHead title="Developer Tools" sub="Useful tools to build with or alongside our core products." />
   <UtilityGrid />
 
   <SectionHead divider title="Connect with Upstash" sub="Join the community, read our blog, and follow us." />


### PR DESCRIPTION
## Summary

- rename the sidebar group from Utility Tools to Dev Tools
- rename the home page section from Developer utility tools to Developer Tools
- regenerate llms-full.txt

## Checks

- npm --prefix llms run build
- JSON parse check for docs.json
- git diff --check