### PR TITLE
Enable Docs7 footer attribution

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -9,6 +9,7 @@
   },
   "favicon": "/favicon.png",
   "filterSidebar": false,
+  "poweredByDocs7": true,
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
## Summary

- enable the Built with Docs7 footer link for Upstash Docs

## Dependency

Requires upstash/docs7#301 for the renderer behavior.

## Validation

- docs.json parses as JSON
- llms.txt and llms-full.txt regeneration produced no changes
- llms freshness check passed
- the configuration rendered the attribution link with the Docs7 PR branch
- git diff --check passed