### PR TITLE
docs(agentkit): document Eve memory slots on Upstash Redis

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -75214,23 +75214,47 @@ export default defineMemory({
 });
 ```
 
-<Accordion title="Options and what gets recalled">
-  `redisMemory()` takes `rememberMessages` (default `true`, meaning `"fromUser"` — also `"all"`,
-  `"fromModel"`, or `false` to capture nothing), `topK`, `minScore`, `maxRecallCharacters`,
-  `maxMemoryCharacters`, `prefix` / `indexName`, and `redis`. `redisDocuments()` takes `prefix`,
-  `ttlSeconds`, and `redis`.
+<Accordion title="Options">
+  `redisMemory()`:
 
-  Automatic recall injects **only** facts saved through `save_memory`. Captured messages live in the
-  same store but are kept out of that ranking, so a passing remark can't outrank a fact the model
-  deliberately kept — they stay reachable through `search_memory` and `read_session`.
+  | Option | Default | What it does |
+  | --- | --- | --- |
+  | `rememberMessages` | `true` | What gets saved automatically. `true` (same as `"fromUser"`) saves what the user says; `"all"` saves both sides; `"fromModel"` saves the agent's replies; `false` saves nothing. |
+  | `topK` | `5` | How many memories to bring back each turn. |
+  | `minScore` | `0` | Minimum relevance score to bring one back. Scores are BM25, so unbounded. |
+  | `maxRecallCharacters` | `4000` | Size limit for everything recalled in one turn. |
+  | `maxMemoryCharacters` | `2048` | Size limit for a single stored memory. |
+  | `prefix` / `indexName` | `agentkit:memorySlot` | Redis key prefix and search index name. |
+  | `redis` | `Redis.fromEnv()` | Your Redis client. |
 
-  `forget_memory` redacts rather than deletes: the text is erased and the entry can never be recalled
-  or searched again, but `read_session` shows it as `[redacted]` instead of leaving a silent gap. It
-  isn't contributed under `"all"` or `"fromModel"`, because those modes store the assistant's replies
-  and a reply confirming a deletion quotes the text it just deleted.
+  `redisDocuments()`:
 
-  Slots are agent-owned, so the extension can't contribute one — these are the files you write
-  yourself. `scope` is the tenant boundary; `byPrincipal` fails closed for anonymous callers.
+  | Option | Default | What it does |
+  | --- | --- | --- |
+  | `prefix` | `agentkit:memoryFile` | Redis key prefix. |
+  | `ttlSeconds` | no expiry | Expire a scope's document after this long. |
+  | `redis` | `Redis.fromEnv()` | Your Redis client. |
+
+  `scope` is Eve's, not ours, but it is the tenant boundary — `byPrincipal` fails closed and disables
+  the slot for anonymous callers rather than pooling them together.
+</Accordion>
+
+<Accordion title="What does the agent remember?">
+  Two things: facts it chose to save with `save_memory`, and the messages it captured automatically
+  (see `rememberMessages` above).
+
+  Before each turn it is handed the **saved facts** that match what the user just said. Captured
+  messages are deliberately left out of that list, so an offhand remark can't crowd out a fact the
+  agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
+  everything, and `read_session` replays a whole past conversation.
+
+  Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
+  conversation shows the entry as `[redacted]` rather than dropping it silently, so nothing that was
+  said can look like it never happened.
+
+  One exception: with `rememberMessages` set to `"all"` or `"fromModel"` the agent gets no forget
+  tool. Those modes store its replies, and a reply confirming a deletion repeats the deleted text, so
+  forgetting couldn't be honest.
 </Accordion>
 
 ### Memory and RAG as individual tool files
@@ -75794,23 +75818,47 @@ export default defineMemory({
 });
 ```
 
-<Accordion title="Options and what gets recalled">
-  `redisMemory()` takes `rememberMessages` (default `true`, meaning `"fromUser"` — also `"all"`,
-  `"fromModel"`, or `false` to capture nothing), `topK`, `minScore`, `maxRecallCharacters`,
-  `maxMemoryCharacters`, `prefix` / `indexName`, and `redis`. `redisDocuments()` takes `prefix`,
-  `ttlSeconds`, and `redis`.
+<Accordion title="Options">
+  `redisMemory()`:
 
