### PR TITLE
docs: enable page feedback controls

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -10,6 +10,11 @@
   "favicon": "/favicon.png",
   "filterSidebar": false,
   "poweredByDocs7": true,
+  "feedback": {
+    "thumbsRating": true,
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
Enable Yes/No page ratings, Suggest edits, and Raise issue in the Upstash docs. Set the three existing feedback options to true in `docs.json`.

Validation passed:
- Full configuration validation with the Docs7 renderer.
- Feedback link checks for the repository root and `main` branch.
- All five existing page feedback tests.
- `npm --prefix llms run check` and `git diff --check`.

CI note: Mintlify reports 44 broken links in unchanged QStash and Workflow pages. The generated-docs check and Mintlify preview build passed.
