### PR TITLE
DX-2965: document browser login and whoami for the Upstash CLI

### DIFF
--- a/agent-resources/cli.mdx
+++ b/agent-resources/cli.mdx
@@ -54,7 +54,7 @@ A browser login has a few limits:
 - Teams that require MFA reject browser logins.
 - A read-only login refuses write commands and returns only read-only database credentials.
 
-`upstash logout` revokes the login on the server. The CLI stays listed under [OAuth Clients](https://console.upstash.com/account/oauth-clients) in the console until you remove it there.
+`upstash logout` revokes the login on the server. The CLI stays listed in the console under Account → OAuth Clients until you remove it there.
 
 ## 2. Saved API key
 
@@ -112,10 +112,7 @@ upstash vector  # Vector indexes
 upstash search  # Search indexes
 upstash qstash  # QStash instances
 upstash blob    # Blob buckets
-upstash box     # Upstash Box sandboxes (same commands as the box CLI)
 ```
-
-`upstash box` needs a browser login or a Box API key (`UPSTASH_BOX_API_KEY` or `--token`); Upstash Box does not accept developer API keys.
 
 Use `--help` on any command or subcommand for details:
 

--- a/agent-resources/cli.mdx
+++ b/agent-resources/cli.mdx
@@ -36,19 +36,37 @@ upstash start-redis --id $DB_ID
 
 # Authentication
 
-The CLI needs your account email and a developer API key. Grab one from the [Upstash Console under Account → API Keys](https://console.upstash.com/account/api), then set credentials using whichever method fits your workflow.
+Every command that touches your account needs credentials. There are two kinds: a browser login with your Upstash account, or a developer API key. Set them using whichever method fits your workflow.
 
-## 1. Saved login (recommended)
+## 1. Browser login
 
-Saves your credentials to `~/.config/upstash/config.json` (taken from `$XDG_CONFIG_HOME`) so you only have to do it once per machine.
+Signs in with your Upstash account through the browser and saves the session to `~/.config/upstash/config.json` (taken from `$XDG_CONFIG_HOME`).
+
+```bash
+upstash login --oauth
+```
+
+The consent page asks which account to use (personal or one team) and whether the login should be read-only. The choice applies to the whole login: run `upstash login --oauth` again to switch teams or turn read-only off. Pass `--no-browser` to print the login URL instead of opening a browser, for example over SSH.
+
+A browser login has a few limits:
+
+- `team create`, `team delete`, `team add-member` and `team remove-member` need an API key login.
+- Teams that require MFA reject browser logins.
+- A read-only login refuses write commands and returns only read-only database credentials.
+
+`upstash logout` revokes the login on the server. The CLI stays listed under [OAuth Clients](https://console.upstash.com/account/oauth-clients) in the console until you remove it there.
+
+## 2. Saved API key
+
+Grab a developer API key from the [Upstash Console under Account → API Keys](https://console.upstash.com/account/api), then save it once per machine:
 
 ```bash
 upstash login
 ```
 
-## 2. Environment variables
+## 3. Environment variables
 
-The CLI reads `UPSTASH_EMAIL` and `UPSTASH_API_KEY` from the process environment, and also auto-loads them from a `.env` file in the current directory.
+The CLI reads `UPSTASH_EMAIL` and `UPSTASH_API_KEY` from the process environment, and also auto-loads them from a `.env` file in the current directory. This is the recommended setup for CI and agents.
 
 ```bash
 # Exported in your shell or CI
@@ -68,7 +86,7 @@ Use `--env-path` to point at a different file:
 upstash --env-path .dev.vars redis list
 ```
 
-## 3. Per-command flags
+## 4. Per-command flags
 
 Override whatever is set above for a single invocation. Handy for scripts that switch between accounts.
 
@@ -79,8 +97,10 @@ upstash --email you@example.com --api-key your_api_key redis list
 <Note>
   When credentials come from multiple sources, precedence is:
 
-  `flags` > `environment variables` > `.env` > `saved config file`
+  `flags` > `environment variables` > `.env` > `saved login (browser or API key)`
 </Note>
+
+Run `upstash whoami` to see which credentials the CLI is using. For a browser login it also reports the team and whether the login is read-only.
 
 # Usage
 

--- a/agent-resources/cli.mdx
+++ b/agent-resources/cli.mdx
@@ -112,7 +112,10 @@ upstash vector  # Vector indexes
 upstash search  # Search indexes
 upstash qstash  # QStash instances
 upstash blob    # Blob buckets
+upstash box     # Upstash Box sandboxes (same commands as the box CLI)
 ```
+
+`upstash box` needs a browser login or a Box API key (`UPSTASH_BOX_API_KEY` or `--token`); Upstash Box does not accept developer API keys.
 
 Use `--help` on any command or subcommand for details:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -84,19 +84,37 @@ upstash start-redis --id $DB_ID
 
 # Authentication
 
-The CLI needs your account email and a developer API key. Grab one from the [Upstash Console under Account → API Keys](https://console.upstash.com/account/api), then set credentials using whichever method fits your workflow.
+Every command that touches your account needs credentials. There are two kinds: a browser login with your Upstash account, or a developer API key. Set them using whichever method fits your workflow.
 
-## 1. Saved login (recommended)
+## 1. Browser login
 
-Saves your credentials to `~/.config/upstash/config.json` (taken from `$XDG_CONFIG_HOME`) so you only have to do it once per machine.
+Signs in with your Upstash account through the browser and saves the session to `~/.config/upstash/config.json` (taken from `$XDG_CONFIG_HOME`).
+
+```bash
+upstash login --oauth
+```
+
+The consent page asks which account to use (personal or one team) and whether the login should be read-only. The choice applies to the whole login: run `upstash login --oauth` again to switch teams or turn read-only off. Pass `--no-browser` to print the login URL instead of opening a browser, for example over SSH.
+
+A browser login has a few limits:
+
+* `team create`, `team delete`, `team add-member` and `team remove-member` need an API key login.
+* Teams that require MFA reject browser logins.
+* A read-only login refuses write commands and returns only read-only database credentials.
+
+`upstash logout` revokes the login on the server. The CLI stays listed under [OAuth Clients](https://console.upstash.com/account/oauth-clients) in the console until you remove it there.
+
+## 2. Saved API key
+
+Grab a developer API key from the [Upstash Console under Account → API Keys](https://console.upstash.com/account/api), then save it once per machine:
 
 ```bash
 upstash login
 ```
 
-## 2. Environment variables
+## 3. Environment variables
 
-The CLI reads `UPSTASH_EMAIL` and `UPSTASH_API_KEY` from the process environment, and also auto-loads them from a `.env` file in the current directory.
+The CLI reads `UPSTASH_EMAIL` and `UPSTASH_API_KEY` from the process environment, and also auto-loads them from a `.env` file in the current directory. This is the recommended setup for CI and agents.
 
 ```bash
 # Exported in your shell or CI
@@ -116,7 +134,7 @@ Use `--env-path` to point at a different file:
 upstash --env-path .dev.vars redis list
 ```
 
-## 3. Per-command flags
+## 4. Per-command flags
 
 Override whatever is set above for a single invocation. Handy for scripts that switch between accounts.
 
@@ -127,8 +145,10 @@ upstash --email you@example.com --api-key your_api_key redis list
 <Note>
   When credentials come from multiple sources, precedence is:
 
-  `flags` > `environment variables` > `.env` > `saved config file`
+  `flags` > `environment variables` > `.env` > `saved login (browser or API key)`
 </Note>
+
+Run `upstash whoami` to see which credentials the CLI is using. For a browser login it also reports the team and whether the login is read-only.
 
 # Usage
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -102,7 +102,7 @@ A browser login has a few limits:
 * Teams that require MFA reject browser logins.
 * A read-only login refuses write commands and returns only read-only database credentials.
 
-`upstash logout` revokes the login on the server. The CLI stays listed under [OAuth Clients](https://console.upstash.com/account/oauth-clients) in the console until you remove it there.
+`upstash logout` revokes the login on the server. The CLI stays listed in the console under Account → OAuth Clients until you remove it there.
 
 ## 2. Saved API key
 
@@ -160,10 +160,7 @@ upstash vector  # Vector indexes
 upstash search  # Search indexes
 upstash qstash  # QStash instances
 upstash blob    # Blob buckets
-upstash box     # Upstash Box sandboxes (same commands as the box CLI)
 ```
-
-`upstash box` needs a browser login or a Box API key (`UPSTASH_BOX_API_KEY` or `--token`); Upstash Box does not accept developer API keys.
 
 Use `--help` on any command or subcommand for details:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -160,7 +160,10 @@ upstash vector  # Vector indexes
 upstash search  # Search indexes
 upstash qstash  # QStash instances
 upstash blob    # Blob buckets
+upstash box     # Upstash Box sandboxes (same commands as the box CLI)
 ```
+
+`upstash box` needs a browser login or a Box API key (`UPSTASH_BOX_API_KEY` or `--token`); Upstash Box does not accept developer API keys.
 
 Use `--help` on any command or subcommand for details:
 


### PR DESCRIPTION
Adds the browser login (`upstash login --oauth`), its limits, and `upstash whoami` to the CLI authentication section. Pairs with upstash/cli DX-2965.