-  Automatic recall injects **only** facts saved through `save_memory`. Captured messages live in the
-  same store but are kept out of that ranking, so a passing remark can't outrank a fact the model
-  deliberately kept — they stay reachable through `search_memory` and `read_session`.
+  | Option | Default | What it does |
+  | --- | --- | --- |
+  | `rememberMessages` | `true` | What gets saved automatically. `true` (same as `"fromUser"`) saves what the user says; `"all"` saves both sides; `"fromModel"` saves the agent's replies; `false` saves nothing. |
+  | `topK` | `5` | How many memories to bring back each turn. |
+  | `minScore` | `0` | Minimum relevance score to bring one back. Scores are BM25, so unbounded. |
+  | `maxRecallCharacters` | `4000` | Size limit for everything recalled in one turn. |
+  | `maxMemoryCharacters` | `2048` | Size limit for a single stored memory. |
+  | `prefix` / `indexName` | `agentkit:memorySlot` | Redis key prefix and search index name. |
+  | `redis` | `Redis.fromEnv()` | Your Redis client. |
 
-  `forget_memory` redacts rather than deletes: the text is erased and the entry can never be recalled
-  or searched again, but `read_session` shows it as `[redacted]` instead of leaving a silent gap. It
-  isn't contributed under `"all"` or `"fromModel"`, because those modes store the assistant's replies
-  and a reply confirming a deletion quotes the text it just deleted.
+  `redisDocuments()`:
 
