### PR TITLE
DX-2996: connect every client to the remote MCP server

### DIFF
--- a/agent-resources/clients.mdx
+++ b/agent-resources/clients.mdx
@@ -6,7 +6,9 @@ description: "Step-by-step setup of the Upstash Skills and MCP server for every 
 
 Each section below covers everything for one agent: the [Upstash Skills](/agent-resources/skills) (docs and the `upstash` [CLI](/agent-resources/cli) reference your agent loads on demand) and the [MCP server](/agent-resources/mcp) (live tools for your account).
 
-The **remote MCP server** (`https://mcp.upstash.com/mcp`) needs no setup up front — it authenticates over OAuth on first use, and the Upstash plugin for Claude Code, Claude Desktop, and Codex bundles it, so installing the plugin also connects the MCP. The **local (stdio) MCP server** needs your account email and a [Developer API key](/devops/developer-api/introduction#create-an-api-key) (readonly keys work; the server then disables every mutating tool). The skills need no credentials. See the [MCP server page](/agent-resources/mcp) for remote vs. local, authentication, and feature options.
+Every section sets up the **remote MCP server** (`https://mcp.upstash.com/mcp`), which needs no credentials up front — it authenticates over OAuth on first use, and the Upstash plugin for Claude Code, Claude Desktop, and Codex bundles it, so installing the plugin also connects the MCP.
+
+The **local (stdio) server** is the alternative, folded into each section. It needs your account email and a [Developer API key](/devops/developer-api/introduction#create-an-api-key) (readonly keys work; the server then disables every mutating tool), and it is the only one that carries [Upstash Box](/box/overall/quickstart) tools — the remote server covers Redis, QStash, Workflow, Vector, and Search. The skills need no credentials either way. See the [MCP server page](/agent-resources/mcp) for remote vs. local, authentication, and feature options.
 
 ## Claude Code
 
@@ -19,11 +21,19 @@ The [`upstash/skills`](https://github.com/upstash/skills) repo is a Claude Code 
 
 The plugin bundles the **remote MCP server** (over OAuth), so this one install sets up both the skills and the MCP — approve the consent screen on the first tool call.
 
-Prefer the local (stdio) server instead — for example, to use [Upstash Box](/box/overall/quickstart) tools, which the remote server doesn't carry? Add it separately with a [Developer API key](/devops/developer-api/introduction#create-an-api-key):
+To add the remote server on its own, without the plugin:
 
 ```sh
-claude mcp add --transport stdio upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+claude mcp add --scope user --transport http upstash https://mcp.upstash.com/mcp
 ```
+
+Then run `/mcp` → **Authenticate**.
+
+<Accordion title="Local (stdio) server instead">
+  ```sh
+  claude mcp add --transport stdio upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+  ```
+</Accordion>
 
 See the [Claude Code plugin docs](https://code.claude.com/docs/en/plugins) and [MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp) for more info.
 
@@ -43,9 +53,30 @@ npx skills add upstash/skills --agent cursor
 
 For the MCP server, use the one-click install:
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=upstash&config=eyJjb21tYW5kIjoibnB4IC15IEB1cHN0YXNoL21jcC1zZXJ2ZXJAbGF0ZXN0IC0tZW1haWwgWU9VUl9FTUFJTCAtLWFwaS1rZXkgWU9VUl9BUElfS0VZIn0%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=upstash&config=eyJ1cmwiOiJodHRwczovL21jcC51cHN0YXNoLmNvbS9tY3AifQ%3D%3D)
 
-It writes a global server; move the `upstash` entry into `.cursor/mcp.json` in your repo to scope it to one project instead.
+It writes a global server; move the `upstash` entry into `.cursor/mcp.json` in your repo to scope it to one project instead. Or add it to `~/.cursor/mcp.json` by hand — Cursor runs the OAuth flow on the first tool call:
+
+```json
+{
+  "mcpServers": {
+    "upstash": { "url": "https://mcp.upstash.com/mcp" }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## OpenAI Codex
 
@@ -58,11 +89,18 @@ codex plugin add upstash@upstash
 
 The plugin bundles the **remote MCP server** (over OAuth), so this also connects the MCP — approve the consent screen on the first tool call.
 
-Prefer the local (stdio) server instead (for example, for [Upstash Box](/box/overall/quickstart) tools)? Add it with a [Developer API key](/devops/developer-api/introduction#create-an-api-key):
+To add the remote server on its own, put this in `~/.codex/config.toml` (or `.codex/config.toml`):
 
-```sh
-codex mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+```toml
+[mcp_servers.upstash]
+url = "https://mcp.upstash.com/mcp"
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```sh
+  codex mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+  ```
+</Accordion>
 
 See the [Codex plugin docs](https://developers.openai.com/codex/plugins/build) and [MCP docs](https://developers.openai.com/codex/mcp) for more info.
 
@@ -87,13 +125,28 @@ For the MCP server, add this to `~/.config/opencode/opencode.json` or a project-
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "upstash": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+      "type": "remote",
+      "url": "https://mcp.upstash.com/mcp",
       "enabled": true
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+      "upstash": {
+        "type": "local",
+        "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+        "enabled": true
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Zed
 
@@ -109,7 +162,21 @@ npx skills add upstash/skills --agent zed
 
 The skills show up in Zed's Agent Panel, and the agent can load them on its own or via `/upstash`. Zed's extension marketplace has no channel for skills, so the CLI is the only way to install them.
 
-For the MCP server, the repo ships a Zed extension in [`zed-extension/`](https://github.com/upstash/skills/tree/main/zed-extension). Clone the repo, run `zed: install dev extension` from the command palette, and pick the `zed-extension/` directory. Zed then prompts for `upstash_email` and `upstash_api_key` (and an optional `upstash_box_api_key` for [Upstash Box](/box/overall/quickstart) tools).
+For the MCP server, go to **Settings → AI → MCP Servers**, click **Add Server → Add Remote Server**, or put this in `settings.json`. With no `Authorization` header configured, Zed runs the standard MCP OAuth flow:
+
+```json
+{
+  "context_servers": {
+    "upstash": {
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  The repo ships a Zed extension in [`zed-extension/`](https://github.com/upstash/skills/tree/main/zed-extension). Clone the repo, run `zed: install dev extension` from the command palette, and pick the `zed-extension/` directory. Zed then prompts for `upstash_email` and `upstash_api_key` (and an optional `upstash_box_api_key` for [Upstash Box](/box/overall/quickstart) tools).
+</Accordion>
 
 See the [Zed MCP docs](https://zed.dev/docs/ai/mcp) for more info.
 
@@ -127,9 +194,34 @@ npx skills add upstash/skills --agent github-copilot
 
 For the MCP server, use the one-click install:
 
-[<img alt="Install in VS Code (npx)" src="https://img.shields.io/badge/Install%20in%20VS%20Code-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white" />](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22upstash-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40upstash%2Fmcp-server%40latest%22%5D%7D)
+[<img alt="Install in VS Code" src="https://img.shields.io/badge/Install%20in%20VS%20Code-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white" />](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22upstash%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.upstash.com%2Fmcp%22%7D)
 
 It writes the server to `.vscode/mcp.json`. See the [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for more info.
+
+```json
+{
+  "servers": {
+    "upstash": {
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "servers": {
+      "upstash": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Devin Desktop
 
@@ -145,12 +237,24 @@ For the MCP server, add this to `~/.codeium/windsurf/mcp_config.json`. See the [
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "serverUrl": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Gemini CLI
 
@@ -160,18 +264,36 @@ Install the skills with the Agent Skills CLI:
 npx skills add upstash/skills --agent gemini-cli
 ```
 
-For the MCP server, open `~/.gemini/settings.json` and add Upstash to `mcpServers`. See the [Gemini CLI configuration docs](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html) for details.
+Add the MCP server with the CLI:
+
+```bash
+gemini mcp add --transport http upstash https://mcp.upstash.com/mcp
+```
+
+Or open `~/.gemini/settings.json` and add Upstash to `mcpServers` by hand. See the [Gemini CLI configuration docs](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html) for details.
 
 ```json
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "httpUrl": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Google Antigravity
 
@@ -181,18 +303,30 @@ Install the skills with the Agent Skills CLI:
 npx skills add upstash/skills --agent antigravity
 ```
 
-For the MCP server, add this to your Antigravity MCP config. See the [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
+For the MCP server, add this to your Antigravity MCP config. Antigravity registers itself as an OAuth client, so no credentials go in the file. See the [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
 
 ```json
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "serverUrl": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## DeepSeek Harness
 
@@ -208,7 +342,7 @@ dsh web
 
 Installing the bundle mounts the skills as a skill provider right away; no further setup is needed for them.
 
-The same bundle also mounts the MCP server (`npx -y @upstash/mcp-server@latest` over stdio), but it only starts once your credentials are stored. Run this from inside a session:
+The same bundle also mounts the **local (stdio)** MCP server (`npx -y @upstash/mcp-server@latest`), the one client here that does not use the remote server. It only starts once your credentials are stored. Run this from inside a session:
 
 ```
 /upstash-login YOUR_EMAIL YOUR_API_KEY
@@ -231,16 +365,23 @@ npx skills add upstash/skills --agent grok
 Add the MCP server with the Grok CLI. Pass `--scope project` to write it to `.grok/config.toml` in the current directory instead of your user config.
 
 ```bash
-grok mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+grok mcp add --transport http upstash https://mcp.upstash.com/mcp
 ```
 
-Or add it to `~/.grok/config.toml` by hand. See the [Grok Build MCP docs](https://docs.x.ai/build/features/mcp-servers) for more info.
+Or add it to `~/.grok/config.toml` by hand. Grok opens the OAuth flow on first use and stores the tokens in `~/.grok/mcp_credentials.json`. See the [Grok Build MCP docs](https://docs.x.ai/build/features/mcp-servers) for more info.
 
 ```toml
 [mcp_servers.upstash]
-command = "npx"
-args = ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+url = "https://mcp.upstash.com/mcp"
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```toml
+  [mcp_servers.upstash]
+  command = "npx"
+  args = ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+  ```
+</Accordion>
 
 Run `grok mcp doctor upstash` to check the connection.
 
@@ -256,13 +397,27 @@ Add this to `~/.config/kilo/kilo.jsonc` (global) or `kilo.jsonc` in the project 
 {
   "mcp": {
     "upstash": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+      "type": "remote",
+      "url": "https://mcp.upstash.com/mcp",
       "enabled": true
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcp": {
+      "upstash": {
+        "type": "local",
+        "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+        "enabled": true
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Copilot CLI
 
@@ -270,19 +425,36 @@ Add this to `~/.config/kilo/kilo.jsonc` (global) or `kilo.jsonc` in the project 
 npx skills add upstash/skills --agent github-copilot
 ```
 
-Add this to `~/.copilot/mcp-config.json`:
+```bash
+copilot mcp add --transport http upstash https://mcp.upstash.com/mcp
+```
+
+Or add it to `~/.copilot/mcp-config.json` by hand:
 
 ```json
 {
   "mcpServers": {
     "upstash": {
-      "type": "local",
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "type": "local",
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Warp
 
@@ -295,14 +467,25 @@ Go to **Settings → Agents → MCP servers → + Add** and paste:
 ```json
 {
   "upstash": {
-    "command": "npx",
-    "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
-    "env": {},
-    "working_directory": null,
+    "url": "https://mcp.upstash.com/mcp",
     "start_on_launch": true
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "upstash": {
+      "command": "npx",
+      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+      "env": {},
+      "working_directory": null,
+      "start_on_launch": true
+    }
+  }
+  ```
+</Accordion>
 
 ## Qwen Code
 
@@ -311,10 +494,26 @@ npx skills add upstash/skills --agent qwen-code
 ```
 
 ```bash
-qwen mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+qwen mcp add --transport http upstash https://mcp.upstash.com/mcp
 ```
 
-Or add the standard `mcpServers` entry above to `~/.qwen/settings.json` or `.qwen/settings.json`.
+Or add the entry to `~/.qwen/settings.json` or `.qwen/settings.json` by hand:
+
+```json
+{
+  "mcpServers": {
+    "upstash": {
+      "httpUrl": "https://mcp.upstash.com/mcp"
+    }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  ```bash
+  qwen mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+  ```
+</Accordion>
 
 ## Hermes
 
@@ -327,9 +526,17 @@ Add this to `~/.hermes/config.yaml`:
 ```yaml
 mcp_servers:
   upstash:
-    command: "npx"
-    args: ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+    url: "https://mcp.upstash.com/mcp"
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```yaml
+  mcp_servers:
+    upstash:
+      command: "npx"
+      args: ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+  ```
+</Accordion>
 
 ## Factory
 
@@ -338,8 +545,14 @@ npx skills add upstash/skills --agent droid
 ```
 
 ```bash
-droid mcp add upstash "npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY"
+droid mcp add upstash https://mcp.upstash.com/mcp --type http
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```bash
+  droid mcp add upstash "npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY"
+  ```
+</Accordion>
 
 ## fx
 
@@ -352,21 +565,34 @@ fx installs skills straight from a GitHub repo. From inside a session:
 Add the MCP server the same way:
 
 ```
-/mcp add upstash npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+/mcp add --transport http upstash https://mcp.upstash.com/mcp
 ```
 
-Or add it to `~/.fx/mcp.json` by hand. See the [fx MCP docs](https://fx.sh/docs/capabilities/mcp#add-a-local-stdio-server) for more info.
+Or add it to `~/.fx/mcp.json` by hand. See the [fx MCP docs](https://fx.sh/docs/capabilities/mcp) for more info.
 
 ```json
 {
   "mcp": {
     "upstash": {
-      "type": "stdio",
-      "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcp": {
+      "upstash": {
+        "type": "stdio",
+        "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Crush
 
@@ -381,13 +607,27 @@ Add this to your Crush config file:
   "$schema": "https://charm.land/crush.json",
   "mcp": {
     "upstash": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "$schema": "https://charm.land/crush.json",
+    "mcp": {
+      "upstash": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Any other agent
 
@@ -405,21 +645,36 @@ For the MCP server, most clients take the standard `mcpServers` shape below. Che
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
 
+Some clients want the transport named alongside the URL — `"type": "http"` for most, `"type": "streamable-http"` for Roo Code, `"type": "remote"` for OpenCode and Kilo Code. An unrecognized key is usually ignored, so when in doubt start with the plain `url` above.
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
+
 Some of the clients that use it, with their Agent Skills CLI `id`:
 
 | Client | Skills `id` | MCP server |
 |--------|-------------|------------|
-| Kiro | `kiro-cli` | `.kiro/settings/mcp.json`, or **Kiro → MCP Servers → + Add** |
-| Cline | `cline` | **MCP Servers → Remote Servers → Edit Configuration** |
-| Roo Code | `roo` | MCP settings file (`mcp_settings.json`) |
-| Trae | `trae` | **MCP → Add manually** |
-| Augment Code | `augment` | **Settings → MCP → +**, command `npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY` |
+| Amp | `amp` | `amp mcp add upstash https://mcp.upstash.com/mcp` |
+| Kiro | `kiro-cli` | `.kiro/settings/mcp.json`, or **Kiro → MCP Servers → + Add**; takes `url` |
+| Cline | `cline` | **MCP Servers → Remote Servers → Edit Configuration**; takes `url` |
+| Roo Code | `roo` | MCP settings file (`mcp_settings.json`); needs `"type": "streamable-http"` |
+| Trae | `trae` | **MCP → Add manually**; takes `url` |
+| Augment Code | `augment` | **Settings → MCP → + Add remote MCP**, connection type **HTTP** |
 | Zencoder | `zencoder` | **Agent tools → Add custom MCP**, paste the `upstash` entry |
-| Rovo Dev CLI | `rovodev` | `acli rovodev mcp` opens the config file |
+| Rovo Dev CLI | `rovodev` | `acli rovodev mcp` opens the config file; takes `url` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -303,7 +303,9 @@ Source: https://upstash.com/docs/agent-resources/clients
 
 Each section below covers everything for one agent: the [Upstash Skills](/docs/agent-resources/skills) (docs and the `upstash` [CLI](/docs/agent-resources/cli) reference your agent loads on demand) and the [MCP server](/docs/agent-resources/mcp) (live tools for your account).
 
-The **remote MCP server** (`https://mcp.upstash.com/mcp`) needs no setup up front — it authenticates over OAuth on first use, and the Upstash plugin for Claude Code, Claude Desktop, and Codex bundles it, so installing the plugin also connects the MCP. The **local (stdio) MCP server** needs your account email and a [Developer API key](/docs/devops/developer-api/introduction#create-an-api-key) (readonly keys work; the server then disables every mutating tool). The skills need no credentials. See the [MCP server page](/docs/agent-resources/mcp) for remote vs. local, authentication, and feature options.
+Every section sets up the **remote MCP server** (`https://mcp.upstash.com/mcp`), which needs no credentials up front — it authenticates over OAuth on first use, and the Upstash plugin for Claude Code, Claude Desktop, and Codex bundles it, so installing the plugin also connects the MCP.
+
+The **local (stdio) server** is the alternative, folded into each section. It needs your account email and a [Developer API key](/docs/devops/developer-api/introduction#create-an-api-key) (readonly keys work; the server then disables every mutating tool), and it is the only one that carries [Upstash Box](/docs/box/overall/quickstart) tools — the remote server covers Redis, QStash, Workflow, Vector, and Search. The skills need no credentials either way. See the [MCP server page](/docs/agent-resources/mcp) for remote vs. local, authentication, and feature options.
 
 ## Claude Code
 
@@ -316,11 +318,19 @@ The [`upstash/skills`](https://github.com/upstash/skills) repo is a Claude Code 
 
 The plugin bundles the **remote MCP server** (over OAuth), so this one install sets up both the skills and the MCP — approve the consent screen on the first tool call.
 
-Prefer the local (stdio) server instead — for example, to use [Upstash Box](/docs/box/overall/quickstart) tools, which the remote server doesn't carry? Add it separately with a [Developer API key](/docs/devops/developer-api/introduction#create-an-api-key):
+To add the remote server on its own, without the plugin:
 
 ```sh
-claude mcp add --transport stdio upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+claude mcp add --scope user --transport http upstash https://mcp.upstash.com/mcp
 ```
+
+Then run `/mcp` → **Authenticate**.
+
+<Accordion title="Local (stdio) server instead">
+  ```sh
+  claude mcp add --transport stdio upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+  ```
+</Accordion>
 
 See the [Claude Code plugin docs](https://code.claude.com/docs/en/plugins) and [MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp) for more info.
 
@@ -340,9 +350,30 @@ npx skills add upstash/skills --agent cursor
 
 For the MCP server, use the one-click install:
 
-[![Install MCP Server]()](https://cursor.com/en/install-mcp?name=upstash&config=eyJjb21tYW5kIjoibnB4IC15IEB1cHN0YXNoL21jcC1zZXJ2ZXJAbGF0ZXN0IC0tZW1haWwgWU9VUl9FTUFJTCAtLWFwaS1rZXkgWU9VUl9BUElfS0VZIn0%3D)
+[![Install MCP Server]()](https://cursor.com/en/install-mcp?name=upstash&config=eyJ1cmwiOiJodHRwczovL21jcC51cHN0YXNoLmNvbS9tY3AifQ%3D%3D)
 
-It writes a global server; move the `upstash` entry into `.cursor/mcp.json` in your repo to scope it to one project instead.
+It writes a global server; move the `upstash` entry into `.cursor/mcp.json` in your repo to scope it to one project instead. Or add it to `~/.cursor/mcp.json` by hand — Cursor runs the OAuth flow on the first tool call:
+
+```json
+{
+  "mcpServers": {
+    "upstash": { "url": "https://mcp.upstash.com/mcp" }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## OpenAI Codex
 
@@ -355,11 +386,18 @@ codex plugin add upstash@upstash
 
 The plugin bundles the **remote MCP server** (over OAuth), so this also connects the MCP — approve the consent screen on the first tool call.
 
-Prefer the local (stdio) server instead (for example, for [Upstash Box](/docs/box/overall/quickstart) tools)? Add it with a [Developer API key](/docs/devops/developer-api/introduction#create-an-api-key):
+To add the remote server on its own, put this in `~/.codex/config.toml` (or `.codex/config.toml`):
 
-```sh
-codex mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+```toml
+[mcp_servers.upstash]
+url = "https://mcp.upstash.com/mcp"
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```sh
+  codex mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+  ```
+</Accordion>
 
 See the [Codex plugin docs](https://developers.openai.com/codex/plugins/build) and [MCP docs](https://developers.openai.com/codex/mcp) for more info.
 
@@ -384,13 +422,28 @@ For the MCP server, add this to `~/.config/opencode/opencode.json` or a project-
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "upstash": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+      "type": "remote",
+      "url": "https://mcp.upstash.com/mcp",
       "enabled": true
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+      "upstash": {
+        "type": "local",
+        "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+        "enabled": true
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Zed
 
@@ -406,7 +459,21 @@ npx skills add upstash/skills --agent zed
 
 The skills show up in Zed's Agent Panel, and the agent can load them on its own or via `/upstash`. Zed's extension marketplace has no channel for skills, so the CLI is the only way to install them.
 
-For the MCP server, the repo ships a Zed extension in [`zed-extension/`](https://github.com/upstash/skills/tree/main/zed-extension). Clone the repo, run `zed: install dev extension` from the command palette, and pick the `zed-extension/` directory. Zed then prompts for `upstash_email` and `upstash_api_key` (and an optional `upstash_box_api_key` for [Upstash Box](/docs/box/overall/quickstart) tools).
+For the MCP server, go to **Settings → AI → MCP Servers**, click **Add Server → Add Remote Server**, or put this in `settings.json`. With no `Authorization` header configured, Zed runs the standard MCP OAuth flow:
+
+```json
+{
+  "context_servers": {
+    "upstash": {
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  The repo ships a Zed extension in [`zed-extension/`](https://github.com/upstash/skills/tree/main/zed-extension). Clone the repo, run `zed: install dev extension` from the command palette, and pick the `zed-extension/` directory. Zed then prompts for `upstash_email` and `upstash_api_key` (and an optional `upstash_box_api_key` for [Upstash Box](/docs/box/overall/quickstart) tools).
+</Accordion>
 
 See the [Zed MCP docs](https://zed.dev/docs/ai/mcp) for more info.
 
@@ -424,9 +491,34 @@ npx skills add upstash/skills --agent github-copilot
 
 For the MCP server, use the one-click install:
 
-[<img alt="Install in VS Code (npx)" />](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22upstash-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40upstash%2Fmcp-server%40latest%22%5D%7D)
+[<img alt="Install in VS Code" />](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22upstash%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.upstash.com%2Fmcp%22%7D)
 
 It writes the server to `.vscode/mcp.json`. See the [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for more info.
+
+```json
+{
+  "servers": {
+    "upstash": {
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "servers": {
+      "upstash": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Devin Desktop
 
@@ -442,12 +534,24 @@ For the MCP server, add this to `~/.codeium/windsurf/mcp_config.json`. See the [
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "serverUrl": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Gemini CLI
 
@@ -457,18 +561,36 @@ Install the skills with the Agent Skills CLI:
 npx skills add upstash/skills --agent gemini-cli
 ```
 
-For the MCP server, open `~/.gemini/settings.json` and add Upstash to `mcpServers`. See the [Gemini CLI configuration docs](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html) for details.
+Add the MCP server with the CLI:
+
+```bash
+gemini mcp add --transport http upstash https://mcp.upstash.com/mcp
+```
+
+Or open `~/.gemini/settings.json` and add Upstash to `mcpServers` by hand. See the [Gemini CLI configuration docs](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html) for details.
 
 ```json
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "httpUrl": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Google Antigravity
 
@@ -478,18 +600,30 @@ Install the skills with the Agent Skills CLI:
 npx skills add upstash/skills --agent antigravity
 ```
 
-For the MCP server, add this to your Antigravity MCP config. See the [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
+For the MCP server, add this to your Antigravity MCP config. Antigravity registers itself as an OAuth client, so no credentials go in the file. See the [Antigravity MCP docs](https://antigravity.google/docs/mcp) for more info.
 
 ```json
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "serverUrl": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## DeepSeek Harness
 
@@ -505,7 +639,7 @@ dsh web
 
 Installing the bundle mounts the skills as a skill provider right away; no further setup is needed for them.
 
-The same bundle also mounts the MCP server (`npx -y @upstash/mcp-server@latest` over stdio), but it only starts once your credentials are stored. Run this from inside a session:
+The same bundle also mounts the **local (stdio)** MCP server (`npx -y @upstash/mcp-server@latest`), the one client here that does not use the remote server. It only starts once your credentials are stored. Run this from inside a session:
 
 ```
 /upstash-login YOUR_EMAIL YOUR_API_KEY
@@ -528,16 +662,23 @@ npx skills add upstash/skills --agent grok
 Add the MCP server with the Grok CLI. Pass `--scope project` to write it to `.grok/config.toml` in the current directory instead of your user config.
 
 ```bash
-grok mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+grok mcp add --transport http upstash https://mcp.upstash.com/mcp
 ```
 
-Or add it to `~/.grok/config.toml` by hand. See the [Grok Build MCP docs](https://docs.x.ai/build/features/mcp-servers) for more info.
+Or add it to `~/.grok/config.toml` by hand. Grok opens the OAuth flow on first use and stores the tokens in `~/.grok/mcp_credentials.json`. See the [Grok Build MCP docs](https://docs.x.ai/build/features/mcp-servers) for more info.
 
 ```toml
 [mcp_servers.upstash]
-command = "npx"
-args = ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+url = "https://mcp.upstash.com/mcp"
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```toml
+  [mcp_servers.upstash]
+  command = "npx"
+  args = ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+  ```
+</Accordion>
 
 Run `grok mcp doctor upstash` to check the connection.
 
@@ -553,13 +694,27 @@ Add this to `~/.config/kilo/kilo.jsonc` (global) or `kilo.jsonc` in the project 
 {
   "mcp": {
     "upstash": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+      "type": "remote",
+      "url": "https://mcp.upstash.com/mcp",
       "enabled": true
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcp": {
+      "upstash": {
+        "type": "local",
+        "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+        "enabled": true
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Copilot CLI
 
@@ -567,19 +722,36 @@ Add this to `~/.config/kilo/kilo.jsonc` (global) or `kilo.jsonc` in the project 
 npx skills add upstash/skills --agent github-copilot
 ```
 
-Add this to `~/.copilot/mcp-config.json`:
+```bash
+copilot mcp add --transport http upstash https://mcp.upstash.com/mcp
+```
+
+Or add it to `~/.copilot/mcp-config.json` by hand:
 
 ```json
 {
   "mcpServers": {
     "upstash": {
-      "type": "local",
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "type": "local",
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Warp
 
@@ -592,14 +764,25 @@ Go to **Settings → Agents → MCP servers → + Add** and paste:
 ```json
 {
   "upstash": {
-    "command": "npx",
-    "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
-    "env": {},
-    "working_directory": null,
+    "url": "https://mcp.upstash.com/mcp",
     "start_on_launch": true
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "upstash": {
+      "command": "npx",
+      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"],
+      "env": {},
+      "working_directory": null,
+      "start_on_launch": true
+    }
+  }
+  ```
+</Accordion>
 
 ## Qwen Code
 
@@ -608,10 +791,26 @@ npx skills add upstash/skills --agent qwen-code
 ```
 
 ```bash
-qwen mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+qwen mcp add --transport http upstash https://mcp.upstash.com/mcp
 ```
 
-Or add the standard `mcpServers` entry above to `~/.qwen/settings.json` or `.qwen/settings.json`.
+Or add the entry to `~/.qwen/settings.json` or `.qwen/settings.json` by hand:
+
+```json
+{
+  "mcpServers": {
+    "upstash": {
+      "httpUrl": "https://mcp.upstash.com/mcp"
+    }
+  }
+}
+```
+
+<Accordion title="Local (stdio) server instead">
+  ```bash
+  qwen mcp add upstash -- npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+  ```
+</Accordion>
 
 ## Hermes
 
@@ -624,9 +823,17 @@ Add this to `~/.hermes/config.yaml`:
 ```yaml
 mcp_servers:
   upstash:
-    command: "npx"
-    args: ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+    url: "https://mcp.upstash.com/mcp"
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```yaml
+  mcp_servers:
+    upstash:
+      command: "npx"
+      args: ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+  ```
+</Accordion>
 
 ## Factory
 
@@ -635,8 +842,14 @@ npx skills add upstash/skills --agent droid
 ```
 
 ```bash
-droid mcp add upstash "npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY"
+droid mcp add upstash https://mcp.upstash.com/mcp --type http
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```bash
+  droid mcp add upstash "npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY"
+  ```
+</Accordion>
 
 ## fx
 
@@ -649,21 +862,34 @@ fx installs skills straight from a GitHub repo. From inside a session:
 Add the MCP server the same way:
 
 ```
-/mcp add upstash npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
+/mcp add --transport http upstash https://mcp.upstash.com/mcp
 ```
 
-Or add it to `~/.fx/mcp.json` by hand. See the [fx MCP docs](https://fx.sh/docs/capabilities/mcp#add-a-local-stdio-server) for more info.
+Or add it to `~/.fx/mcp.json` by hand. See the [fx MCP docs](https://fx.sh/docs/capabilities/mcp) for more info.
 
 ```json
 {
   "mcp": {
     "upstash": {
-      "type": "stdio",
-      "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcp": {
+      "upstash": {
+        "type": "stdio",
+        "command": ["npx", "-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Crush
 
@@ -678,13 +904,27 @@ Add this to your Crush config file:
   "$schema": "https://charm.land/crush.json",
   "mcp": {
     "upstash": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "$schema": "https://charm.land/crush.json",
+    "mcp": {
+      "upstash": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
 
 ## Any other agent
 
@@ -702,24 +942,39 @@ For the MCP server, most clients take the standard `mcpServers` shape below. Che
 {
   "mcpServers": {
     "upstash": {
-      "command": "npx",
-      "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      "url": "https://mcp.upstash.com/mcp"
     }
   }
 }
 ```
 
+Some clients want the transport named alongside the URL — `"type": "http"` for most, `"type": "streamable-http"` for Roo Code, `"type": "remote"` for OpenCode and Kilo Code. An unrecognized key is usually ignored, so when in doubt start with the plain `url` above.
+
+<Accordion title="Local (stdio) server instead">
+  ```json
+  {
+    "mcpServers": {
+      "upstash": {
+        "command": "npx",
+        "args": ["-y", "@upstash/mcp-server@latest", "--email", "YOUR_EMAIL", "--api-key", "YOUR_API_KEY"]
+      }
+    }
+  }
+  ```
+</Accordion>
+
 Some of the clients that use it, with their Agent Skills CLI `id`:
 
 | Client | Skills `id` | MCP server |
 |--------|-------------|------------|
-| Kiro | `kiro-cli` | `.kiro/settings/mcp.json`, or **Kiro → MCP Servers → + Add** |
-| Cline | `cline` | **MCP Servers → Remote Servers → Edit Configuration** |
-| Roo Code | `roo` | MCP settings file (`mcp_settings.json`) |
-| Trae | `trae` | **MCP → Add manually** |
-| Augment Code | `augment` | **Settings → MCP → +**, command `npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY` |
+| Amp | `amp` | `amp mcp add upstash https://mcp.upstash.com/mcp` |
+| Kiro | `kiro-cli` | `.kiro/settings/mcp.json`, or **Kiro → MCP Servers → + Add**; takes `url` |
+| Cline | `cline` | **MCP Servers → Remote Servers → Edit Configuration**; takes `url` |
+| Roo Code | `roo` | MCP settings file (`mcp_settings.json`); needs `"type": "streamable-http"` |
+| Trae | `trae` | **MCP → Add manually**; takes `url` |
+| Augment Code | `augment` | **Settings → MCP → + Add remote MCP**, connection type **HTTP** |
 | Zencoder | `zencoder` | **Agent tools → Add custom MCP**, paste the `upstash` entry |
-| Rovo Dev CLI | `rovodev` | `acli rovodev mcp` opens the config file |
+| Rovo Dev CLI | `rovodev` | `acli rovodev mcp` opens the config file; takes `url` |
 
 # llms.txt
 Source: https://upstash.com/docs/agent-resources/llms-txt


### PR DESCRIPTION
Every agent past Claude Code, Claude Desktop and Codex still set up the local stdio server on the Install-by-agent page. Each section now leads with the remote server (`https://mcp.upstash.com/mcp`) over OAuth, with the stdio command folded into a collapsed "Local (stdio) server instead" block.

Config shapes were verified against each client's own MCP docs, then cross-checked against context7's all-clients page:

- `url` — Cursor, Zed (`context_servers`), Warp, Grok
- `serverUrl` — Devin Desktop, Antigravity
- `httpUrl` — Gemini CLI, Qwen Code
- `type: "http"` — VS Code, Copilot CLI, Crush, fx, Factory
- `type: "remote"` — OpenCode, Kilo Code

Also regenerates the Cursor and VS Code one-click deeplinks (their payloads had the stdio command baked in), adds the `--transport http` CLI forms, and adds an Amp row to the fallback table.

DeepSeek Harness stays on stdio — its bundle mounts that server — and the section now says so.

https://claude.ai/code/session_01RbmH11oU4KZmNfe2bbsAdA