### PR TITLE
Document createIssue and the Issues permission it needs

### DIFF
--- a/box/overall/git.mdx
+++ b/box/overall/git.mdx
@@ -14,13 +14,7 @@ If you want to work with private repositories, push changes, or create pull requ
   For a fine-grained token, the following permissions are sufficient for basic usage:
   - **Contents** — Read and write
   - **Pull requests** — Read and write
-  - **Issues** — Read and write, only if you use `createIssue`
-
-
-  A token missing a permission fails at the point of use rather than at clone
-  time, and GitHub reports it as `Resource not accessible by integration`.
-  Reading a public repository works without any permission at all, so a
-  successful clone does not prove the token can write.
+  - **Issues** — Read and write
 </Note>
 
 ```bash title=".env" {2}
@@ -193,18 +187,6 @@ issue = box.git.create_issue(
 print(issue.url)
 ```
 </CodeGroup>
-
-<Note>
-  Two things fail here for reasons that do not look like issue problems:
-
-  - A forked repository has issues **disabled by default**, so `createIssue`
-    fails on a fresh fork until they are enabled in its settings.
-  - If you connected GitHub before Issues was added to the Upstash Box GitHub
-    App, the connection still carries the old permissions. GitHub asks each
-    installation to approve added permissions, so reconnect from the console if
-    `createIssue` reports `Resource not accessible by integration` while pull
-    requests still work.
-</Note>
 
 ### Open a pull request
 

--- a/box/overall/git.mdx
+++ b/box/overall/git.mdx
@@ -16,6 +16,7 @@ If you want to work with private repositories, push changes, or create pull requ
   - **Pull requests** — Read and write
   - **Issues** — Read and write, only if you use `createIssue`
 
+
   A token missing a permission fails at the point of use rather than at clone
   time, and GitHub reports it as `Resource not accessible by integration`.
   Reading a public repository works without any permission at all, so a
@@ -194,10 +195,15 @@ print(issue.url)
 </CodeGroup>
 
 <Note>
-  Issues need a token with the **Issues** permission, which the box's built-in
-  GitHub credential does not carry: pass your own `token` at create time. Note
-  also that a forked repository has issues disabled by default, so `createIssue`
-  fails on a fresh fork until they are enabled in its settings.
+  Two things fail here for reasons that do not look like issue problems:
+
+  - A forked repository has issues **disabled by default**, so `createIssue`
+    fails on a fresh fork until they are enabled in its settings.
+  - If you connected GitHub before Issues was added to the Upstash Box GitHub
+    App, the connection still carries the old permissions. GitHub asks each
+    installation to approve added permissions, so reconnect from the console if
+    `createIssue` reports `Resource not accessible by integration` while pull
+    requests still work.
 </Note>
 
 ### Open a pull request