-  Slots are agent-owned, so the extension can't contribute one — these are the files you write
-  yourself. `scope` is the tenant boundary; `byPrincipal` fails closed for anonymous callers.
+  | Option | Default | What it does |
+  | --- | --- | --- |
+  | `prefix` | `agentkit:memoryFile` | Redis key prefix. |
+  | `ttlSeconds` | no expiry | Expire a scope's document after this long. |
+  | `redis` | `Redis.fromEnv()` | Your Redis client. |
+
+  `scope` is Eve's, not ours, but it is the tenant boundary — `byPrincipal` fails closed and disables
+  the slot for anonymous callers rather than pooling them together.
+</Accordion>
+
+<Accordion title="What does the agent remember?">
+  Two things: facts it chose to save with `save_memory`, and the messages it captured automatically
+  (see `rememberMessages` above).
+
+  Before each turn it is handed the **saved facts** that match what the user just said. Captured
+  messages are deliberately left out of that list, so an offhand remark can't crowd out a fact the
+  agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
+  everything, and `read_session` replays a whole past conversation.
+
+  Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
+  conversation shows the entry as `[redacted]` rather than dropping it silently, so nothing that was
+  said can look like it never happened.
+
+  One exception: with `rememberMessages` set to `"all"` or `"fromModel"` the agent gets no forget
+  tool. Those modes store its replies, and a reply confirming a deletion repeats the deleted text, so
+  forgetting couldn't be honest.
 </Accordion>
 
 ### Memory and RAG as individual tool files

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -75173,6 +75173,66 @@ export default defineCachedTool({
   Keys are `agentkit:toolCache:<userId>:<toolName>:<hash>`.
 </Accordion>
 
+### How to use Eve's memory slots
+
+Eve has a native [memory](https://eve.dev/docs/memory) feature: a slot file under `agent/memory/`
+that Eve calls before and after each turn. `@upstash/agentkit-eve/memory` puts Upstash Redis behind
+it, two ways. Needs Eve 0.45.2 or newer.
+
+`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, captures
+what the user says afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
+`<slot>__read_session`, and `<slot>__forget_memory`:
+
+```ts
+// agent/memory/recall.ts
+import { redisMemory } from "@upstash/agentkit-eve/memory";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Everything the caller has told this agent before, recalled by relevance.",
+  provider: redisMemory({ topK: 5 }),
+  scope: byPrincipal,
+});
+```
+
+`redisDocuments()` is a storage backend for Eve's own `fileMemory()` provider, which replays one
+short, model-curated document in full before every turn. Without a backend, `fileMemory()` only
+resolves storage under `eve dev` and on Vercel with a Blob store attached:
+
+```ts
+// agent/memory/profile.ts
+import { redisDocuments } from "@upstash/agentkit-eve/memory";
+import { defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "A short, curated list of stable facts about the caller.",
+  provider: fileMemory({ backend: redisDocuments() }),
+  scope: byPrincipal,
+});
+```
+
+<Accordion title="Options and what gets recalled">
+  `redisMemory()` takes `rememberMessages` (default `true`, meaning `"fromUser"` — also `"all"`,
+  `"fromModel"`, or `false` to capture nothing), `topK`, `minScore`, `maxRecallCharacters`,
+  `maxMemoryCharacters`, `prefix` / `indexName`, and `redis`. `redisDocuments()` takes `prefix`,
+  `ttlSeconds`, and `redis`.
+
+  Automatic recall injects **only** facts saved through `save_memory`. Captured messages live in the
+  same store but are kept out of that ranking, so a passing remark can't outrank a fact the model
+  deliberately kept — they stay reachable through `search_memory` and `read_session`.
+
+  `forget_memory` redacts rather than deletes: the text is erased and the entry can never be recalled
+  or searched again, but `read_session` shows it as `[redacted]` instead of leaving a silent gap. It
+  isn't contributed under `"all"` or `"fromModel"`, because those modes store the assistant's replies
+  and a reply confirming a deletion quotes the text it just deleted.
+
+  Slots are agent-owned, so the extension can't contribute one — these are the files you write
+  yourself. `scope` is the tenant boundary; `byPrincipal` fails closed for anonymous callers.
+</Accordion>
+
 ### Memory and RAG as individual tool files
 
 The same two features the extension mounts, written as standalone `agent/tools/` files. Use these when
@@ -75691,6 +75751,66 @@ export default defineCachedTool({
   * `redis` — defaults to `Redis.fromEnv()`.
 
   Keys are `agentkit:toolCache:<userId>:<toolName>:<hash>`.
+</Accordion>
+
+### How to use Eve's memory slots
+
+Eve has a native [memory](https://eve.dev/docs/memory) feature: a slot file under `agent/memory/`
+that Eve calls before and after each turn. `@upstash/agentkit-eve/memory` puts Upstash Redis behind
+it, two ways. Needs Eve 0.45.2 or newer.
+
+`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, captures
+what the user says afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
+`<slot>__read_session`, and `<slot>__forget_memory`:
+
+```ts
+// agent/memory/recall.ts
+import { redisMemory } from "@upstash/agentkit-eve/memory";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Everything the caller has told this agent before, recalled by relevance.",
+  provider: redisMemory({ topK: 5 }),
+  scope: byPrincipal,
+});
+```
+
+`redisDocuments()` is a storage backend for Eve's own `fileMemory()` provider, which replays one
+short, model-curated document in full before every turn. Without a backend, `fileMemory()` only
+resolves storage under `eve dev` and on Vercel with a Blob store attached:
+
+```ts
+// agent/memory/profile.ts
+import { redisDocuments } from "@upstash/agentkit-eve/memory";
+import { defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "A short, curated list of stable facts about the caller.",
+  provider: fileMemory({ backend: redisDocuments() }),
+  scope: byPrincipal,
+});
+```
+
+<Accordion title="Options and what gets recalled">
+  `redisMemory()` takes `rememberMessages` (default `true`, meaning `"fromUser"` — also `"all"`,
+  `"fromModel"`, or `false` to capture nothing), `topK`, `minScore`, `maxRecallCharacters`,
+  `maxMemoryCharacters`, `prefix` / `indexName`, and `redis`. `redisDocuments()` takes `prefix`,
+  `ttlSeconds`, and `redis`.
+
+  Automatic recall injects **only** facts saved through `save_memory`. Captured messages live in the
+  same store but are kept out of that ranking, so a passing remark can't outrank a fact the model
+  deliberately kept — they stay reachable through `search_memory` and `read_session`.
+
+  `forget_memory` redacts rather than deletes: the text is erased and the entry can never be recalled
+  or searched again, but `read_session` shows it as `[redacted]` instead of leaving a silent gap. It
+  isn't contributed under `"all"` or `"fromModel"`, because those modes store the assistant's replies
+  and a reply confirming a deletion quotes the text it just deleted.
+
+  Slots are agent-owned, so the extension can't contribute one — these are the files you write
+  yourself. `scope` is the tenant boundary; `byPrincipal` fails closed for anonymous callers.
 </Accordion>
 
 ### Memory and RAG as individual tool files

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -75179,8 +75179,8 @@ Eve has a native [memory](https://eve.dev/docs/memory) feature: a slot file unde
 that Eve calls before and after each turn. `@upstash/agentkit-eve/memory` puts Upstash Redis behind
 it, two ways. Needs Eve 0.45.2 or newer.
 
-`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, captures
-what the user says afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
+`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, stores the
+user's messages afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
 `<slot>__read_session`, and `<slot>__forget_memory`:
 
 ```ts
@@ -75240,12 +75240,12 @@ export default defineMemory({
 </Accordion>
 
 <Accordion title="What does the agent remember?">
-  Two things: facts it chose to save with `save_memory`, and the messages it captured automatically
-  (see `rememberMessages` above).
+  Two things: facts it chose to save with `save_memory`, and the messages themselves — what the user
+  said, and optionally what the agent replied (see `rememberMessages` above).
 
-  Before each turn it is handed the **saved facts** that match what the user just said. Captured
-  messages are deliberately left out of that list, so an offhand remark can't crowd out a fact the
-  agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
+  Before each turn it is handed the **saved facts** that match what the user just said. User and
+  agent messages are deliberately left out of that list, so an offhand remark can't crowd out a fact
+  the agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
   everything, and `read_session` replays a whole past conversation.
 
   Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
@@ -75783,8 +75783,8 @@ Eve has a native [memory](https://eve.dev/docs/memory) feature: a slot file unde
 that Eve calls before and after each turn. `@upstash/agentkit-eve/memory` puts Upstash Redis behind
 it, two ways. Needs Eve 0.45.2 or newer.
 
-`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, captures
-what the user says afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
+`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, stores the
+user's messages afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
 `<slot>__read_session`, and `<slot>__forget_memory`:
 
 ```ts
@@ -75844,12 +75844,12 @@ export default defineMemory({
 </Accordion>
 
 <Accordion title="What does the agent remember?">
-  Two things: facts it chose to save with `save_memory`, and the messages it captured automatically
-  (see `rememberMessages` above).
+  Two things: facts it chose to save with `save_memory`, and the messages themselves — what the user
+  said, and optionally what the agent replied (see `rememberMessages` above).
 
-  Before each turn it is handed the **saved facts** that match what the user just said. Captured
-  messages are deliberately left out of that list, so an offhand remark can't crowd out a fact the
-  agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
+  Before each turn it is handed the **saved facts** that match what the user just said. User and
+  agent messages are deliberately left out of that list, so an offhand remark can't crowd out a fact
+  the agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
   everything, and `read_session` replays a whole past conversation.
 
   Asking it to forget something blanks the entry — it can never be recalled or searched again. A past

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -75243,10 +75243,10 @@ export default defineMemory({
   Two things: facts it chose to save with `save_memory`, and the messages themselves — what the user
   said, and optionally what the agent replied (see `rememberMessages` above).
 
-  Before each turn it is handed the **saved facts** that match what the user just said. User and
-  agent messages are deliberately left out of that list, so an offhand remark can't crowd out a fact
-  the agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
-  everything, and `read_session` replays a whole past conversation.
+  Before each turn the agent is handed the **saved facts** that match what the user just said. User
+  and agent messages are deliberately left out of that list, so an offhand remark can't crowd out a
+  fact the agent decided was worth keeping. It can still reach them itself: `search_memory` looks
+  through everything, and `read_session` replays a whole past conversation.
 
   Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
   conversation shows the entry as `[redacted]` rather than dropping it silently, so nothing that was
@@ -75847,10 +75847,10 @@ export default defineMemory({
   Two things: facts it chose to save with `save_memory`, and the messages themselves — what the user
   said, and optionally what the agent replied (see `rememberMessages` above).
 
-  Before each turn it is handed the **saved facts** that match what the user just said. User and
-  agent messages are deliberately left out of that list, so an offhand remark can't crowd out a fact
-  the agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
-  everything, and `read_session` replays a whole past conversation.
+  Before each turn the agent is handed the **saved facts** that match what the user just said. User
+  and agent messages are deliberately left out of that list, so an offhand remark can't crowd out a
+  fact the agent decided was worth keeping. It can still reach them itself: `search_memory` looks
+  through everything, and `read_session` replays a whole past conversation.
 
   Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
   conversation shows the entry as `[redacted]` rather than dropping it silently, so nothing that was

--- a/redis/sdks/agentkit/eve.mdx
+++ b/redis/sdks/agentkit/eve.mdx
@@ -475,23 +475,47 @@ export default defineMemory({
 });
 ```
 
-<Accordion title="Options and what gets recalled">
-  `redisMemory()` takes `rememberMessages` (default `true`, meaning `"fromUser"` — also `"all"`,
-  `"fromModel"`, or `false` to capture nothing), `topK`, `minScore`, `maxRecallCharacters`,
-  `maxMemoryCharacters`, `prefix` / `indexName`, and `redis`. `redisDocuments()` takes `prefix`,
-  `ttlSeconds`, and `redis`.
+<Accordion title="Options">
+  `redisMemory()`:
 
-  Automatic recall injects **only** facts saved through `save_memory`. Captured messages live in the
-  same store but are kept out of that ranking, so a passing remark can't outrank a fact the model
-  deliberately kept — they stay reachable through `search_memory` and `read_session`.
+  | Option | Default | What it does |
+  | --- | --- | --- |
+  | `rememberMessages` | `true` | What gets saved automatically. `true` (same as `"fromUser"`) saves what the user says; `"all"` saves both sides; `"fromModel"` saves the agent's replies; `false` saves nothing. |
+  | `topK` | `5` | How many memories to bring back each turn. |
+  | `minScore` | `0` | Minimum relevance score to bring one back. Scores are BM25, so unbounded. |
+  | `maxRecallCharacters` | `4000` | Size limit for everything recalled in one turn. |
+  | `maxMemoryCharacters` | `2048` | Size limit for a single stored memory. |
+  | `prefix` / `indexName` | `agentkit:memorySlot` | Redis key prefix and search index name. |
+  | `redis` | `Redis.fromEnv()` | Your Redis client. |
 
-  `forget_memory` redacts rather than deletes: the text is erased and the entry can never be recalled
-  or searched again, but `read_session` shows it as `[redacted]` instead of leaving a silent gap. It
-  isn't contributed under `"all"` or `"fromModel"`, because those modes store the assistant's replies
-  and a reply confirming a deletion quotes the text it just deleted.
+  `redisDocuments()`:
 
-  Slots are agent-owned, so the extension can't contribute one — these are the files you write
-  yourself. `scope` is the tenant boundary; `byPrincipal` fails closed for anonymous callers.
+  | Option | Default | What it does |
+  | --- | --- | --- |
+  | `prefix` | `agentkit:memoryFile` | Redis key prefix. |
+  | `ttlSeconds` | no expiry | Expire a scope's document after this long. |
+  | `redis` | `Redis.fromEnv()` | Your Redis client. |
+
+  `scope` is Eve's, not ours, but it is the tenant boundary — `byPrincipal` fails closed and disables
+  the slot for anonymous callers rather than pooling them together.
+</Accordion>
+
+<Accordion title="What does the agent remember?">
+  Two things: facts it chose to save with `save_memory`, and the messages it captured automatically
+  (see `rememberMessages` above).
+
+  Before each turn it is handed the **saved facts** that match what the user just said. Captured
+  messages are deliberately left out of that list, so an offhand remark can't crowd out a fact the
+  agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
+  everything, and `read_session` replays a whole past conversation.
+
+  Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
+  conversation shows the entry as `[redacted]` rather than dropping it silently, so nothing that was
+  said can look like it never happened.
+
+  One exception: with `rememberMessages` set to `"all"` or `"fromModel"` the agent gets no forget
+  tool. Those modes store its replies, and a reply confirming a deletion repeats the deleted text, so
+  forgetting couldn't be honest.
 </Accordion>
 
 ### Memory and RAG as individual tool files

--- a/redis/sdks/agentkit/eve.mdx
+++ b/redis/sdks/agentkit/eve.mdx
@@ -434,6 +434,66 @@ export default defineCachedTool({
   Keys are `agentkit:toolCache:<userId>:<toolName>:<hash>`.
 </Accordion>
 
+### How to use Eve's memory slots
+
+Eve has a native [memory](https://eve.dev/docs/memory) feature: a slot file under `agent/memory/`
+that Eve calls before and after each turn. `@upstash/agentkit-eve/memory` puts Upstash Redis behind
+it, two ways. Needs Eve 0.45.2 or newer.
+
+`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, captures
+what the user says afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
+`<slot>__read_session`, and `<slot>__forget_memory`:
+
+```ts
+// agent/memory/recall.ts
+import { redisMemory } from "@upstash/agentkit-eve/memory";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Everything the caller has told this agent before, recalled by relevance.",
+  provider: redisMemory({ topK: 5 }),
+  scope: byPrincipal,
+});
+```
+
+`redisDocuments()` is a storage backend for Eve's own `fileMemory()` provider, which replays one
+short, model-curated document in full before every turn. Without a backend, `fileMemory()` only
+resolves storage under `eve dev` and on Vercel with a Blob store attached:
+
+```ts
+// agent/memory/profile.ts
+import { redisDocuments } from "@upstash/agentkit-eve/memory";
+import { defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "A short, curated list of stable facts about the caller.",
+  provider: fileMemory({ backend: redisDocuments() }),
+  scope: byPrincipal,
+});
+```
+
+<Accordion title="Options and what gets recalled">
+  `redisMemory()` takes `rememberMessages` (default `true`, meaning `"fromUser"` — also `"all"`,
+  `"fromModel"`, or `false` to capture nothing), `topK`, `minScore`, `maxRecallCharacters`,
+  `maxMemoryCharacters`, `prefix` / `indexName`, and `redis`. `redisDocuments()` takes `prefix`,
+  `ttlSeconds`, and `redis`.
+
+  Automatic recall injects **only** facts saved through `save_memory`. Captured messages live in the
+  same store but are kept out of that ranking, so a passing remark can't outrank a fact the model
+  deliberately kept — they stay reachable through `search_memory` and `read_session`.
+
+  `forget_memory` redacts rather than deletes: the text is erased and the entry can never be recalled
+  or searched again, but `read_session` shows it as `[redacted]` instead of leaving a silent gap. It
+  isn't contributed under `"all"` or `"fromModel"`, because those modes store the assistant's replies
+  and a reply confirming a deletion quotes the text it just deleted.
+
+  Slots are agent-owned, so the extension can't contribute one — these are the files you write
+  yourself. `scope` is the tenant boundary; `byPrincipal` fails closed for anonymous callers.
+</Accordion>
+
 ### Memory and RAG as individual tool files
 
 The same two features the extension mounts, written as standalone `agent/tools/` files. Use these when

--- a/redis/sdks/agentkit/eve.mdx
+++ b/redis/sdks/agentkit/eve.mdx
@@ -440,8 +440,8 @@ Eve has a native [memory](https://eve.dev/docs/memory) feature: a slot file unde
 that Eve calls before and after each turn. `@upstash/agentkit-eve/memory` puts Upstash Redis behind
 it, two ways. Needs Eve 0.45.2 or newer.
 
-`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, captures
-what the user says afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
+`redisMemory()` is a full provider. It recalls the memories relevant to the current turn, stores the
+user's messages afterwards, and contributes `<slot>__save_memory`, `<slot>__search_memory`,
 `<slot>__read_session`, and `<slot>__forget_memory`:
 
 ```ts
@@ -501,12 +501,12 @@ export default defineMemory({
 </Accordion>
 
 <Accordion title="What does the agent remember?">
-  Two things: facts it chose to save with `save_memory`, and the messages it captured automatically
-  (see `rememberMessages` above).
+  Two things: facts it chose to save with `save_memory`, and the messages themselves — what the user
+  said, and optionally what the agent replied (see `rememberMessages` above).
 
-  Before each turn it is handed the **saved facts** that match what the user just said. Captured
-  messages are deliberately left out of that list, so an offhand remark can't crowd out a fact the
-  agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
+  Before each turn it is handed the **saved facts** that match what the user just said. User and
+  agent messages are deliberately left out of that list, so an offhand remark can't crowd out a fact
+  the agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
   everything, and `read_session` replays a whole past conversation.
 
   Asking it to forget something blanks the entry — it can never be recalled or searched again. A past

--- a/redis/sdks/agentkit/eve.mdx
+++ b/redis/sdks/agentkit/eve.mdx
@@ -504,10 +504,10 @@ export default defineMemory({
   Two things: facts it chose to save with `save_memory`, and the messages themselves — what the user
   said, and optionally what the agent replied (see `rememberMessages` above).
 
-  Before each turn it is handed the **saved facts** that match what the user just said. User and
-  agent messages are deliberately left out of that list, so an offhand remark can't crowd out a fact
-  the agent decided was worth keeping. It can still reach them itself: `search_memory` looks through
-  everything, and `read_session` replays a whole past conversation.
+  Before each turn the agent is handed the **saved facts** that match what the user just said. User
+  and agent messages are deliberately left out of that list, so an offhand remark can't crowd out a
+  fact the agent decided was worth keeping. It can still reach them itself: `search_memory` looks
+  through everything, and `read_session` replays a whole past conversation.
 
   Asking it to forget something blanks the entry — it can never be recalled or searched again. A past
   conversation shows the entry as `[redacted]` rather than dropping it silently, so nothing that was


### PR DESCRIPTION
Adds a section for `@upstash/agentkit-eve/memory`: `redisMemory()` as a full memory provider, and `redisDocuments()` as storage behind Eve's own `fileMemory()`. Covers the options and the two behaviours worth knowing — automatic recall injects saved facts only, and `forget_memory` redacts rather than deletes.

Claude-Session: https://claude.ai/code/session_01D3v2QieC7eC1EwhZk7KtKj