### PR TITLE
DX-2996: list every MCP tool, grouped and collapsed

### DIFF
--- a/agent-resources/mcp.mdx
+++ b/agent-resources/mcp.mdx
@@ -108,6 +108,71 @@ A group covers every product it names, because those products share their tools:
   A name the server does not recognize is dropped, so `?features=redis,typo` still returns the Redis tools. But if *every* name is dropped, the server starts with no tools at all — and a client then reports `tools/list` as an unknown method rather than showing an empty list. If a fresh connection looks like it has no tools, check the spelling here first.
 </Note>
 
+## Tools
+
+38 tools, grouped the way `?features=` groups them. The access column is the tool's own annotation, which clients use to decide what to confirm with you: **read** never changes anything, **write** creates or updates, **destructive** can delete or overwrite data. On a read-only connection every write and destructive tool is refused.
+
+<AccordionGroup>
+  <Accordion title="Redis — 11 tools">
+    | Tool | Access | What it does |
+    | --- | --- | --- |
+    | `redis_list_databases` | read | Every Redis database in the account scope |
+    | `redis_get_database` | read | One database in detail, with its REST credentials |
+    | `redis_get_stats` | read | Throughput, data size, hit and miss counts |
+    | `redis_list_backups` | read | Backups taken of a database |
+    | `redis_create_database` | write | Creates a database and returns its credentials |
+    | `redis_rename_database` | write | Renames a database |
+    | `redis_set_eviction` | write | Turns key eviction on or off |
+    | `redis_set_auto_upgrade` | write | Turns automatic plan upgrade on or off |
+    | `redis_create_backup` | write | Takes a manual backup |
+    | `redis_delete_database` | destructive | Deletes a database and everything in it |
+    | `redis_run_command` | destructive | Runs Redis commands over the REST API, one or a pipeline |
+
+    `redis_run_command` is annotated destructive because it takes arbitrary commands. On a read-only connection it still works, but only for commands on an allowlist of read-only ones — anything else, including a command the server does not recognize, is refused.
+  </Accordion>
+
+  <Accordion title="QStash and Workflow — 10 tools">
+    Every tool here takes a `region` (`eu` or `us`), which picks the QStash user. The three shared ones take a `service` (`qstash` or `workflow`) to say which side you mean.
+
+    | Tool | Access | What it does |
+    | --- | --- | --- |
+    | `qstash_list_users` | read | The QStash user per region, with REST tokens and signing keys |
+    | `qstash_list_schedules` | read | Schedules in a region |
+    | `qstash_flow_control_get` | read | Rate and parallelism for a flow-control key, or the account's global parallelism |
+    | `logs_list` | read | Delivery and run logs, paginated by cursor |
+    | `dlq_list` | read | The dead-letter queue, paginated by cursor |
+    | `qstash_publish_message` | write | Publishes a message to a destination URL |
+    | `qstash_flow_control_manage` | write | Pauses, resumes, pins, unpins or resets the rate on a key |
+    | `qstash_manage_schedule` | destructive | Creates, reads, deletes, pauses or resumes a schedule |
+    | `workflow_manage_run` | destructive | Reads a run's steps, or cancels the run |
+    | `dlq_manage` | destructive | Reads or deletes a DLQ entry; Workflow entries can also be restarted or resumed |
+  </Accordion>
+
+  <Accordion title="Vector and Search — 17 tools">
+    A Search database is a Vector index whose named indexes are namespaces, so most tools serve both and take a `service` (`vector` or `search`). Only querying and writing documents differ, which is why those four keep product names.
+
+    | Tool | Access | What it does |
+    | --- | --- | --- |
+    | `index_list` | read | Every Vector index or Search database in the account scope |
+    | `index_get` | read | One of them in detail, with its REST credentials |
+    | `index_info` | read | Document counts, index size, per-namespace breakdown |
+    | `index_list_namespaces` | read | Namespaces, which for Search are its named indexes |
+    | `index_fetch` | read | Documents by ID or ID prefix |
+    | `index_range` | read | Pages through the documents of a namespace |
+    | `index_create` | write | Creates a Vector index or a Search database |
+    | `index_update` | write | Edits one document in place, including a metadata patch mode |
+    | `index_rename_namespace` | write | Renames a namespace |
+    | `index_delete` | destructive | Deletes an index or database and everything in it |
+    | `index_delete_documents` | destructive | Deletes documents by ID, prefix or filter |
+    | `index_reset` | destructive | Empties a namespace, or every namespace, keeping the index |
+    | `index_delete_namespace` | destructive | Deletes a namespace and its contents |
+    | `vector_query` | read | Vector similarity search, with server-side embedding optional |
+    | `search_query` | read | Full-text and semantic search over one named index |
+    | `vector_upsert` | write | Upserts vectors, or text for the server to embed |
+    | `search_upsert` | write | Upserts documents, creating the named index if needed |
+  </Accordion>
+</AccordionGroup>
+
 # Local server (`@upstash/mcp-server`)
 
 A stdio server you run with `npx`, authenticated with your account email and a Developer API key. Adds [Upstash Box](/box/overall/quickstart) tools on top of Redis, QStash, and Workflow. Repository [here](https://github.com/upstash/mcp-server).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -833,6 +833,71 @@ A group covers every product it names, because those products share their tools:
   A name the server does not recognize is dropped, so `?features=redis,typo` still returns the Redis tools. But if *every* name is dropped, the server starts with no tools at all — and a client then reports `tools/list` as an unknown method rather than showing an empty list. If a fresh connection looks like it has no tools, check the spelling here first.
 </Note>
 
+## Tools
+
+38 tools, grouped the way `?features=` groups them. The access column is the tool's own annotation, which clients use to decide what to confirm with you: **read** never changes anything, **write** creates or updates, **destructive** can delete or overwrite data. On a read-only connection every write and destructive tool is refused.
+
+<AccordionGroup>
+  <Accordion title="Redis — 11 tools">
+    | Tool | Access | What it does |
+    | --- | --- | --- |
+    | `redis_list_databases` | read | Every Redis database in the account scope |
+    | `redis_get_database` | read | One database in detail, with its REST credentials |
+    | `redis_get_stats` | read | Throughput, data size, hit and miss counts |
+    | `redis_list_backups` | read | Backups taken of a database |
+    | `redis_create_database` | write | Creates a database and returns its credentials |
+    | `redis_rename_database` | write | Renames a database |
+    | `redis_set_eviction` | write | Turns key eviction on or off |
+    | `redis_set_auto_upgrade` | write | Turns automatic plan upgrade on or off |
+    | `redis_create_backup` | write | Takes a manual backup |
+    | `redis_delete_database` | destructive | Deletes a database and everything in it |
+    | `redis_run_command` | destructive | Runs Redis commands over the REST API, one or a pipeline |
+
+    `redis_run_command` is annotated destructive because it takes arbitrary commands. On a read-only connection it still works, but only for commands on an allowlist of read-only ones — anything else, including a command the server does not recognize, is refused.
+  </Accordion>
+
+  <Accordion title="QStash and Workflow — 10 tools">
+    Every tool here takes a `region` (`eu` or `us`), which picks the QStash user. The three shared ones take a `service` (`qstash` or `workflow`) to say which side you mean.
+
+    | Tool | Access | What it does |
+    | --- | --- | --- |
+    | `qstash_list_users` | read | The QStash user per region, with REST tokens and signing keys |
+    | `qstash_list_schedules` | read | Schedules in a region |
+    | `qstash_flow_control_get` | read | Rate and parallelism for a flow-control key, or the account's global parallelism |
+    | `logs_list` | read | Delivery and run logs, paginated by cursor |
+    | `dlq_list` | read | The dead-letter queue, paginated by cursor |
+    | `qstash_publish_message` | write | Publishes a message to a destination URL |
+    | `qstash_flow_control_manage` | write | Pauses, resumes, pins, unpins or resets the rate on a key |
+    | `qstash_manage_schedule` | destructive | Creates, reads, deletes, pauses or resumes a schedule |
+    | `workflow_manage_run` | destructive | Reads a run's steps, or cancels the run |
+    | `dlq_manage` | destructive | Reads or deletes a DLQ entry; Workflow entries can also be restarted or resumed |
+  </Accordion>
+
+  <Accordion title="Vector and Search — 17 tools">
+    A Search database is a Vector index whose named indexes are namespaces, so most tools serve both and take a `service` (`vector` or `search`). Only querying and writing documents differ, which is why those four keep product names.
+
+    | Tool | Access | What it does |
+    | --- | --- | --- |
+    | `index_list` | read | Every Vector index or Search database in the account scope |
+    | `index_get` | read | One of them in detail, with its REST credentials |
+    | `index_info` | read | Document counts, index size, per-namespace breakdown |
+    | `index_list_namespaces` | read | Namespaces, which for Search are its named indexes |
+    | `index_fetch` | read | Documents by ID or ID prefix |
+    | `index_range` | read | Pages through the documents of a namespace |
+    | `index_create` | write | Creates a Vector index or a Search database |
+    | `index_update` | write | Edits one document in place, including a metadata patch mode |
+    | `index_rename_namespace` | write | Renames a namespace |
+    | `index_delete` | destructive | Deletes an index or database and everything in it |
+    | `index_delete_documents` | destructive | Deletes documents by ID, prefix or filter |
+    | `index_reset` | destructive | Empties a namespace, or every namespace, keeping the index |
+    | `index_delete_namespace` | destructive | Deletes a namespace and its contents |
+    | `vector_query` | read | Vector similarity search, with server-side embedding optional |
+    | `search_query` | read | Full-text and semantic search over one named index |
+    | `vector_upsert` | write | Upserts vectors, or text for the server to embed |
+    | `search_upsert` | write | Upserts documents, creating the named index if needed |
+  </Accordion>
+</AccordionGroup>
+
 # Local server (`@upstash/mcp-server`)
 
 A stdio server you run with `npx`, authenticated with your account email and a Developer API key. Adds [Upstash Box](/docs/box/overall/quickstart) tools on top of Redis, QStash, and Workflow. Repository [here](https://github.com/upstash/mcp-server).


### PR DESCRIPTION
The page said which feature groups exist but never what is in them, so the only way to find out was to connect a client and read tools/list.

One accordion per group, closed by default so the page keeps its shape, with a table of the tools inside. The access column is the tool's own annotation rather than a description I wrote, since that is what a client reads to decide what to confirm, and it is the same signal the read-only connection enforces.

Checked both columns against a running server: 38 tools, none missing, none invented, and every read / write / destructive label matches the annotation the tool actually ships with.