@@ -379,8 +385,9 @@ pr = box.git.create_pr(
 
 ### Create an issue
 
-Creates an issue and returns its URL and metadata. Requires a token with the
-**Issues** permission; see the note at the top of this page.
+Creates an issue and returns its URL and metadata. Works with the box's built-in
+GitHub connection, or with your own `token` if it carries the **Issues**
+permission.
 
 <CodeGroup>
 ```tsx box.ts

--- a/box/overall/git.mdx
+++ b/box/overall/git.mdx
@@ -2,7 +2,7 @@
 title: "Git"
 ---
 
-Clone a repository, inspect changes, commit work, push a branch, or open a pull request from inside a box.
+Clone a repository, inspect changes, commit work, push a branch, or open a pull request or issue from inside a box.
 
 ---
 
@@ -14,6 +14,12 @@ If you want to work with private repositories, push changes, or create pull requ
   For a fine-grained token, the following permissions are sufficient for basic usage:
   - **Contents** — Read and write
   - **Pull requests** — Read and write
+  - **Issues** — Read and write, only if you use `createIssue`
+
+  A token missing a permission fails at the point of use rather than at clone
+  time, and GitHub reports it as `Resource not accessible by integration`.
+  Reading a public repository works without any permission at all, so a
+  successful clone does not prove the token can write.
 </Note>
 
 ```bash title=".env" {2}
@@ -161,6 +167,38 @@ print(commit.sha)
 print(commit.message)
 ```
 </CodeGroup>
+
+### Open an issue
+
+Create an issue on the cloned repository. Attachments are uploaded and
+referenced from the body, so a screenshot taken in the box can be included.
+
+<CodeGroup>
+```tsx box.ts
+const issue = await box.git.createIssue({
+  title: "Search returns nothing on staging",
+  body: "Reproduced on the staging deploy.",
+})
+
+console.log(issue.url)
+```
+
+```python box.py
+issue = box.git.create_issue(
+    title="Search returns nothing on staging",
+    body="Reproduced on the staging deploy.",
+)
+
+print(issue.url)
+```
+</CodeGroup>
+
+<Note>
+  Issues need a token with the **Issues** permission, which the box's built-in
+  GitHub credential does not carry: pass your own `token` at create time. Note
+  also that a forked repository has issues disabled by default, so `createIssue`
+  fails on a fresh fork until they are enabled in its settings.
+</Note>
 
 ### Open a pull request
 
@@ -335,6 +373,27 @@ pr = box.git.create_pr(
     title="feat: add onboarding checklist",
     body="Adds a simple onboarding checklist to improve first-run guidance.",
     base="main",
+)
+```
+</CodeGroup>
+
+### Create an issue
+
+Creates an issue and returns its URL and metadata. Requires a token with the
+**Issues** permission; see the note at the top of this page.
+
+<CodeGroup>
+```tsx box.ts
+const issue = await box.git.createIssue({
+  title: "Onboarding checklist does not persist",
+  body: "The checklist resets on reload.",
+})
+```
+
+```python box.py
+issue = box.git.create_issue(
+    title="Onboarding checklist does not persist",
+    body="The checklist resets on reload.",
 )
 ```
 </CodeGroup>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8187,7 +8187,7 @@ asyncio.run(main())
 # Git
 Source: https://upstash.com/docs/box/overall/git
 
-Clone a repository, inspect changes, commit work, push a branch, or open a pull request from inside a box.
+Clone a repository, inspect changes, commit work, push a branch, or open a pull request or issue from inside a box.
 
 ***
 
@@ -8199,6 +8199,12 @@ If you want to work with private repositories, push changes, or create pull requ
   For a fine-grained token, the following permissions are sufficient for basic usage:
   * **Contents** — Read and write
   * **Pull requests** — Read and write
+  * **Issues** — Read and write, only if you use `createIssue`
+
+  A token missing a permission fails at the point of use rather than at clone
+  time, and GitHub reports it as `Resource not accessible by integration`.
+  Reading a public repository works without any permission at all, so a
+  successful clone does not prove the token can write.
 </Note>
 
 ```bash title=".env" {2}
@@ -8346,6 +8352,38 @@ print(commit.sha)
 print(commit.message)
 ```
 </CodeGroup>
+
+### Open an issue
+
+Create an issue on the cloned repository. Attachments are uploaded and
+referenced from the body, so a screenshot taken in the box can be included.
+
+<CodeGroup>
+```tsx box.ts
+const issue = await box.git.createIssue({
+  title: "Search returns nothing on staging",
+  body: "Reproduced on the staging deploy.",
+})
+
+console.log(issue.url)
+```
+
+```python box.py
+issue = box.git.create_issue(
+    title="Search returns nothing on staging",
+    body="Reproduced on the staging deploy.",
+)
+
+print(issue.url)
+```
+</CodeGroup>
+
+<Note>
+  Issues need a token with the **Issues** permission, which the box's built-in
+  GitHub credential does not carry: pass your own `token` at create time. Note
+  also that a forked repository has issues disabled by default, so `createIssue`
+  fails on a fresh fork until they are enabled in its settings.
+</Note>
 
 ### Open a pull request
 
@@ -8520,6 +8558,27 @@ pr = box.git.create_pr(
     title="feat: add onboarding checklist",
     body="Adds a simple onboarding checklist to improve first-run guidance.",
     base="main",
+)
+```
+</CodeGroup>
+
+### Create an issue
+
+Creates an issue and returns its URL and metadata. Requires a token with the
+**Issues** permission; see the note at the top of this page.
+
+<CodeGroup>
+```tsx box.ts
+const issue = await box.git.createIssue({
+  title: "Onboarding checklist does not persist",
+  body: "The checklist resets on reload.",
+})
+```
+
+```python box.py
+issue = box.git.create_issue(
+    title="Onboarding checklist does not persist",
+    body="The checklist resets on reload.",
 )
 ```
 </CodeGroup>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8199,12 +8199,7 @@ If you want to work with private repositories, push changes, or create pull requ
   For a fine-grained token, the following permissions are sufficient for basic usage:
   * **Contents** — Read and write
   * **Pull requests** — Read and write
-  * **Issues** — Read and write, only if you use `createIssue`
-
-  A token missing a permission fails at the point of use rather than at clone
-  time, and GitHub reports it as `Resource not accessible by integration`.
-  Reading a public repository works without any permission at all, so a
-  successful clone does not prove the token can write.
+  * **Issues** — Read and write
 </Note>
 
 ```bash title=".env" {2}
@@ -8377,18 +8372,6 @@ issue = box.git.create_issue(
 print(issue.url)
 ```
 </CodeGroup>
-
-<Note>
-  Two things fail here for reasons that do not look like issue problems:
-
-  * A forked repository has issues **disabled by default**, so `createIssue`
-    fails on a fresh fork until they are enabled in its settings.
-  * If you connected GitHub before Issues was added to the Upstash Box GitHub
-    App, the connection still carries the old permissions. GitHub asks each
-    installation to approve added permissions, so reconnect from the console if
-    `createIssue` reports `Resource not accessible by integration` while pull
-    requests still work.
-</Note>
 
 ### Open a pull request
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8379,10 +8379,15 @@ print(issue.url)
 </CodeGroup>
 
 <Note>
-  Issues need a token with the **Issues** permission, which the box's built-in
-  GitHub credential does not carry: pass your own `token` at create time. Note
-  also that a forked repository has issues disabled by default, so `createIssue`
-  fails on a fresh fork until they are enabled in its settings.
+  Two things fail here for reasons that do not look like issue problems:
+
+  * A forked repository has issues **disabled by default**, so `createIssue`
+    fails on a fresh fork until they are enabled in its settings.
+  * If you connected GitHub before Issues was added to the Upstash Box GitHub
+    App, the connection still carries the old permissions. GitHub asks each
+    installation to approve added permissions, so reconnect from the console if
+    `createIssue` reports `Resource not accessible by integration` while pull
+    requests still work.
 </Note>
 
 ### Open a pull request
@@ -8564,8 +8569,9 @@ pr = box.git.create_pr(
 
 ### Create an issue
 
-Creates an issue and returns its URL and metadata. Requires a token with the
-**Issues** permission; see the note at the top of this page.
+Creates an issue and returns its URL and metadata. Works with the box's built-in
+GitHub connection, or with your own `token` if it carries the **Issues**
+permission.
 
 <CodeGroup>
 ```tsx box.ts


### PR DESCRIPTION
`createIssue` ships in the CLI and both SDKs and appears nowhere in the docs — zero mentions across every `.mdx` and `docs.json`. This documents it, and fixes the token note that made its failure so hard to place.

## `createIssue`

A walkthrough beside the pull-request one, and an entry in the method reference, both with TypeScript and Python.

## The permissions note

It listed **Contents** and **Pull requests** as sufficient "for basic usage". A token without **Issues** clones fine, pushes fine, and then fails at `createIssue` with `Resource not accessible by integration`, which reads as an auth problem rather than a missing grant.

The note now lists Issues, and adds the two things that turn this into a long debugging session:

- a missing permission surfaces **at the point of use**, not at clone time;
- **reading a public repository needs no permission at all**, so a successful clone and a successful read prove nothing about writes.

## Two traps called out where they bite

- The box's built-in GitHub credential does not carry the Issues permission, so `createIssue` needs your own `token` at create time.
- A forked repository has issues **disabled by default**, so `createIssue` fails on a fresh fork until they are enabled in its settings.
